### PR TITLE
fix: Unmounted view measurements on the UI thread showing warnings

### DIFF
--- a/packages/react-native-sortable/src/contexts/shared/providers/MeasurementsProvider.tsx
+++ b/packages/react-native-sortable/src/contexts/shared/providers/MeasurementsProvider.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithChildren, useCallback } from 'react';
+import { type PropsWithChildren, useCallback, useEffect } from 'react';
 import { StyleSheet } from 'react-native';
 import Animated, {
   measure,
@@ -70,6 +70,13 @@ const { MeasurementsProvider, useMeasurementsContext } = createEnhancedContext(
   const containerWidth = useSharedValue(-1);
   const containerHeight = useSharedValue(-1);
   const canSwitchToAbsoluteLayout = useSharedValue(false);
+
+  useEffect(() => {
+    return () => {
+      clearAnimatedInterval(measurementIntervalId.value);
+      clearAnimatedTimeout(updateTimeoutId.value);
+    };
+  }, [measurementIntervalId, updateTimeoutId]);
 
   const handleItemMeasurement = useUIStableCallback(
     (key: string, dimensions: Dimensions) => {


### PR DESCRIPTION
## Description

Before changes from this PR, animated timeouts and intervals weren't canceled when the component was unmounted, which resulted in the warning about invalid `measure` function call.