### PR TITLE
fix: Transition from relative to absolute flex layout

### DIFF
--- a/packages/react-native-sortable/src/components/shared/DraggableView.tsx
+++ b/packages/react-native-sortable/src/components/shared/DraggableView.tsx
@@ -18,7 +18,13 @@ import {
 } from '../../providers';
 import ItemDecoration from './ItemDecoration';
 
-const RELATIVE_STYLE: ViewStyle = { position: 'relative' };
+const RELATIVE_STYLE: ViewStyle = {
+  height: undefined,
+  position: 'relative',
+  transform: [],
+  width: undefined,
+  zIndex: 0
+};
 
 type DraggableViewProps = {
   itemKey: string;

--- a/packages/react-native-sortable/src/hooks/reanimated.ts
+++ b/packages/react-native-sortable/src/hooks/reanimated.ts
@@ -26,7 +26,7 @@ export function useAnimatableValue<V, F extends (value: V) => any>(
   modify?: F
 ): SharedValue<ReturnType<F>> | SharedValue<V> {
   return useDerivedValue(() => {
-    const inputValue = isSharedValue(value) ? value.value : value;
+    const inputValue = isSharedValue<V>(value) ? value.value : value;
     return modify ? modify(inputValue) : inputValue;
   }, [value, modify]);
 }

--- a/packages/react-native-sortable/src/providers/layout/flex/utils.ts
+++ b/packages/react-native-sortable/src/providers/layout/flex/utils.ts
@@ -36,7 +36,7 @@ export const groupItems = (
       return null;
     }
     const itemDimension = itemDimensions[limitedDimension];
-    if (currentDimension + itemDimension + getCurrentGap() > limit) {
+    if (currentDimension + itemDimension > limit) {
       groups.push(currentGroup);
       currentGroup = [];
       currentDimension = 0;


### PR DESCRIPTION
## Description

This PR fixes incorrect item grouping in absolute flex layout (gap was added twice while determining whether the item should be included in the current group or added ti the next one).