### PR TITLE
fix: Don't trigger press animation when sorting is disabled

### DIFF
--- a/packages/react-native-sortable/src/components/shared/DraggableView.tsx
+++ b/packages/react-native-sortable/src/components/shared/DraggableView.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { type StyleProp, type ViewProps, type ViewStyle } from 'react-native';
+import type { StyleProp, ViewProps, ViewStyle } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedRef,

--- a/packages/react-native-sortable/src/providers/shared/hooks/useItemPanGesture.ts
+++ b/packages/react-native-sortable/src/providers/shared/hooks/useItemPanGesture.ts
@@ -12,7 +12,7 @@ export default function useItemPanGesture(
   pressProgress: SharedValue<number>,
   reverseXAxis = false
 ) {
-  const { touchedItemKey } = useCommonValuesContext();
+  const { sortEnabled, touchedItemKey } = useCommonValuesContext();
   const { handleDragEnd, handleTouchStart, handleTouchesMove } =
     useDragContext();
   const { updateStartScrollOffset } = useAutoScrollContext() ?? {};
@@ -23,7 +23,7 @@ export default function useItemPanGesture(
         .manualActivation(true)
         .onTouchesDown((e, manager) => {
           // Ignore touch if another item is already being touched/activated
-          if (touchedItemKey.value !== null) {
+          if (touchedItemKey.value !== null || !sortEnabled.value) {
             manager.fail();
             return;
           }
@@ -54,7 +54,8 @@ export default function useItemPanGesture(
       handleTouchStart,
       handleTouchesMove,
       handleDragEnd,
-      updateStartScrollOffset
+      updateStartScrollOffset,
+      sortEnabled
     ]
   );
 }

--- a/packages/react-native-sortable/tsconfig.build.json
+++ b/packages/react-native-sortable/tsconfig.build.json
@@ -4,7 +4,8 @@
     "module": "esnext",
     "noEmit": false,
     "declaration": true,
-    "target": "esnext"
+    "target": "esnext",
+    "types": ["react-native", "jest", "node"]
   },
   "include": ["src"],
   "exclude": ["__tests__", "**/*.test.ts", "**/*.test.tsx"]


### PR DESCRIPTION
## Description

Small fix for incorrect press animation triggering. Animation is no longer triggered when sorting is not enabled on the sortable component.
