### PR TITLE
chore: Add warning for debug and scrollableRef prop changes, adjust debug examples

### DIFF
--- a/example/app/src/examples/SortableFlex/DebugExample.tsx
+++ b/example/app/src/examples/SortableFlex/DebugExample.tsx
@@ -52,7 +52,11 @@ export default function DebugExample() {
 
         <Group style={[flex.fill, styles.scrollViewGroup]}>
           <Animated.ScrollView
+            // We set key here to dismiss the property change on the fly warning
+            // (scrollableRef and debug properties of the sortable component
+            // shouldn't be changed on the fly)
             contentContainerStyle={styles.scrollViewContent}
+            key={2 * +debugEnabled + +autoScrollEnabled}
             ref={scrollableRef}
             style={flex.fill}>
             <Group style={styles.boundGroup} withMargin={false} bordered center>

--- a/example/app/src/examples/SortableGrid/DebugExample.tsx
+++ b/example/app/src/examples/SortableGrid/DebugExample.tsx
@@ -59,7 +59,11 @@ export default function DebugExample() {
 
         <Group style={[flex.fill, styles.scrollViewGroup]}>
           <Animated.ScrollView
+            // We set key here to dismiss the property change on the fly warning
+            // (scrollableRef and debug properties of the sortable component
+            // shouldn't be changed on the fly)
             contentContainerStyle={styles.scrollViewContent}
+            key={2 * +debugEnabled + +autoScrollEnabled}
             ref={scrollableRef}
             style={flex.fill}>
             <Group style={styles.boundGroup} withMargin={false} bordered center>

--- a/packages/react-native-sortable/src/constants/index.ts
+++ b/packages/react-native-sortable/src/constants/index.ts
@@ -2,3 +2,4 @@ export * from './layout';
 export * from './props';
 export * from './timings';
 export * from './values';
+export * from './warnings';

--- a/packages/react-native-sortable/src/constants/warnings.ts
+++ b/packages/react-native-sortable/src/constants/warnings.ts
@@ -1,0 +1,4 @@
+export const WARNINGS = {
+  propChange: (prop: string) =>
+    `You shouldn't change the '${prop}' prop on the fly. It can break the current state of the sortable component.`
+};

--- a/packages/react-native-sortable/src/hooks/callbacks/useStableCallback.ts
+++ b/packages/react-native-sortable/src/hooks/callbacks/useStableCallback.ts
@@ -1,10 +1,13 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import type { AnyFunction } from '../../types';
 
 export default function useStableCallback<C extends AnyFunction>(callback: C) {
   const callbackRef = useRef(callback);
-  callbackRef.current = callback;
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
 
   return useCallback((...args: Parameters<C>) => {
     callbackRef.current(...args);

--- a/packages/react-native-sortable/src/hooks/index.ts
+++ b/packages/react-native-sortable/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './callbacks';
 export * from './handlers';
 export * from './reanimated';
 export { default as useHaptics } from './useHaptics';
+export { default as useWarnOnPropChange } from './useWarnOnPropChange';

--- a/packages/react-native-sortable/src/hooks/useWarnOnPropChange.ts
+++ b/packages/react-native-sortable/src/hooks/useWarnOnPropChange.ts
@@ -1,0 +1,14 @@
+import { useEffect, useRef } from 'react';
+
+import { WARNINGS } from '../constants';
+
+export default function useWarnOnPropChange(prop: string, value: unknown) {
+  const previousValueRef = useRef(value);
+
+  useEffect(() => {
+    if (previousValueRef.current !== value) {
+      console.warn(WARNINGS.propChange(prop));
+      previousValueRef.current = value;
+    }
+  }, [prop, value]);
+}

--- a/packages/react-native-sortable/src/providers/SharedProvider.tsx
+++ b/packages/react-native-sortable/src/providers/SharedProvider.tsx
@@ -4,6 +4,7 @@ import type { ViewStyle } from 'react-native';
 import { LayoutAnimationConfig } from 'react-native-reanimated';
 
 import { DebugOutlet, DebugProvider } from '../debug';
+import { useWarnOnPropChange } from '../hooks';
 import type {
   ActiveItemDecorationSettings,
   ActiveItemSnapSettings,
@@ -48,6 +49,9 @@ export default function SharedProvider({
   scrollableRef,
   ...rest
 }: SharedProviderProps) {
+  useWarnOnPropChange('debug', debug);
+  useWarnOnPropChange('scrollableRef', scrollableRef);
+
   const providers = [
     // Provider used for proper zIndex management
     <LayerProvider />,


### PR DESCRIPTION
## Description

`debug` and `scrollableRef` shouldn't be changed on the fly as they add/remove providers in the component tree, which causes the entire sortable component render. Because of that, the current state of the component is lost.

To make it obvious for the user that they shouldn't modify these props on the fly, after the component is rendered for the first time, I added a warning for these props changes.