### PR TITLE
chore: Limit docs deployments to Vercel

### DIFF
--- a/packages/docs/.vercel/ignore.sh
+++ b/packages/docs/.vercel/ignore.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Fetch the list of changed files in the last commit
+CHANGED_FILES=$(git diff --name-only HEAD^ HEAD)
+
+# Check if any changed file is under packages/docs/
+if echo "$CHANGED_FILES" | grep -q '^packages/docs/'; then
+  exit 1 # This allows deployment
+fi
+
+exit 0 # This prevents deployment

--- a/packages/docs/vercel.json
+++ b/packages/docs/vercel.json
@@ -1,0 +1,5 @@
+{
+  "build": {
+    "ignoreCommand": ".vercel/ignore.sh"
+  }
+}


### PR DESCRIPTION
## Description

This PR adds docs deployment skipping when no changes to docs were made. It should limit Vercel deployments which were triggered on every commit.