### PR TITLE
fix: A bunch of small issues I noticed

### DIFF
--- a/example/app/src/examples/SortableFlex/PlaygroundExample.tsx
+++ b/example/app/src/examples/SortableFlex/PlaygroundExample.tsx
@@ -2,7 +2,6 @@ import { StyleSheet, Text, View } from 'react-native';
 import Sortable from 'react-native-sortables';
 
 import { colors, text } from '@/theme';
-import Animated, { useAnimatedRef } from 'react-native-reanimated';
 
 const DATA = [
   'Poland',
@@ -20,21 +19,15 @@ const DATA = [
 ];
 
 export default function Flex() {
-  const scrollableRef = useAnimatedRef<Animated.ScrollView>();
-
   return (
-    <Animated.ScrollView
-      ref={scrollableRef}
-      contentContainerStyle={{ padding: 20 }}>
-      <Sortable.Flex gap={10} paddingTop={40}>
-        {/* You can render anything within the Sortable.Flex component */}
-        {DATA.map(item => (
-          <View key={item} style={styles.cell}>
-            <Text style={styles.text}>{item}</Text>
-          </View>
-        ))}
-      </Sortable.Flex>
-    </Animated.ScrollView>
+    <Sortable.Flex gap={10} padding={10}>
+      {/* You can render anything within the Sortable.Flex component */}
+      {DATA.map(item => (
+        <View key={item} style={styles.cell}>
+          <Text style={styles.text}>{item}</Text>
+        </View>
+      ))}
+    </Sortable.Flex>
   );
 }
 

--- a/example/app/src/examples/SortableFlex/PlaygroundExample.tsx
+++ b/example/app/src/examples/SortableFlex/PlaygroundExample.tsx
@@ -2,6 +2,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import Sortable from 'react-native-sortables';
 
 import { colors, text } from '@/theme';
+import Animated, { useAnimatedRef } from 'react-native-reanimated';
 
 const DATA = [
   'Poland',
@@ -19,15 +20,21 @@ const DATA = [
 ];
 
 export default function Flex() {
+  const scrollableRef = useAnimatedRef<Animated.ScrollView>();
+
   return (
-    <Sortable.Flex gap={10} padding={10}>
-      {/* You can render anything within the Sortable.Flex component */}
-      {DATA.map(item => (
-        <View key={item} style={styles.cell}>
-          <Text style={styles.text}>{item}</Text>
-        </View>
-      ))}
-    </Sortable.Flex>
+    <Animated.ScrollView
+      ref={scrollableRef}
+      contentContainerStyle={{ padding: 20 }}>
+      <Sortable.Flex gap={10} paddingTop={40}>
+        {/* You can render anything within the Sortable.Flex component */}
+        {DATA.map(item => (
+          <View key={item} style={styles.cell}>
+            <Text style={styles.text}>{item}</Text>
+          </View>
+        ))}
+      </Sortable.Flex>
+    </Animated.ScrollView>
   );
 }
 

--- a/packages/react-native-sortables/src/constants/layout.ts
+++ b/packages/react-native-sortables/src/constants/layout.ts
@@ -1,3 +1,3 @@
 export const OFFSET_EPS = 1;
-export const ACTIVATION_FAIL_OFFSET = 10;
-export const EXTRA_SWAP_OFFSET = 10;
+export const ACTIVATION_FAIL_OFFSET = 20;
+export const EXTRA_SWAP_OFFSET = 5;

--- a/packages/react-native-sortables/src/providers/layout/flex/utils/layout.ts
+++ b/packages/react-native-sortables/src/providers/layout/flex/utils/layout.ts
@@ -188,7 +188,7 @@ const handleLayoutCalculation = (
   );
 
   let totalHeight = isRow
-    ? contentAlignment.totalSize + paddingHorizontal
+    ? contentAlignment.totalSize + paddingVertical
     : isMultiColumn
       ? limits.maxHeight
       : limits.minHeight;
@@ -223,7 +223,7 @@ const handleLayoutCalculation = (
     if (!isRow && !isMultiColumn) {
       totalHeight = Math.max(
         totalHeight,
-        contentJustification.totalSize + paddingHorizontal
+        contentJustification.totalSize + paddingVertical
       );
     }
 

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
@@ -235,7 +235,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
 
       inactiveAnimationProgress.value = delayed();
       activationProgress.value = delayed(finished => {
-        if (finished && activeItemKey.value !== null) {
+        if (finished && touchedItemKey.value === null) {
           activeItemDropped.value = true;
           updateLayer?.(LayerState.Idle);
         }
@@ -285,7 +285,6 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       onActivate: () => void
     ) => {
       'worklet';
-      activeItemDropped.value = false;
       const firstTouch = e.allTouches[0];
       if (!firstTouch) {
         return;
@@ -314,6 +313,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
 
         onActivate();
         activationProgress.value = 0;
+        activeItemDropped.value = false;
         touchedItemKey.value = key;
         startTouch.value = firstTouch;
         touchStartItemPosition.value = itemPositions.value[key] ?? null;

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
@@ -192,7 +192,6 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       'worklet';
       updateStartScrollOffset?.();
       activeItemKey.value = key;
-      activeItemDropped.value = false;
       dragStartIndex.value = keyToIndex.value[key]!;
       dragStartTouchTranslation.value = touchTranslation.value;
       activationState.value = DragActivationState.ACTIVE;
@@ -209,7 +208,6 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       updateStartScrollOffset,
       stableOnDragStart,
       activationState,
-      activeItemDropped,
       activeItemKey,
       dragStartIndex,
       keyToIndex,
@@ -218,8 +216,12 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
   );
 
   const handleDragEnd = useCallback(
-    (key: string) => {
+    (key: string, pressProgress: SharedValue<number>) => {
       'worklet';
+      pressProgress.value = withTiming(0, {
+        duration: TIME_TO_ACTIVATE_PAN
+      });
+
       const delayed = (callback?: (finished: boolean | undefined) => void) =>
         withTiming(0, { duration: TIME_TO_ACTIVATE_PAN }, callback);
 
@@ -233,7 +235,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
 
       inactiveAnimationProgress.value = delayed();
       activationProgress.value = delayed(finished => {
-        if (finished) {
+        if (finished && activeItemKey.value !== null) {
           activeItemDropped.value = true;
           updateLayer?.(LayerState.Idle);
         }
@@ -283,6 +285,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       onActivate: () => void
     ) => {
       'worklet';
+      activeItemDropped.value = false;
       const firstTouch = e.allTouches[0];
       if (!firstTouch) {
         return;
@@ -326,7 +329,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
             if (touchedItemKey.value === key && itemPositions.value[key]) {
               handleDragStart(key);
             } else {
-              handleDragEnd(key);
+              handleDragEnd(key, pressProgress);
             }
           }
         });
@@ -340,6 +343,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       touchStartItemPosition,
       activationState,
       activationProgress,
+      activeItemDropped,
       inactiveAnimationProgress,
       updateLayer,
       handleDragStart,

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
@@ -1,8 +1,7 @@
 import { useMemo } from 'react';
 import { Gesture } from 'react-native-gesture-handler';
-import { type SharedValue, withTiming } from 'react-native-reanimated';
+import { type SharedValue } from 'react-native-reanimated';
 
-import { TIME_TO_ACTIVATE_PAN } from '../../../constants';
 import { useAutoScrollContext } from '../AutoScrollProvider';
 import { useCommonValuesContext } from '../CommonValuesProvider';
 import { useDragContext } from '../DragProvider';
@@ -39,11 +38,8 @@ export default function useItemPanGesture(
           handleTouchesMove(e, manager.fail);
         })
         .onFinalize(() => {
-          pressProgress.value = withTiming(0, {
-            duration: TIME_TO_ACTIVATE_PAN
-          });
           updateStartScrollOffset?.(-1);
-          handleDragEnd(key);
+          handleDragEnd(key, pressProgress);
         }),
     [
       key,

--- a/packages/react-native-sortables/src/providers/shared/utils.ts
+++ b/packages/react-native-sortables/src/providers/shared/utils.ts
@@ -1,9 +1,9 @@
-const MIN_ADDITIONAL_OFFSET = 5;
+import { EXTRA_SWAP_OFFSET } from '../../constants';
 
 export const getAdditionalSwapOffset = (gap: number, size: number) => {
   'worklet';
   return Math.max(
-    MIN_ADDITIONAL_OFFSET,
-    Math.min(gap / 2 + MIN_ADDITIONAL_OFFSET, (gap + size) / 2)
+    EXTRA_SWAP_OFFSET,
+    Math.min(gap / 2 + EXTRA_SWAP_OFFSET, (gap + size) / 2)
   );
 };

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -84,7 +84,7 @@ export type DragContextType = {
     onActivate: () => void
   ) => void;
   handleTouchesMove: (e: GestureTouchEvent, onFail: () => void) => void;
-  handleDragEnd: (key: string) => void;
+  handleDragEnd: (key: string, pressProgress: SharedValue<number>) => void;
   handleOrderChange: (
     key: string,
     fromIndex: number,


### PR DESCRIPTION
## Description

This PR fixes:

- drop indicator position when other item started being touched before the drop animation of the previous touch target finished

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/b151648d-de19-4f1e-81ba-051d8412ba20" /> | <video src="https://github.com/user-attachments/assets/92b53086-9de6-40e9-a5b6-a952ef068bb5" /> |

---

- container overflow change when other item started being touched before the drop animation of the previous touch target finished

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/370a537b-0913-4608-bc24-a42ba8a6c2ba" /> | <video src="https://github.com/user-attachments/assets/b0a76cea-e6e3-4d52-a9c8-1aae711dcecc" /> |

---

- flex container height when only vertical padding was added (before, container cropped part of the content, and hidden overflowing items)

<details>
<summary>Source code</summary>

```tsx
import { StyleSheet, Text, View } from 'react-native';
import Sortable from 'react-native-sortables';

import { colors, text } from '@/theme';
import Animated, { useAnimatedRef } from 'react-native-reanimated';

const DATA = [
  'Poland',
  'Germany',
  'France',
  'Italy',
  'Spain',
  'Portugal',
  'Greece',
  'Great Britain',
  'United States',
  'Canada',
  'Australia',
  'New Zealand'
];

export default function Flex() {
  const scrollableRef = useAnimatedRef<Animated.ScrollView>();

  return (
    <Animated.ScrollView ref={scrollableRef}>
      <Sortable.Flex gap={10} paddingTop={40}>
        {/* You can render anything within the Sortable.Flex component */}
        {DATA.map(item => (
          <View key={item} style={styles.cell}>
            <Text style={styles.text}>{item}</Text>
          </View>
        ))}
      </Sortable.Flex>
    </Animated.ScrollView>
  );
}

const styles = StyleSheet.create({
  cell: {
    alignItems: 'center',
    backgroundColor: '#36877F',
    borderRadius: 9999,
    justifyContent: 'center',
    padding: 10
  },
  text: {
    ...text.label2,
    color: colors.white
  }
});
```
</details>

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/2c52441f-9031-4b94-94b9-e99a82447941" /> | <video src="https://github.com/user-attachments/assets/32b0f7cd-9b9d-45f3-acdd-0101e11cc5a1" /> |
