### PR TITLE
fix: View drop animation on native after adding shouldAnimateLayout

### DIFF
--- a/packages/react-native-sortables/src/components/shared/DraggableView.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView.tsx
@@ -87,7 +87,7 @@ export default function DraggableView({
     let left = layoutX;
     let top = layoutY;
 
-    if (IS_WEB && shouldAnimateLayout.value) {
+    if (shouldAnimateLayout.value) {
       left = layoutX !== null ? withTiming(layoutX) : layoutX;
       top = layoutY !== null ? withTiming(layoutY) : layoutY;
     }

--- a/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
@@ -6,7 +6,7 @@ import {
   useSharedValue
 } from 'react-native-reanimated';
 
-import type { DEFAULT_SORTABLE_FLEX_PROPS } from '../../../constants';
+import { type DEFAULT_SORTABLE_FLEX_PROPS, IS_WEB } from '../../../constants';
 import { useDebugContext } from '../../../debug';
 import type {
   FlexLayout,
@@ -125,6 +125,7 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
             // Animate layout only if parent container is not resized
             // (e.g. skip animation when the browser window is resized)
             !!(
+              IS_WEB &&
               props &&
               previousProps &&
               haveEqualPropValues(props.limits, previousProps.limits)

--- a/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
@@ -6,6 +6,7 @@ import {
   useSharedValue
 } from 'react-native-reanimated';
 
+import { IS_WEB } from '../../../constants';
 import { useDebugContext } from '../../../debug';
 import { useAnimatableValue } from '../../../hooks';
 import type {
@@ -78,7 +79,11 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
             calculateLayout(props),
             // Animate layout only if parent container is not resized
             // (e.g. skip animation when the browser window is resized)
-            !!previousProps && props.columnWidth === previousProps.columnWidth
+            !!(
+              IS_WEB &&
+              previousProps &&
+              props.columnWidth === previousProps.columnWidth
+            )
           );
         }
       ),

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
@@ -107,7 +107,7 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
   const containerRef = useAnimatedRef<Animated.View>();
   const sortEnabled = useAnimatableValue(_sortEnabled);
   const canSwitchToAbsoluteLayout = useSharedValue(false);
-  const shouldAnimateLayout = useSharedValue(false);
+  const shouldAnimateLayout = useSharedValue(true);
 
   useEffect(() => {
     if (areArraysDifferent(itemKeys, prevKeysRef.current)) {

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemTranslation.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemTranslation.ts
@@ -17,7 +17,6 @@ export default function useItemTranslation(
   const {
     dropAnimationDuration,
     itemPositions,
-    shouldAnimateLayout,
     touchedItemKey,
     touchedItemPosition
   } = useCommonValuesContext();
@@ -49,8 +48,7 @@ export default function useItemTranslation(
 
       if (
         isTouched ||
-        ((layoutX === null || layoutY === null) && !hasProgress) ||
-        !shouldAnimateLayout.value
+        ((layoutX === null || layoutY === null) && !hasProgress)
       ) {
         // Apply the translation immediately if the item is being dragged or
         // the item was mounted with the absolute position and we cannot set

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -56,7 +56,7 @@ export type CommonValuesContextType = {
   containerRef: AnimatedRef<Animated.View>;
   sortEnabled: SharedValue<boolean>;
   canSwitchToAbsoluteLayout: SharedValue<boolean>;
-  shouldAnimateLayout: SharedValue<boolean>;
+  shouldAnimateLayout: SharedValue<boolean>; // used only on web
 } & AnimatedValues<ActiveItemDecorationSettings> &
   AnimatedValues<ActiveItemSnapSettings> &
   AnimatedValues<ItemActivationSettings>;


### PR DESCRIPTION
## Description

Small fix for the view drop animation on native after the `shouldAnimateLayout` prop was introduced to fix page resizing behavior on web. Before this change, the view appeared immediately on the target position if no reordering happened and the view was dragged without changing position from it initial render position.