### PR TITLE
feat: Custom drag handle, better drag gesture handling

### DIFF
--- a/example/app/src/components/inputs/TabSelector.tsx
+++ b/example/app/src/components/inputs/TabSelector.tsx
@@ -98,7 +98,6 @@ const Tab = typedMemo(function Tab<T extends string>({
 
   return (
     <AnimatedTouchableOpacity
-      hitSlop={spacing.md}
       key={tab}
       style={[styles.tab, style]}
       onPress={() => onSelectTab(tab)}

--- a/example/app/src/examples/SortableGrid/AutoScrollExample.tsx
+++ b/example/app/src/examples/SortableGrid/AutoScrollExample.tsx
@@ -9,7 +9,7 @@ import { GridCard, Group, Screen, Section, TabView } from '@/components';
 import { colors, spacing, style } from '@/theme';
 import { getItems } from '@/utils';
 
-const MANY_ITEMS = getItems(21);
+const MANY_ITEMS = getItems(30);
 const FEW_ITEMS = getItems(6);
 
 const LIST_ITEM_SECTIONS = ['List item 1', 'List item 2', 'List item 3'];
@@ -141,6 +141,7 @@ function ManyCards({ scrollableRef }: CardsSectionProps) {
       renderItem={({ item }) => <GridCard>{item}</GridCard>}
       rowGap={spacing.xs}
       scrollableRef={scrollableRef}
+      autoScrollSpeed={0.2}
     />
   );
 }

--- a/example/app/src/examples/SortableGrid/AutoScrollExample.tsx
+++ b/example/app/src/examples/SortableGrid/AutoScrollExample.tsx
@@ -135,14 +135,12 @@ type CardsSectionProps = {
 function ManyCards({ scrollableRef }: CardsSectionProps) {
   return (
     <Sortable.Grid
-      debug
       columnGap={spacing.sm}
       columns={3}
       data={MANY_ITEMS}
       renderItem={({ item }) => <GridCard>{item}</GridCard>}
       rowGap={spacing.xs}
       scrollableRef={scrollableRef}
-      autoScrollSpeed={0.2}
     />
   );
 }

--- a/example/app/src/examples/SortableGrid/AutoScrollExample.tsx
+++ b/example/app/src/examples/SortableGrid/AutoScrollExample.tsx
@@ -9,7 +9,7 @@ import { GridCard, Group, Screen, Section, TabView } from '@/components';
 import { colors, spacing, style } from '@/theme';
 import { getItems } from '@/utils';
 
-const MANY_ITEMS = getItems(30);
+const MANY_ITEMS = getItems(21);
 const FEW_ITEMS = getItems(6);
 
 const LIST_ITEM_SECTIONS = ['List item 1', 'List item 2', 'List item 3'];
@@ -135,6 +135,7 @@ type CardsSectionProps = {
 function ManyCards({ scrollableRef }: CardsSectionProps) {
   return (
     <Sortable.Grid
+      debug
       columnGap={spacing.sm}
       columns={3}
       data={MANY_ITEMS}

--- a/example/app/src/examples/SortableGrid/DragHandleExample.tsx
+++ b/example/app/src/examples/SortableGrid/DragHandleExample.tsx
@@ -1,3 +1,5 @@
+import { faGripVertical } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { useCallback } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import type { SortableGridRenderItem } from 'react-native-sortables';
@@ -6,13 +8,16 @@ import Sortable from 'react-native-sortables';
 import { ScrollScreen } from '@/components';
 import { colors, radius, sizes, spacing, text } from '@/theme';
 
-const DATA = Array.from({ length: 12 }, (_, index) => `Item ${index + 1}`);
+const DATA = Array.from({ length: 10 }, (_, index) => `Item ${index + 1}`);
 
-export default function PlaygroundExample() {
+export default function DragHandleExample() {
   const renderItem = useCallback<SortableGridRenderItem<string>>(
     ({ item }) => (
       <View style={styles.card}>
         <Text style={styles.text}>{item}</Text>
+        <Sortable.Handle>
+          <FontAwesomeIcon icon={faGripVertical} color={colors.white} />
+        </Sortable.Handle>
       </View>
     ),
     []
@@ -22,8 +27,11 @@ export default function PlaygroundExample() {
     <ScrollScreen style={styles.container}>
       <Sortable.Grid
         columnGap={10}
-        columns={3}
+        columns={1}
         data={DATA}
+        customHandle
+        dragActivationDelay={0}
+        activeItemScale={1}
         renderItem={renderItem}
         rowGap={10}
       />
@@ -34,10 +42,12 @@ export default function PlaygroundExample() {
 const styles = StyleSheet.create({
   card: {
     alignItems: 'center',
+    flexDirection: 'row',
     backgroundColor: '#36877F',
     borderRadius: radius.md,
-    height: sizes.xl,
-    justifyContent: 'center'
+    height: sizes.lg,
+    justifyContent: 'space-between',
+    padding: spacing.md
   },
   container: {
     padding: spacing.md

--- a/example/app/src/examples/SortableGrid/DragHandleExample.tsx
+++ b/example/app/src/examples/SortableGrid/DragHandleExample.tsx
@@ -1,16 +1,25 @@
 import { faGripVertical } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import Animated, { useAnimatedRef } from 'react-native-reanimated';
 import type { SortableGridRenderItem } from 'react-native-sortables';
 import Sortable from 'react-native-sortables';
 
-import { ScrollScreen } from '@/components';
-import { colors, radius, sizes, spacing, text } from '@/theme';
+import { TabSelector } from '@/components';
+import { colors, flex, radius, sizes, spacing, style, text } from '@/theme';
 
-const DATA = Array.from({ length: 10 }, (_, index) => `Item ${index + 1}`);
+const COLUMNS = ['1', '2', '3', '4'];
+const DATA = Array.from({ length: 20 }, (_, index) => `Item ${index + 1}`);
 
 export default function DragHandleExample() {
+  const [columns, setColumns] = useState(1);
+  const scrollableRef = useAnimatedRef<Animated.ScrollView>();
+
+  const handleSelectTab = useCallback((tab: string) => {
+    setColumns(+tab);
+  }, []);
+
   const renderItem = useCallback<SortableGridRenderItem<string>>(
     ({ item }) => (
       <View style={styles.card}>
@@ -24,18 +33,32 @@ export default function DragHandleExample() {
   );
 
   return (
-    <ScrollScreen style={styles.container}>
-      <Sortable.Grid
-        activeItemScale={1}
-        columnGap={10}
-        columns={1}
-        data={DATA}
-        dragActivationDelay={0}
-        renderItem={renderItem}
-        rowGap={10}
-        customHandle
-      />
-    </ScrollScreen>
+    <>
+      <View style={styles.columnSelector}>
+        <Text style={styles.columnSelectorTitle}>Columns</Text>
+        <TabSelector
+          selectedTab={columns.toString()}
+          tabs={COLUMNS}
+          onSelectTab={handleSelectTab}
+        />
+      </View>
+      <Animated.ScrollView
+        contentContainerStyle={[style.contentContainer, styles.container]}
+        ref={scrollableRef}
+        style={flex.fill}>
+        <Sortable.Grid
+          activeItemScale={1}
+          columnGap={10}
+          columns={columns}
+          data={DATA}
+          dragActivationDelay={0}
+          renderItem={renderItem}
+          rowGap={10}
+          scrollableRef={scrollableRef}
+          customHandle
+        />
+      </Animated.ScrollView>
+    </>
   );
 }
 
@@ -48,6 +71,17 @@ const styles = StyleSheet.create({
     height: sizes.lg,
     justifyContent: 'space-between',
     padding: spacing.md
+  },
+  columnSelector: {
+    alignItems: 'center',
+    gap: spacing.md,
+    padding: spacing.md
+  },
+  columnSelectorTitle: {
+    ...text.label2,
+    color: colors.foreground3,
+    fontSize: 16,
+    fontWeight: 'bold'
   },
   container: {
     padding: spacing.md

--- a/example/app/src/examples/SortableGrid/DragHandleExample.tsx
+++ b/example/app/src/examples/SortableGrid/DragHandleExample.tsx
@@ -16,7 +16,7 @@ export default function DragHandleExample() {
       <View style={styles.card}>
         <Text style={styles.text}>{item}</Text>
         <Sortable.Handle>
-          <FontAwesomeIcon icon={faGripVertical} color={colors.white} />
+          <FontAwesomeIcon color={colors.white} icon={faGripVertical} />
         </Sortable.Handle>
       </View>
     ),
@@ -26,14 +26,14 @@ export default function DragHandleExample() {
   return (
     <ScrollScreen style={styles.container}>
       <Sortable.Grid
+        activeItemScale={1}
         columnGap={10}
         columns={1}
         data={DATA}
-        customHandle
         dragActivationDelay={0}
-        activeItemScale={1}
         renderItem={renderItem}
         rowGap={10}
+        customHandle
       />
     </ScrollScreen>
   );
@@ -42,9 +42,9 @@ export default function DragHandleExample() {
 const styles = StyleSheet.create({
   card: {
     alignItems: 'center',
-    flexDirection: 'row',
     backgroundColor: '#36877F',
     borderRadius: radius.md,
+    flexDirection: 'row',
     height: sizes.lg,
     justifyContent: 'space-between',
     padding: spacing.md

--- a/example/app/src/examples/SortableGrid/PlaygroundExample.tsx
+++ b/example/app/src/examples/SortableGrid/PlaygroundExample.tsx
@@ -21,7 +21,6 @@ export default function PlaygroundExample() {
   return (
     <ScrollScreen style={styles.container}>
       <Sortable.Grid
-        debug
         columnGap={10}
         columns={3}
         data={DATA}

--- a/example/app/src/examples/SortableGrid/PlaygroundExample.tsx
+++ b/example/app/src/examples/SortableGrid/PlaygroundExample.tsx
@@ -26,6 +26,7 @@ export default function PlaygroundExample() {
   return (
     <ScrollScreen style={styles.container}>
       <Sortable.Grid
+        debug
         columnGap={10}
         columns={3}
         data={DATA}

--- a/example/app/src/examples/SortableGrid/PlaygroundExample.tsx
+++ b/example/app/src/examples/SortableGrid/PlaygroundExample.tsx
@@ -5,6 +5,8 @@ import Sortable from 'react-native-sortables';
 
 import { ScrollScreen } from '@/components';
 import { colors, radius, sizes, spacing, text } from '@/theme';
+import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
+import { faGripVertical } from '@fortawesome/free-solid-svg-icons';
 
 const DATA = Array.from({ length: 12 }, (_, index) => `Item ${index + 1}`);
 
@@ -13,6 +15,9 @@ export default function PlaygroundExample() {
     ({ item }) => (
       <View style={styles.card}>
         <Text style={styles.text}>{item}</Text>
+        <Sortable.Handle>
+          <FontAwesomeIcon icon={faGripVertical} />
+        </Sortable.Handle>
       </View>
     ),
     []
@@ -26,6 +31,8 @@ export default function PlaygroundExample() {
         data={DATA}
         renderItem={renderItem}
         rowGap={10}
+        dragActivationDelay={0}
+        customHandle
       />
     </ScrollScreen>
   );

--- a/example/app/src/examples/SortableGrid/PlaygroundExample.tsx
+++ b/example/app/src/examples/SortableGrid/PlaygroundExample.tsx
@@ -21,6 +21,7 @@ export default function PlaygroundExample() {
   return (
     <ScrollScreen style={styles.container}>
       <Sortable.Grid
+        debug
         columnGap={10}
         columns={3}
         data={DATA}

--- a/example/app/src/examples/SortableGrid/index.ts
+++ b/example/app/src/examples/SortableGrid/index.ts
@@ -3,7 +3,7 @@ export { default as CallbacksExample } from './CallbacksExample';
 export { default as DataChangeExample } from './DataChangeExample';
 export { default as DebugExample } from './DebugExample';
 export { default as DifferentSizeItems } from './DifferentSizeItems';
+export { default as DragHandleExample } from './DragHandleExample';
 export { default as DropIndicatorExample } from './DropIndicatorExample';
 export { default as OrderingStrategyExample } from './OrderingStrategyExample';
 export { default as PlaygroundExample } from './PlaygroundExample';
-export { default as DragHandleExample } from './DragHandleExample';

--- a/example/app/src/examples/SortableGrid/index.ts
+++ b/example/app/src/examples/SortableGrid/index.ts
@@ -6,3 +6,4 @@ export { default as DifferentSizeItems } from './DifferentSizeItems';
 export { default as DropIndicatorExample } from './DropIndicatorExample';
 export { default as OrderingStrategyExample } from './OrderingStrategyExample';
 export { default as PlaygroundExample } from './PlaygroundExample';
+export { default as DragHandleExample } from './DragHandleExample';

--- a/example/app/src/examples/custom/CustomDropIndicator.tsx
+++ b/example/app/src/examples/custom/CustomDropIndicator.tsx
@@ -13,10 +13,10 @@ import type { DropIndicatorComponentProps } from 'react-native-sortables';
 
 export default function CustomDropIndicator({
   activeAnimationProgress,
+  activeItemKey,
   dropIndex,
   orderedItemKeys,
-  style,
-  activeItemKey
+  style
 }: DropIndicatorComponentProps) {
   const itemsCount = useDerivedValue(() => orderedItemKeys.value.length);
   const indexes = useDerivedValue(() =>

--- a/example/app/src/examples/custom/CustomDropIndicator.tsx
+++ b/example/app/src/examples/custom/CustomDropIndicator.tsx
@@ -12,11 +12,11 @@ import Animated, {
 import type { DropIndicatorComponentProps } from 'react-native-sortables';
 
 export default function CustomDropIndicator({
-  activationProgress,
+  activeAnimationProgress,
   dropIndex,
   orderedItemKeys,
   style,
-  touchedItemKey
+  activeItemKey
 }: DropIndicatorComponentProps) {
   const itemsCount = useDerivedValue(() => orderedItemKeys.value.length);
   const indexes = useDerivedValue(() =>
@@ -32,7 +32,7 @@ export default function CustomDropIndicator({
   const scale = useSharedValue(0);
   const colorIndex = useSharedValue(0);
   const showIndicator = useDerivedValue(
-    () => activationProgress.value > 0.2 && touchedItemKey.value !== null
+    () => activeAnimationProgress.value > 0.2 && activeItemKey.value !== null
   );
 
   useAnimatedReaction(

--- a/example/app/src/examples/navigation/routes.ts
+++ b/example/app/src/examples/navigation/routes.ts
@@ -18,6 +18,10 @@ const routes: Routes = {
         Component: SortableGrid.DropIndicatorExample,
         name: 'Drop Indicator'
       },
+      DragHandle: {
+        Component: SortableGrid.DragHandleExample,
+        name: 'Drag Handle'
+      },
       AutoScroll: {
         Component: SortableGrid.AutoScrollExample,
         name: 'Auto Scroll'

--- a/packages/react-native-sortables/src/components/defaults/DefaultDropIndicator.tsx
+++ b/packages/react-native-sortables/src/components/defaults/DefaultDropIndicator.tsx
@@ -6,15 +6,15 @@ import Animated, {
 import type { DropIndicatorComponentProps } from '../../types';
 
 export default function DefaultDropIndicator({
-  activationProgress,
+  activeAnimationProgress,
   style
 }: DropIndicatorComponentProps): JSX.Element {
   const animatedStyle = useAnimatedStyle(() => ({
-    opacity: style.opacity ?? activationProgress.value,
+    opacity: style.opacity ?? activeAnimationProgress.value,
     transform: style.transform ?? [
       {
         scale: interpolate(
-          Math.pow(activationProgress.value, 1 / 3),
+          Math.pow(activeAnimationProgress.value, 1 / 3),
           [0, 1],
           [1.1, 1]
         )

--- a/packages/react-native-sortables/src/components/shared/AnimatedOnLayoutView.tsx
+++ b/packages/react-native-sortables/src/components/shared/AnimatedOnLayoutView.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from 'react';
-import type { ViewProps } from 'react-native';
+import type { View, ViewProps } from 'react-native';
 import Animated from 'react-native-reanimated';
 
 import { IS_WEB } from '../../constants';
@@ -11,25 +11,25 @@ import type { RequiredBy } from '../../types';
  * (onLayout is called with 0 dimensions for views which have display: none,
  * so it gets called on navigation between screens)
  */
-const AnimatedViewWeb = forwardRef<
-  Animated.View,
-  RequiredBy<ViewProps, 'onLayout'>
->(function AnimatedViewWeb({ onLayout, ...rest }, ref) {
-  return (
-    <Animated.View
-      {...rest}
-      ref={ref}
-      onLayout={e => {
-        const el = (e.nativeEvent as unknown as { target: HTMLElement }).target;
-        // We want to call onLayout only for displayed views to prevent
-        // layout animation on navigation between screens
-        // @ts-expect-error This is a correct HTML element prop on web
-        if (el?.offsetParent) {
-          onLayout(e);
-        }
-      }}
-    />
-  );
-});
+const AnimatedViewWeb = forwardRef<View, RequiredBy<ViewProps, 'onLayout'>>(
+  function AnimatedViewWeb({ onLayout, ...rest }, ref) {
+    return (
+      <Animated.View
+        {...rest}
+        ref={ref}
+        onLayout={e => {
+          const el = (e.nativeEvent as unknown as { target: HTMLElement })
+            .target;
+          // We want to call onLayout only for displayed views to prevent
+          // layout animation on navigation between screens
+          // @ts-expect-error This is a correct HTML element prop on web
+          if (el?.offsetParent) {
+            onLayout(e);
+          }
+        }}
+      />
+    );
+  }
+);
 
 export default IS_WEB ? AnimatedViewWeb : Animated.View;

--- a/packages/react-native-sortables/src/components/shared/DraggableView.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView.tsx
@@ -31,10 +31,10 @@ export default function DraggableView({
   style,
   ...viewProps
 }: DraggableViewProps) {
-  const { customHandle, touchedItemKey } = useCommonValuesContext();
+  const { activeItemKey, customHandle } = useCommonValuesContext();
   const { handleItemMeasurement, handleItemRemoval } = useMeasurementsContext();
 
-  const isBeingActivated = useDerivedValue(() => touchedItemKey.value === key);
+  const isBeingActivated = useDerivedValue(() => activeItemKey.value === key);
   const pressProgress = useSharedValue(0);
   const layoutStyles = useItemLayoutStyles(key, pressProgress);
 

--- a/packages/react-native-sortables/src/components/shared/DraggableView.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import type { ViewProps } from 'react-native';
-import { GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   LinearTransition,
   useDerivedValue,
@@ -12,11 +11,11 @@ import {
   ItemContextProvider,
   useCommonValuesContext,
   useItemLayoutStyles,
-  useItemPanGesture,
   useMeasurementsContext
 } from '../../providers';
 import type { LayoutAnimation } from '../../types';
 import ItemDecoration from './ItemDecoration';
+import { SortableHandleInternal } from './SortableHandle';
 
 type DraggableViewProps = {
   itemKey: string;
@@ -32,46 +31,51 @@ export default function DraggableView({
   style,
   ...viewProps
 }: DraggableViewProps) {
-  const { touchedItemKey } = useCommonValuesContext();
+  const { customHandle, touchedItemKey } = useCommonValuesContext();
   const { handleItemMeasurement, handleItemRemoval } = useMeasurementsContext();
 
   const isBeingActivated = useDerivedValue(() => touchedItemKey.value === key);
   const pressProgress = useSharedValue(0);
-  const gesture = useItemPanGesture(key, pressProgress);
   const layoutStyles = useItemLayoutStyles(key, pressProgress);
 
   useEffect(() => {
     return () => handleItemRemoval(key);
   }, [key, handleItemRemoval]);
 
+  const innerComponent = (
+    <ItemDecoration
+      isBeingActivated={isBeingActivated}
+      itemKey={key}
+      pressProgress={pressProgress}
+      // Keep onLayout the closest to the children to measure the real item size
+      // (without paddings or other style changes made to the wrapper component)
+      onLayout={({ nativeEvent: { layout } }) => {
+        handleItemMeasurement(key, {
+          height: layout.height,
+          width: layout.width
+        });
+      }}>
+      {children}
+    </ItemDecoration>
+  );
+
   return (
     <Animated.View
       {...viewProps}
       layout={IS_WEB ? undefined : LinearTransition}
       style={[style, layoutStyles]}>
-      <Animated.View entering={entering} exiting={exiting}>
-        <GestureDetector gesture={gesture}>
-          <ItemDecoration
-            isBeingActivated={isBeingActivated}
-            itemKey={key}
-            pressProgress={pressProgress}
-            // Keep onLayout the closest to the children to measure the real item size
-            // (without paddings or other style changes made to the wrapper component)
-            onLayout={({ nativeEvent: { layout } }) => {
-              handleItemMeasurement(key, {
-                height: layout.height,
-                width: layout.width
-              });
-            }}>
-            <ItemContextProvider
-              isBeingActivated={isBeingActivated}
-              itemKey={key}
-              pressProgress={pressProgress}>
-              {children}
-            </ItemContextProvider>
-          </ItemDecoration>
-        </GestureDetector>
-      </Animated.View>
+      <ItemContextProvider
+        isBeingActivated={isBeingActivated}
+        itemKey={key}
+        pressProgress={pressProgress}>
+        <Animated.View entering={entering} exiting={exiting}>
+          {customHandle ? (
+            innerComponent
+          ) : (
+            <SortableHandleInternal>{innerComponent}</SortableHandleInternal>
+          )}
+        </Animated.View>
+      </ItemContextProvider>
     </Animated.View>
   );
 }

--- a/packages/react-native-sortables/src/components/shared/DropIndicator.tsx
+++ b/packages/react-native-sortables/src/components/shared/DropIndicator.tsx
@@ -13,7 +13,11 @@ import Animated, {
 } from 'react-native-reanimated';
 
 import { useCommonValuesContext } from '../../providers';
-import type { DropIndicatorComponentProps, Vector } from '../../types';
+import type {
+  Dimensions,
+  DropIndicatorComponentProps,
+  Vector
+} from '../../types';
 
 const DEFAULT_STYLE: ViewStyle = {
   opacity: 0
@@ -41,9 +45,7 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
   const dropIndex = useSharedValue(0);
   const dropPosition = useSharedValue<Vector>({ x: 0, y: 0 });
   const prevUpdateItemKey = useSharedValue<null | string>(null);
-  const activeItemDimensions = useDerivedValue(
-    () => activeItemKey.value && itemDimensions.value[activeItemKey.value]
-  );
+  const dimensions = useSharedValue<Dimensions | null>(null);
 
   const x = useSharedValue<null | number>(null);
   const y = useSharedValue<null | number>(null);
@@ -59,6 +61,7 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
       if (key !== null) {
         dropIndex.value = kToI[key] ?? 0;
         dropPosition.value = positions[key] ?? { x: 0, y: 0 };
+        dimensions.value = itemDimensions.value[key] ?? null;
 
         const update = (target: SharedValue<null | number>, value: number) => {
           if (target.value === null || prevUpdateItemKey.value === null) {
@@ -83,19 +86,13 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
   const animatedStyle = useAnimatedStyle(() => {
     const translateX = x.value;
     const translateY = y.value;
-    const dimensions = activeItemDimensions.value;
 
-    if (
-      !dimensions ||
-      translateX === null ||
-      translateY === null ||
-      activeItemDropped.value
-    ) {
+    if (translateX === null || translateY === null || activeItemDropped.value) {
       return DEFAULT_STYLE;
     }
 
     return {
-      ...dimensions,
+      ...dimensions.value,
       opacity: 1,
       transform: [{ translateX }, { translateY }]
     };

--- a/packages/react-native-sortables/src/components/shared/DropIndicator.tsx
+++ b/packages/react-native-sortables/src/components/shared/DropIndicator.tsx
@@ -29,11 +29,10 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
     activationProgress,
     activeItemDropped,
     indexToKey,
+    itemDimensions,
     itemPositions,
     keyToIndex,
-    touchedItemHeight,
-    touchedItemKey,
-    touchedItemWidth
+    touchedItemKey
   } = useCommonValuesContext();
 
   // Clone the array in order to prevent user from mutating the internal state
@@ -42,6 +41,9 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
   const dropIndex = useSharedValue(0);
   const dropPosition = useSharedValue<Vector>({ x: 0, y: 0 });
   const prevUpdateItemKey = useSharedValue<null | string>(null);
+  const touchedItemDimensions = useDerivedValue(
+    () => touchedItemKey.value && itemDimensions.value[touchedItemKey.value]
+  );
 
   const x = useSharedValue<null | number>(null);
   const y = useSharedValue<null | number>(null);
@@ -81,16 +83,21 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
   const animatedStyle = useAnimatedStyle(() => {
     const translateX = x.value;
     const translateY = y.value;
+    const dimensions = touchedItemDimensions.value;
 
-    if (translateX === null || translateY === null || activeItemDropped.value) {
+    if (
+      !dimensions ||
+      translateX === null ||
+      translateY === null ||
+      activeItemDropped.value
+    ) {
       return DEFAULT_STYLE;
     }
 
     return {
-      height: touchedItemHeight.value,
+      ...dimensions,
       opacity: 1,
-      transform: [{ translateX }, { translateY }],
-      width: touchedItemWidth.value
+      transform: [{ translateX }, { translateY }]
     };
   });
 

--- a/packages/react-native-sortables/src/components/shared/DropIndicator.tsx
+++ b/packages/react-native-sortables/src/components/shared/DropIndicator.tsx
@@ -26,13 +26,13 @@ type DropIndicatorProps = {
 
 function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
   const {
-    activationProgress,
+    activeAnimationProgress,
     activeItemDropped,
+    activeItemKey,
     indexToKey,
     itemDimensions,
     itemPositions,
-    keyToIndex,
-    touchedItemKey
+    keyToIndex
   } = useCommonValuesContext();
 
   // Clone the array in order to prevent user from mutating the internal state
@@ -41,8 +41,8 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
   const dropIndex = useSharedValue(0);
   const dropPosition = useSharedValue<Vector>({ x: 0, y: 0 });
   const prevUpdateItemKey = useSharedValue<null | string>(null);
-  const touchedItemDimensions = useDerivedValue(
-    () => touchedItemKey.value && itemDimensions.value[touchedItemKey.value]
+  const activeItemDimensions = useDerivedValue(
+    () => activeItemKey.value && itemDimensions.value[activeItemKey.value]
   );
 
   const x = useSharedValue<null | number>(null);
@@ -52,7 +52,7 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
     () => ({
       dropped: activeItemDropped.value,
       kToI: keyToIndex.value,
-      key: touchedItemKey.value,
+      key: activeItemKey.value,
       positions: itemPositions.value
     }),
     ({ dropped, kToI, key, positions }) => {
@@ -83,7 +83,7 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
   const animatedStyle = useAnimatedStyle(() => {
     const translateX = x.value;
     const translateY = y.value;
-    const dimensions = touchedItemDimensions.value;
+    const dimensions = activeItemDimensions.value;
 
     if (
       !dimensions ||
@@ -104,12 +104,12 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
   return (
     <Animated.View style={[styles.container, animatedStyle]}>
       <DropIndicatorComponent
-        activationProgress={activationProgress}
+        activeAnimationProgress={activeAnimationProgress}
+        activeItemKey={activeItemKey}
         dropIndex={dropIndex}
         dropPosition={dropPosition}
         orderedItemKeys={orderedItemKeys}
         style={style}
-        touchedItemKey={touchedItemKey}
       />
     </Animated.View>
   );

--- a/packages/react-native-sortables/src/components/shared/ItemDecoration.tsx
+++ b/packages/react-native-sortables/src/components/shared/ItemDecoration.tsx
@@ -27,20 +27,20 @@ export default function ItemDecoration({
   ...rest
 }: ItemDecorationProps) {
   const {
+    activeAnimationDuration,
     activeItemOpacity,
     activeItemScale,
     activeItemShadowOpacity,
-    dragActivationDuration,
     inactiveAnimationProgress,
     inactiveItemOpacity,
     inactiveItemScale,
     itemsStyleOverride,
-    prevTouchedItemKey
+    prevActiveItemKey
   } = useCommonValuesContext();
 
   const adjustedInactiveProgress = useDerivedValue(() => {
-    if (isBeingActivated.value || prevTouchedItemKey.value === key) {
-      return withTiming(0, { duration: dragActivationDuration.value });
+    if (isBeingActivated.value || prevActiveItemKey.value === key) {
+      return withTiming(0, { duration: activeAnimationDuration.value });
     }
 
     return interpolate(

--- a/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
@@ -28,10 +28,10 @@ export default function SortableContainer({
 }: AnimatedHeightContainerProps) {
   const {
     activeItemDropped,
+    activeItemKey,
     canSwitchToAbsoluteLayout,
     containerHeight,
-    shouldAnimateLayout,
-    touchedItemKey
+    shouldAnimateLayout
   } = useCommonValuesContext();
 
   const outerContainerStyle = useAnimatedStyle(() => {
@@ -44,7 +44,7 @@ export default function SortableContainer({
           ? withTiming(containerHeight.value)
           : containerHeight.value,
       overflow:
-        touchedItemKey.value !== null || !activeItemDropped.value
+        activeItemKey.value !== null || !activeItemDropped.value
           ? 'visible'
           : 'hidden',
       width: '100%'

--- a/packages/react-native-sortables/src/components/shared/SortableHandle.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableHandle.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-unused-modules */
 import type { PropsWithChildren } from 'react';
 import { View } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
@@ -20,17 +19,17 @@ export function SortableHandle({
   disabled = false
 }: SortableHandleProps) {
   const { itemKey, pressProgress } = useItemContext();
-  const { touchedHandleDimensions, touchedItemKey } = useCommonValuesContext();
+  const { activeItemKey, snapItemDimensions } = useCommonValuesContext();
 
   const dimensions = useSharedValue<Dimensions | null>(null);
 
   const gesture = useItemPanGesture(itemKey, pressProgress);
 
   useAnimatedReaction(
-    () => touchedItemKey.value,
+    () => activeItemKey.value,
     key => {
       if (key === itemKey) {
-        touchedHandleDimensions.value = dimensions.value;
+        snapItemDimensions.value = dimensions.value;
       }
     }
   );

--- a/packages/react-native-sortables/src/components/shared/SortableHandle.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableHandle.tsx
@@ -1,0 +1,63 @@
+/* eslint-disable import/no-unused-modules */
+import type { PropsWithChildren } from 'react';
+import { View } from 'react-native';
+import { GestureDetector } from 'react-native-gesture-handler';
+import { useAnimatedReaction, useSharedValue } from 'react-native-reanimated';
+
+import {
+  useCommonValuesContext,
+  useItemContext,
+  useItemPanGesture
+} from '../../providers';
+import type { Dimensions } from '../../types';
+
+export type SortableHandleProps = PropsWithChildren<{
+  disabled?: boolean;
+}>;
+
+export function SortableHandle({
+  children,
+  disabled = false
+}: SortableHandleProps) {
+  const { itemKey, pressProgress } = useItemContext();
+  const { touchedHandleDimensions, touchedItemKey } = useCommonValuesContext();
+
+  const dimensions = useSharedValue<Dimensions | null>(null);
+
+  const gesture = useItemPanGesture(itemKey, pressProgress);
+
+  useAnimatedReaction(
+    () => touchedItemKey.value,
+    key => {
+      if (key === itemKey) {
+        touchedHandleDimensions.value = dimensions.value;
+      }
+    }
+  );
+
+  return (
+    <GestureDetector gesture={gesture.enabled(!disabled)}>
+      <View
+        onLayout={({ nativeEvent: { layout } }) => {
+          dimensions.value = {
+            height: layout.height,
+            width: layout.width
+          };
+        }}>
+        {children}
+      </View>
+    </GestureDetector>
+  );
+}
+
+export function SortableHandleInternal({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  const { itemKey, pressProgress } = useItemContext();
+
+  const gesture = useItemPanGesture(itemKey, pressProgress);
+
+  return <GestureDetector gesture={gesture}>{children}</GestureDetector>;
+}

--- a/packages/react-native-sortables/src/components/shared/SortableHandle.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableHandle.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithChildren, useCallback } from 'react';
+import { type PropsWithChildren, useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
 import {
@@ -73,8 +73,13 @@ export function SortableHandle({
   // Measure the handle when the active item key changes
   useAnimatedReaction(() => activeItemKey.value, measureHandle);
 
+  const adjustedGesture = useMemo(
+    () => gesture.enabled(!disabled),
+    [disabled, gesture]
+  );
+
   return (
-    <GestureDetector gesture={gesture.enabled(!disabled)}>
+    <GestureDetector gesture={adjustedGesture}>
       <View ref={viewRef} onLayout={measureHandle}>
         {children}
       </View>

--- a/packages/react-native-sortables/src/components/shared/SortableLayer.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableLayer.tsx
@@ -3,7 +3,9 @@ import type { ViewProps } from 'react-native';
 
 import { LayerProvider } from '../../providers';
 
-type SortableLayerProps = PropsWithChildren<{ disabled?: boolean } & ViewProps>;
+export type SortableLayerProps = PropsWithChildren<
+  { disabled?: boolean } & ViewProps
+>;
 
 export default function SortableLayer({
   children,

--- a/packages/react-native-sortables/src/components/shared/createSortableTouchable.tsx
+++ b/packages/react-native-sortables/src/components/shared/createSortableTouchable.tsx
@@ -21,8 +21,8 @@ export default function createSortableTouchable<P extends AnyPressHandlers>(
         dragState: dragActivationState.value
       }),
       ({ dragState }) => {
-        // Cancels when the item starts being activated
-        if (dragState === DragActivationState.ACTIVATING) {
+        // Cancels when the item is active
+        if (dragState === DragActivationState.ACTIVE) {
           isCancelled.value = true;
         }
         // Resets state when the item is touched again

--- a/packages/react-native-sortables/src/components/shared/index.ts
+++ b/packages/react-native-sortables/src/components/shared/index.ts
@@ -2,4 +2,8 @@ export { default as AnimatedOnLayoutView } from './AnimatedOnLayoutView';
 export { default as createSortableTouchable } from './createSortableTouchable';
 export { default as DraggableView } from './DraggableView';
 export { default as SortableContainer } from './SortableContainer';
-export { default as SortableLayer } from './SortableLayer';
+export * from './SortableHandle';
+export {
+  default as SortableLayer,
+  type SortableLayerProps
+} from './SortableLayer';

--- a/packages/react-native-sortables/src/constants/props.ts
+++ b/packages/react-native-sortables/src/constants/props.ts
@@ -53,9 +53,9 @@ export const DEFAULT_SHARED_PROPS = {
   enableActiveItemSnap: true,
   hapticsEnabled: false,
   inactiveItemOpacity: 0.5,
+  inactiveItemScale: 1,
   // Layout animations on web don't work properly so we don't provide
   // default layout animations here. This is an issue that should be
-  inactiveItemScale: 1,
   // fixed in `react-native-reanimated` in the future.
   itemEntering: IS_WEB ? undefined : SortableItemEntering,
   itemExiting: IS_WEB ? undefined : SortableItemExiting,

--- a/packages/react-native-sortables/src/constants/props.ts
+++ b/packages/react-native-sortables/src/constants/props.ts
@@ -29,6 +29,7 @@ type DefaultSharedProps = DefaultProps<SharedProps, OptionalSharedProps>;
 
 export const DEFAULT_SHARED_PROPS = {
   DropIndicatorComponent: DefaultDropIndicator,
+  activeAnimationDuration: DRAG_ANIMATION_DURATION,
   activeItemOpacity: 1,
   activeItemScale: 1.1,
   activeItemShadowOpacity: 0.2,
@@ -39,7 +40,6 @@ export const DEFAULT_SHARED_PROPS = {
   customHandle: false,
   debug: false,
   dragActivationDelay: DRAG_ACTIVATION_DELAY,
-  dragActivationDuration: DRAG_ANIMATION_DURATION,
   dragActivationFailOffset: DRAG_ACTIVATION_FAIL_OFFSET,
   dropAnimationDuration: DRAG_ANIMATION_DURATION,
   dropIndicatorStyle: {

--- a/packages/react-native-sortables/src/constants/props.ts
+++ b/packages/react-native-sortables/src/constants/props.ts
@@ -36,6 +36,7 @@ export const DEFAULT_SHARED_PROPS = {
   autoScrollActivationOffset: 75,
   autoScrollEnabled: true,
   autoScrollSpeed: 1,
+  customHandle: false,
   debug: false,
   dragActivationDelay: DRAG_ACTIVATION_DELAY,
   dragActivationDuration: DRAG_ANIMATION_DURATION,
@@ -52,9 +53,9 @@ export const DEFAULT_SHARED_PROPS = {
   enableActiveItemSnap: true,
   hapticsEnabled: false,
   inactiveItemOpacity: 0.5,
-  inactiveItemScale: 1,
   // Layout animations on web don't work properly so we don't provide
   // default layout animations here. This is an issue that should be
+  inactiveItemScale: 1,
   // fixed in `react-native-reanimated` in the future.
   itemEntering: IS_WEB ? undefined : SortableItemEntering,
   itemExiting: IS_WEB ? undefined : SortableItemExiting,

--- a/packages/react-native-sortables/src/debug/components/DebugLine.tsx
+++ b/packages/react-native-sortables/src/debug/components/DebugLine.tsx
@@ -69,6 +69,7 @@ export default function DebugLine({ props }: WrappedProps<DebugLineProps>) {
 const styles = StyleSheet.create({
   container: {
     overflow: 'hidden',
+    pointerEvents: 'none',
     position: 'absolute',
     transformOrigin: '0 0'
   }

--- a/packages/react-native-sortables/src/debug/components/DebugRect.tsx
+++ b/packages/react-native-sortables/src/debug/components/DebugRect.tsx
@@ -83,6 +83,7 @@ export default function DebugRect({ props }: WrappedProps<DebugRectProps>) {
 
 const styles = StyleSheet.create({
   container: {
+    pointerEvents: 'none',
     position: 'absolute'
   }
 });

--- a/packages/react-native-sortables/src/index.ts
+++ b/packages/react-native-sortables/src/index.ts
@@ -5,9 +5,11 @@ import {
   createSortableTouchable,
   SortableFlex,
   SortableGrid,
+  SortableHandle,
   SortableLayer
 } from './components';
 
+export type { SortableHandleProps, SortableLayerProps } from './components';
 export * from './constants/layoutAnimations';
 export type {
   DragEndCallback,
@@ -30,6 +32,7 @@ export type {
 const Sortable = {
   Flex: SortableFlex,
   Grid: SortableGrid,
+  Handle: SortableHandle,
   Layer: SortableLayer,
   Pressable: createSortableTouchable(Pressable),
   TouchableHighlight: createSortableTouchable(TouchableHighlight),

--- a/packages/react-native-sortables/src/providers/SharedProvider.tsx
+++ b/packages/react-native-sortables/src/providers/SharedProvider.tsx
@@ -28,6 +28,7 @@ type SharedProviderProps = PropsWithChildren<
     itemKeys: Array<string>;
     sortEnabled: Animatable<boolean>;
     hapticsEnabled: boolean;
+    customHandle: boolean;
     debug: boolean;
     initialItemsStyleOverride?: ViewStyle;
     dropIndicatorStyle?: ViewStyle;

--- a/packages/react-native-sortables/src/providers/layout/flex/updates/insert/utils.ts
+++ b/packages/react-native-sortables/src/providers/layout/flex/updates/insert/utils.ts
@@ -15,7 +15,7 @@ export type ItemGroupSwapProps = {
   mainGap: number;
 };
 
-export type ItemGroupSwapResult = {
+type ItemGroupSwapResult = {
   indexToKey: Array<string>;
   itemIndex: number;
   itemIndexInGroup: number;

--- a/packages/react-native-sortables/src/providers/layout/flex/utils/layout.ts
+++ b/packages/react-native-sortables/src/providers/layout/flex/utils/layout.ts
@@ -12,8 +12,8 @@ import type {
 } from '../../../../types';
 import { reverseArray, sum } from '../../../../utils';
 
-export type AxisDimensions = { cross: Dimension; main: Dimension };
-export type AxisDirections = { cross: Direction; main: Direction };
+type AxisDimensions = { cross: Dimension; main: Dimension };
+type AxisDirections = { cross: Direction; main: Direction };
 
 const createGroups = (
   indexToKey: Array<string>,

--- a/packages/react-native-sortables/src/providers/shared/AutoScrollProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/AutoScrollProvider.tsx
@@ -34,6 +34,7 @@ const { AutoScrollProvider, useAutoScrollContext } = createProvider(
   const {
     activeAnimationProgress,
     activeItemKey,
+    activeItemPosition,
     containerRef,
     itemDimensions,
     touchPosition
@@ -102,6 +103,21 @@ const { AutoScrollProvider, useAutoScrollContext } = createProvider(
     scrollTo(scrollableRef, 0, nextOffset, false);
     prevScrollToOffset.value = nextOffset;
   }, false);
+
+  // TODO - improve auto scroll later on
+  const lastUpdateScrollOffset = useSharedValue(0);
+  useAnimatedReaction(
+    () => scrollOffset.value,
+    offset => {
+      if (touchPosition.value) {
+        touchPosition.value = {
+          x: touchPosition.value.x,
+          y: touchPosition.value.y + (offset - lastUpdateScrollOffset.value)
+        };
+        lastUpdateScrollOffset.value = offset;
+      }
+    }
+  );
 
   const toggleFrameCallback = useCallback(
     (isEnabled: boolean) => frameCallback.setActive(isEnabled),

--- a/packages/react-native-sortables/src/providers/shared/AutoScrollProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/AutoScrollProvider.tsx
@@ -85,7 +85,7 @@ const { AutoScrollProvider, useAutoScrollContext } = createProvider(
     }
 
     const direction = diff > 0 ? 1 : -1;
-    const step = speed.value * direction * Math.abs(diff);
+    const step = speed.value * direction * Math.sqrt(Math.abs(diff));
     const nextOffset =
       targetOffset > currentOffset
         ? Math.min(currentOffset + step, targetOffset)

--- a/packages/react-native-sortables/src/providers/shared/AutoScrollProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/AutoScrollProvider.tsx
@@ -34,7 +34,6 @@ const { AutoScrollProvider, useAutoScrollContext } = createProvider(
   const {
     activeAnimationProgress,
     activeItemKey,
-    activeItemPosition,
     containerRef,
     itemDimensions,
     touchPosition
@@ -86,7 +85,7 @@ const { AutoScrollProvider, useAutoScrollContext } = createProvider(
     }
 
     const direction = diff > 0 ? 1 : -1;
-    const step = speed.value * direction * Math.sqrt(Math.abs(diff));
+    const step = speed.value * direction * Math.abs(diff);
     const nextOffset =
       targetOffset > currentOffset
         ? Math.min(currentOffset + step, targetOffset)
@@ -103,21 +102,6 @@ const { AutoScrollProvider, useAutoScrollContext } = createProvider(
     scrollTo(scrollableRef, 0, nextOffset, false);
     prevScrollToOffset.value = nextOffset;
   }, false);
-
-  // TODO - improve auto scroll later on
-  const lastUpdateScrollOffset = useSharedValue(0);
-  useAnimatedReaction(
-    () => scrollOffset.value,
-    offset => {
-      if (touchPosition.value) {
-        touchPosition.value = {
-          x: touchPosition.value.x,
-          y: touchPosition.value.y + (offset - lastUpdateScrollOffset.value)
-        };
-        lastUpdateScrollOffset.value = offset;
-      }
-    }
-  );
 
   const toggleFrameCallback = useCallback(
     (isEnabled: boolean) => frameCallback.setActive(isEnabled),

--- a/packages/react-native-sortables/src/providers/shared/AutoScrollProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/AutoScrollProvider.tsx
@@ -92,7 +92,7 @@ const { AutoScrollProvider, useAutoScrollContext } = createProvider(
         : Math.max(currentOffset + step, targetOffset);
 
     if (
-      Math.abs(nextOffset - currentOffset) < OFFSET_EPS ||
+      Math.abs(nextOffset - currentOffset) < 0.1 * OFFSET_EPS ||
       prevScrollToOffset.value === nextOffset
     ) {
       targetScrollOffset.value = -1;

--- a/packages/react-native-sortables/src/providers/shared/AutoScrollProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/AutoScrollProvider.tsx
@@ -32,12 +32,11 @@ const { AutoScrollProvider, useAutoScrollContext } = createProvider(
   scrollableRef
 }) => {
   const {
-    activationProgress,
+    activeAnimationProgress,
     activeItemKey,
     containerRef,
     itemDimensions,
-    touchPosition,
-    touchedItemKey
+    touchPosition
   } = useCommonValuesContext();
   const debugContext = useDebugContext();
 
@@ -113,8 +112,8 @@ const { AutoScrollProvider, useAutoScrollContext } = createProvider(
   useAnimatedReaction(
     () => ({
       isEnabled: enabled.value,
-      itemKey: touchedItemKey.value,
-      progress: activationProgress.value
+      itemKey: activeItemKey.value,
+      progress: activeAnimationProgress.value
     }),
     ({ isEnabled, itemKey, progress }) => {
       const shouldBeEnabled = isEnabled && itemKey !== null;

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
@@ -25,6 +25,7 @@ import { createProvider } from '../utils';
 type CommonValuesProviderProps = PropsWithChildren<
   {
     sortEnabled: Animatable<boolean>;
+    customHandle: boolean;
     itemKeys: Array<string>;
     initialItemsStyleOverride?: ViewStyle;
   } & ActiveItemDecorationSettings &
@@ -38,6 +39,7 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
   activeItemOpacity: _activeItemOpacity,
   activeItemScale: _activeItemScale,
   activeItemShadowOpacity: _activeItemShadowOpacity,
+  customHandle,
   dragActivationDelay: _dragActivationDelay,
   dragActivationDuration: _dragActivationDuration,
   dragActivationFailOffset: _dragActivationFailOffset,
@@ -67,8 +69,7 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
   // DIMENSIONS
   const containerWidth = useSharedValue(-1);
   const containerHeight = useSharedValue(-1);
-  const touchedItemWidth = useSharedValue(-1);
-  const touchedItemHeight = useSharedValue(-1);
+  const touchedHandleDimensions = useSharedValue<Dimensions | null>(null);
   const itemDimensions = useSharedValue<Record<string, Dimensions>>({});
   const itemsStyleOverride = useSharedValue<Maybe<ViewStyle>>(
     initialItemsStyleOverride
@@ -129,6 +130,7 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
       containerHeight,
       containerRef,
       containerWidth,
+      customHandle,
       dragActivationDelay,
       dragActivationDuration,
       dragActivationFailOffset,
@@ -148,10 +150,9 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
       snapOffsetY,
       sortEnabled,
       touchPosition,
-      touchedItemHeight,
+      touchedHandleDimensions,
       touchedItemKey,
-      touchedItemPosition,
-      touchedItemWidth
+      touchedItemPosition
     }
   };
 });

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
@@ -64,6 +64,7 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
   const itemPositions = useSharedValue<Record<string, Vector>>({});
   const touchPosition = useSharedValue<Vector | null>(null);
   const activeItemPosition = useSharedValue<Vector | null>(null);
+  const snapItemOffset = useSharedValue<Vector | null>(null);
 
   // DIMENSIONS
   const containerWidth = useSharedValue(-1);
@@ -146,6 +147,7 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
       prevActiveItemKey,
       shouldAnimateLayout,
       snapItemDimensions,
+      snapItemOffset,
       snapOffsetX,
       snapOffsetY,
       sortEnabled,

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
@@ -1,6 +1,5 @@
 import { type PropsWithChildren, useEffect, useRef } from 'react';
-import type { ViewStyle } from 'react-native';
-import type Animated from 'react-native-reanimated';
+import type { View, ViewStyle } from 'react-native';
 import {
   useAnimatedRef,
   useDerivedValue,
@@ -104,7 +103,7 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
   const snapOffsetY = useAnimatableValue(_snapOffsetY);
 
   // OTHER
-  const containerRef = useAnimatedRef<Animated.View>();
+  const containerRef = useAnimatedRef<View>();
   const sortEnabled = useAnimatableValue(_sortEnabled);
   const canSwitchToAbsoluteLayout = useSharedValue(false);
   const shouldAnimateLayout = useSharedValue(true);

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
@@ -36,12 +36,12 @@ type CommonValuesProviderProps = PropsWithChildren<
 const { CommonValuesProvider, useCommonValuesContext } = createProvider(
   'CommonValues'
 )<CommonValuesProviderProps, CommonValuesContextType>(({
+  activeAnimationDuration: _activeAnimationDuration,
   activeItemOpacity: _activeItemOpacity,
   activeItemScale: _activeItemScale,
   activeItemShadowOpacity: _activeItemShadowOpacity,
   customHandle,
   dragActivationDelay: _dragActivationDelay,
-  dragActivationDuration: _dragActivationDuration,
   dragActivationFailOffset: _dragActivationFailOffset,
   dropAnimationDuration: _dropAnimationDuration,
   enableActiveItemSnap: _enableActiveItemSnap,
@@ -64,29 +64,28 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
   // POSITIONS
   const itemPositions = useSharedValue<Record<string, Vector>>({});
   const touchPosition = useSharedValue<Vector | null>(null);
-  const touchedItemPosition = useSharedValue<Vector | null>(null);
+  const activeItemPosition = useSharedValue<Vector | null>(null);
 
   // DIMENSIONS
   const containerWidth = useSharedValue(-1);
   const containerHeight = useSharedValue(-1);
-  const touchedHandleDimensions = useSharedValue<Dimensions | null>(null);
+  const snapItemDimensions = useSharedValue<Dimensions | null>(null);
   const itemDimensions = useSharedValue<Record<string, Dimensions>>({});
   const itemsStyleOverride = useSharedValue<Maybe<ViewStyle>>(
     initialItemsStyleOverride
   );
 
   // DRAG STATE
-  const touchedItemKey = useSharedValue<null | string>(null);
-  const prevTouchedItemKey = useSharedValue<null | string>(null);
   const activeItemKey = useSharedValue<null | string>(null);
+  const prevActiveItemKey = useSharedValue<null | string>(null);
   const activationState = useSharedValue(DragActivationState.INACTIVE);
-  const activationProgress = useSharedValue(0);
+  const activeAnimationProgress = useSharedValue(0);
   const inactiveAnimationProgress = useSharedValue(0);
   const activeItemDropped = useSharedValue(true);
 
   // ITEM ACTIVATION SETTINGS
   const dragActivationDelay = useAnimatableValue(_dragActivationDelay);
-  const dragActivationDuration = useAnimatableValue(_dragActivationDuration);
+  const activeAnimationDuration = useAnimatableValue(_activeAnimationDuration);
   const dragActivationFailOffset = useAnimatableValue(
     _dragActivationFailOffset
   );
@@ -119,11 +118,13 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
 
   return {
     value: {
-      activationProgress,
       activationState,
+      activeAnimationDuration,
+      activeAnimationProgress,
       activeItemDropped,
       activeItemKey,
       activeItemOpacity,
+      activeItemPosition,
       activeItemScale,
       activeItemShadowOpacity,
       canSwitchToAbsoluteLayout,
@@ -132,7 +133,6 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
       containerWidth,
       customHandle,
       dragActivationDelay,
-      dragActivationDuration,
       dragActivationFailOffset,
       dropAnimationDuration,
       enableActiveItemSnap,
@@ -144,15 +144,13 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
       itemPositions,
       itemsStyleOverride,
       keyToIndex,
-      prevTouchedItemKey,
+      prevActiveItemKey,
       shouldAnimateLayout,
+      snapItemDimensions,
       snapOffsetX,
       snapOffsetY,
       sortEnabled,
-      touchPosition,
-      touchedHandleDimensions,
-      touchedItemKey,
-      touchedItemPosition
+      touchPosition
     }
   };
 });

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
@@ -1,12 +1,15 @@
 import { type PropsWithChildren, useCallback } from 'react';
+import type { View } from 'react-native';
 import type {
   GestureTouchEvent,
   TouchData
 } from 'react-native-gesture-handler';
-import { State } from 'react-native-gesture-handler';
-import type { SharedValue } from 'react-native-reanimated';
+import type { AnimatedRef, SharedValue } from 'react-native-reanimated';
 import {
+  interpolate,
+  measure,
   useAnimatedReaction,
+  useDerivedValue,
   useSharedValue,
   withTiming
 } from 'react-native-reanimated';
@@ -44,6 +47,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
     activeItemKey,
     activeItemPosition,
     canSwitchToAbsoluteLayout,
+    containerRef,
     dragActivationDelay,
     dragActivationFailOffset,
     dropAnimationDuration,
@@ -68,17 +72,22 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
   const debugContext = useDebugContext();
 
   const debugCross = debugContext?.useDebugCross();
-
   const haptics = useHaptics(hapticsEnabled);
 
-  const startTouch = useSharedValue<TouchData | null>(null);
-  const touchStartItemPosition = useSharedValue<Vector | null>(null);
-  const touchTranslation = useSharedValue<Vector | null>(null);
-  const dragStartTouchTranslation = useSharedValue<Vector | null>(null);
-
+  const firstTouchBeforeActivation = useSharedValue<TouchData | null>(null);
+  const lastTouchBeforeActivation = useSharedValue<TouchData | null>(null);
+  const dragStartItemTouchOffset = useSharedValue<Vector | null>(null);
   const dragStartIndex = useSharedValue(-1);
+  const snapItemOffset = useSharedValue<Vector | null>(null);
+  const scrollOffsetY = useDerivedValue(() => {
+    if (dragStartScrollOffset?.value === -1) {
+      return 0;
+    }
+    return (scrollOffset?.value ?? 0) - (dragStartScrollOffset?.value ?? 0);
+  });
+
+  // used for activation and deactivation (drop)
   const activationTimeoutId = useSharedValue(-1);
-  const snapTranslation = useSharedValue<Vector | null>(null);
 
   // Create stable callbacks to avoid re-rendering when the callback
   // function is not memoized
@@ -86,103 +95,98 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
   const stableOnDragEnd = useJSStableCallback(onDragEnd);
   const stableOnOrderChange = useJSStableCallback(onOrderChange);
 
-  // ACTIVE ITEM SNAP UPDATER
-  useAnimatedReaction(
-    () => ({
-      dimensions: snapItemDimensions.value,
-      enableSnap: enableActiveItemSnap.value,
-      oX: snapOffsetX.value,
-      oY: snapOffsetY.value,
-      progress: activeAnimationProgress.value,
-      touch: startTouch.value && {
-        x: startTouch.value.x,
-        y: startTouch.value.y
-      }
-    }),
-    ({ dimensions, enableSnap, oX, oY, progress, touch }) => {
-      if (!enableSnap || !dimensions || !touch) {
-        snapTranslation.value = null;
-        return;
-      }
-
-      const translation = touchTranslation.value;
-      const targetDeltaX =
-        touch.x -
-        getOffsetDistance(oX, dimensions.width) +
-        (translation?.x ?? 0);
-      const targetDeltaY =
-        touch.y -
-        getOffsetDistance(oY, dimensions.height) +
-        (translation?.y ?? 0);
-
-      snapTranslation.value = {
-        x: 0,
-        y: 0
-      };
-    }
-  );
-
-  // ACTIVE ITEM POSITION UPDATER
-  useAnimatedReaction(
-    () => ({
-      dragStartTranslation: dragStartTouchTranslation.value,
-      itemStartPosition: touchStartItemPosition.value,
-      scrollOffsetY:
-        dragStartScrollOffset?.value === -1
-          ? 0
-          : (scrollOffset?.value ?? 0) - (dragStartScrollOffset?.value ?? 0),
-      snap: snapTranslation.value,
-      translation: touchTranslation.value
-    }),
-    ({
-      dragStartTranslation,
-      itemStartPosition,
-      scrollOffsetY,
-      snap,
-      translation
-    }) => {
-      if (!itemStartPosition) {
-        activeItemPosition.value = null;
-        return;
-      }
-
-      activeItemPosition.value = {
-        x:
-          itemStartPosition.x +
-          (translation?.x ?? 0) +
-          (snap?.x ?? 0) -
-          (dragStartTranslation?.x ?? 0),
-        y:
-          itemStartPosition.y +
-          (translation?.y ?? 0) +
-          (snap?.y ?? 0) -
-          (dragStartTranslation?.y ?? 0) +
-          scrollOffsetY
-      };
-    }
-  );
-
-  // TOUCH POSITION UPDATER
-  useAnimatedReaction(
-    () => ({
-      itemPosition: activeItemPosition.value,
-      snap: snapTranslation.value,
-      touch: startTouch.value
-        ? { x: startTouch.value.x, y: startTouch.value.y }
-        : null
-    }),
-    ({ itemPosition, snap, touch }) => {
-      if (!itemPosition || !touch) {
-        touchPosition.value = null;
+  const handleTouchChange = useCallback(
+    (touch: TouchData, handleRef?: AnimatedRef<View>) => {
+      'worklet';
+      const containerMeasurements = measure(containerRef);
+      if (!containerMeasurements) {
         debugCross?.set({ position: null });
         return;
       }
 
       touchPosition.value = {
-        x: itemPosition.x + touch.x - (snap?.x ?? 0),
-        y: itemPosition.y + touch.y - (snap?.y ?? 0)
+        x: touch.absoluteX - containerMeasurements.pageX,
+        y: touch.absoluteY - containerMeasurements.pageY
       };
-      debugCross?.set({ color: '#00007e', position: touchPosition.value });
+      debugCross?.set({
+        color: '#00007e',
+        position: touchPosition.value
+      });
+
+      if (handleRef) {
+        const handleMeasurements = measure(handleRef);
+        const activePosition =
+          activeItemPosition.value ??
+          (activeItemKey.value && itemPositions.value[activeItemKey.value]);
+        if (!handleMeasurements || !activePosition) {
+          return;
+        }
+
+        snapItemOffset.value = {
+          x:
+            handleMeasurements.pageX -
+            containerMeasurements.pageX -
+            activePosition.x,
+          y:
+            handleMeasurements.pageY -
+            containerMeasurements.pageY -
+            activePosition.y
+        };
+      }
+    },
+    [
+      activeItemKey,
+      activeItemPosition,
+      containerRef,
+      debugCross,
+      itemPositions,
+      snapItemOffset,
+      touchPosition
+    ]
+  );
+
+  // ACTIVE ITEM POSITION UPDATER
+  useAnimatedReaction(
+    () => ({
+      dimensions: snapItemDimensions.value,
+      enableSnap: enableActiveItemSnap.value,
+      itemTouchOffset: dragStartItemTouchOffset.value,
+      oX: snapOffsetX.value,
+      oY: snapOffsetY.value,
+      progress: activeAnimationProgress.value,
+      scrollY: scrollOffsetY.value,
+      snapOffset: snapItemOffset.value,
+      touchPos: touchPosition.value
+    }),
+    ({
+      dimensions,
+      enableSnap,
+      itemTouchOffset,
+      oX,
+      oY,
+      progress,
+      snapOffset,
+      touchPos
+    }) => {
+      if (!dimensions || !touchPos || !itemTouchOffset) {
+        return;
+      }
+
+      const translate = (from: number, to: number) =>
+        from === to ? from : interpolate(progress, [0, 1], [from, to]);
+
+      let tX = itemTouchOffset.x;
+      let tY = itemTouchOffset.y;
+
+      if (enableSnap) {
+        tX = (snapOffset?.x ?? 0) + getOffsetDistance(oX, dimensions.width);
+        tY = (snapOffset?.y ?? 0) + getOffsetDistance(oY, dimensions.height);
+      }
+
+      activeItemPosition.value = {
+        x: touchPos.x - translate(itemTouchOffset.x, tX),
+        y: touchPos.y - translate(itemTouchOffset.y, tY)
+      };
     }
   );
 
@@ -191,12 +195,43 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
    */
 
   const handleDragStart = useCallback(
-    (key: string) => {
+    (
+      key: string,
+      pressProgress: SharedValue<number>,
+      handleRef?: AnimatedRef<View>
+    ) => {
       'worklet';
-      updateStartScrollOffset?.();
+      activeAnimationProgress.value = 0;
+      activeItemDropped.value = false;
+      prevActiveItemKey.value = activeItemKey.value;
       activeItemKey.value = key;
-      dragStartIndex.value = keyToIndex.value[key]!;
+      dragStartIndex.value = keyToIndex.value[key] ?? -1;
       activationState.value = DragActivationState.ACTIVE;
+
+      updateLayer?.(LayerState.Focused);
+      maybeUpdateSnapDimensions(key);
+      updateStartScrollOffset?.();
+      if (lastTouchBeforeActivation.value) {
+        handleTouchChange(lastTouchBeforeActivation.value, handleRef);
+      }
+
+      const itemPosition = itemPositions.value[key];
+      if (itemPosition && touchPosition.value) {
+        dragStartItemTouchOffset.value = {
+          x: touchPosition.value.x - itemPosition.x,
+          y: touchPosition.value.y - itemPosition.y
+        };
+      }
+
+      const hasInactiveAnimation =
+        inactiveItemOpacity.value !== 1 || inactiveItemScale.value !== 1;
+
+      const animate = () =>
+        withTiming(1, { duration: activeAnimationDuration.value });
+
+      inactiveAnimationProgress.value = hasInactiveAnimation ? animate() : 0;
+      activeAnimationProgress.value = animate();
+      pressProgress.value = animate();
 
       haptics.medium();
       stableOnDragStart({
@@ -205,13 +240,112 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       });
     },
     [
-      updateStartScrollOffset,
-      stableOnDragStart,
+      activeAnimationDuration,
+      activeAnimationProgress,
+      activeItemDropped,
       activationState,
       activeItemKey,
       dragStartIndex,
+      dragStartItemTouchOffset,
+      haptics,
+      handleTouchChange,
+      inactiveAnimationProgress,
+      inactiveItemOpacity,
+      inactiveItemScale,
+      itemPositions,
       keyToIndex,
-      haptics
+      lastTouchBeforeActivation,
+      maybeUpdateSnapDimensions,
+      prevActiveItemKey,
+      stableOnDragStart,
+      touchPosition,
+      updateLayer,
+      updateStartScrollOffset
+    ]
+  );
+
+  const handleTouchStart = useCallback(
+    (
+      e: GestureTouchEvent,
+      key: string,
+      pressProgress: SharedValue<number>,
+      activate: () => void,
+      fail: () => void,
+      handleRef?: AnimatedRef<View>
+    ) => {
+      'worklet';
+      const touch = e.allTouches[0];
+      if (!touch) {
+        fail();
+        return;
+      }
+
+      firstTouchBeforeActivation.value = lastTouchBeforeActivation.value =
+        touch;
+
+      if (!canSwitchToAbsoluteLayout.value) {
+        tryMeasureContainerHeight?.();
+      }
+
+      activationState.value = DragActivationState.TOUCHED;
+      clearAnimatedTimeout(activationTimeoutId.value);
+
+      // Start handling touch after a delay to prevent accidental activation
+      // e.g. while scrolling the ScrollView
+      activationTimeoutId.value = setAnimatedTimeout(() => {
+        activate();
+        handleDragStart(key, pressProgress, handleRef);
+      }, dragActivationDelay.value);
+    },
+    [
+      activationState,
+      activationTimeoutId,
+      canSwitchToAbsoluteLayout,
+      lastTouchBeforeActivation,
+      dragActivationDelay,
+      firstTouchBeforeActivation,
+      handleDragStart,
+      tryMeasureContainerHeight
+    ]
+  );
+
+  const handleTouchesMove = useCallback(
+    (e: GestureTouchEvent, fail: () => void, handleRef?: AnimatedRef<View>) => {
+      'worklet';
+      const touch = e.allTouches[0];
+      if (!touch || !firstTouchBeforeActivation.value) {
+        fail();
+        return;
+      }
+
+      if (activationState.value === DragActivationState.TOUCHED) {
+        const dX = touch.x - firstTouchBeforeActivation.value.x;
+        const dY = touch.y - firstTouchBeforeActivation.value.y;
+
+        // Cancel touch if the touch moved too far from the initial position
+        // before the item activation animation starts
+        const r = Math.sqrt(dX * dX + dY * dY);
+        if (
+          // activeItemKey is set after the drag activation delay passes
+          // and we don't want to cancel the touch anymore after this time
+          activeItemKey.value === null &&
+          r >= dragActivationFailOffset.value
+        ) {
+          fail();
+          return;
+        }
+        lastTouchBeforeActivation.value = touch;
+      } else if (activationState.value === DragActivationState.ACTIVE) {
+        handleTouchChange(touch, handleRef);
+      }
+    },
+    [
+      activationState,
+      activeItemKey,
+      dragActivationFailOffset,
+      firstTouchBeforeActivation,
+      lastTouchBeforeActivation,
+      handleTouchChange
     ]
   );
 
@@ -219,11 +353,13 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
     (key: string, pressProgress: SharedValue<number>) => {
       'worklet';
       prevActiveItemKey.value = activeItemKey.value;
+      activeItemPosition.value = null;
       activeItemKey.value = null;
-      startTouch.value = null;
-      touchTranslation.value = null;
-      touchStartItemPosition.value = null;
-      dragStartTouchTranslation.value = null;
+      firstTouchBeforeActivation.value = null;
+      lastTouchBeforeActivation.value = null;
+      touchPosition.value = null;
+      dragStartIndex.value = -1;
+      dragStartItemTouchOffset.value = null;
       activationState.value = DragActivationState.INACTIVE;
 
       const animate = (callback?: (finished: boolean | undefined) => void) =>
@@ -259,139 +395,25 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
     },
     [
       activeItemKey,
+      activeItemPosition,
       prevActiveItemKey,
-      dragStartTouchTranslation,
-      indexToKey,
-      touchStartItemPosition,
-      startTouch,
-      touchTranslation,
       activationTimeoutId,
       activeItemDropped,
       activeAnimationProgress,
       activationState,
-      inactiveAnimationProgress,
       dropAnimationDuration,
       dragStartIndex,
-      keyToIndex,
-      stableOnDragEnd,
-      updateLayer,
-      haptics
-    ]
-  );
-
-  const handleTouchStart = useCallback(
-    (
-      e: GestureTouchEvent,
-      key: string,
-      pressProgress: SharedValue<number>,
-      onActivate: () => void
-    ) => {
-      'worklet';
-      const firstTouch = e.allTouches[0];
-      if (!firstTouch) {
-        return;
-      }
-
-      if (!canSwitchToAbsoluteLayout.value) {
-        tryMeasureContainerHeight?.();
-      }
-
-      activationState.value = DragActivationState.TOUCHED;
-      clearAnimatedTimeout(activationTimeoutId.value);
-      // Start handling touch after a delay to prevent accidental activation
-      // e.g. while scrolling the ScrollView
-      activationTimeoutId.value = setAnimatedTimeout(() => {
-        maybeUpdateSnapDimensions(key);
-        updateLayer?.(LayerState.Focused);
-
-        onActivate();
-        activeAnimationProgress.value = 0;
-        activeItemDropped.value = false;
-        prevActiveItemKey.value = activeItemKey.value;
-        activeItemKey.value = key;
-        startTouch.value = firstTouch;
-        touchStartItemPosition.value = itemPositions.value[key] ?? null;
-        activationState.value = DragActivationState.ACTIVATING;
-
-        const hasInactiveAnimation =
-          inactiveItemOpacity.value !== 1 || inactiveItemScale.value !== 1;
-
-        const animate = (callback?: (finished?: boolean) => void) =>
-          withTiming(1, { duration: activeAnimationDuration.value }, callback);
-
-        inactiveAnimationProgress.value = hasInactiveAnimation ? animate() : 0;
-        activeAnimationProgress.value = animate();
-        pressProgress.value = animate(finished => {
-          if (
-            finished &&
-            e.state !== State.CANCELLED &&
-            e.state !== State.END
-          ) {
-            if (activeItemKey.value === key && itemPositions.value[key]) {
-              handleDragStart(key);
-            } else {
-              handleDragEnd(key, pressProgress);
-            }
-          }
-        });
-      }, dragActivationDelay.value);
-    },
-    [
-      prevActiveItemKey,
-      startTouch,
-      activeItemKey,
-      itemPositions,
-      activationTimeoutId,
-      touchStartItemPosition,
-      activationState,
-      activeAnimationProgress,
-      activeItemDropped,
+      dragStartItemTouchOffset,
+      firstTouchBeforeActivation,
+      haptics,
       inactiveAnimationProgress,
-      inactiveItemOpacity,
-      inactiveItemScale,
-      updateLayer,
-      handleDragStart,
-      handleDragEnd,
-      maybeUpdateSnapDimensions,
-      tryMeasureContainerHeight,
-      canSwitchToAbsoluteLayout,
-      dragActivationDelay,
-      activeAnimationDuration
+      indexToKey,
+      keyToIndex,
+      lastTouchBeforeActivation,
+      stableOnDragEnd,
+      touchPosition,
+      updateLayer
     ]
-  );
-
-  const handleTouchesMove = useCallback(
-    (e: GestureTouchEvent, onFail: () => void) => {
-      'worklet';
-      if (!startTouch.value || activeItemKey.value === null) {
-        return;
-      }
-
-      const firstTouch = e.allTouches[0];
-      if (!firstTouch) {
-        onFail();
-        return;
-      }
-
-      const dX = firstTouch.absoluteX - startTouch.value.absoluteX;
-      const dY = firstTouch.absoluteY - startTouch.value.absoluteY;
-
-      // Cancel touch if the touch moved too far from the initial position
-      // before the item activation animation starts
-      const r = Math.sqrt(dX * dX + dY * dY);
-      if (
-        // activeItemKeyis set after the drag activation delay passes
-        // and we don't want to cancel the touch anymore after this time
-        activeItemKey.value === null &&
-        r >= dragActivationFailOffset.value
-      ) {
-        onFail();
-        return;
-      }
-
-      touchTranslation.value = { x: dX, y: dY };
-    },
-    [startTouch, touchTranslation, activeItemKey, dragActivationFailOffset]
   );
 
   const handleOrderChange = useCallback(
@@ -420,6 +442,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
     value: {
       dropAnimationDuration,
       handleDragEnd,
+      handleDragStart,
       handleOrderChange,
       handleTouchStart,
       handleTouchesMove

--- a/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.tsx
@@ -39,10 +39,10 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
     containerHeight,
     containerRef,
     containerWidth,
+    customHandle,
     itemDimensions,
-    touchedItemHeight,
-    touchedItemKey,
-    touchedItemWidth
+    touchedHandleDimensions,
+    touchedItemKey
   } = useCommonValuesContext();
 
   const measuredItemsCount = useSharedValue(0);
@@ -73,9 +73,8 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
       }
 
       itemDimensions.value[key] = dimensions;
-      if (touchedItemKey.value === key) {
-        touchedItemWidth.value = dimensions.width;
-        touchedItemHeight.value = dimensions.height;
+      if (!customHandle && touchedItemKey.value === key) {
+        touchedHandleDimensions.value = dimensions;
       }
 
       // Update the array of item dimensions only after all items have been
@@ -107,14 +106,17 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
     measuredItemsCount.value = Math.max(0, measuredItemsCount.value - 1);
   });
 
-  const updateTouchedItemDimensions = useCallback(
+  /**
+   * Updates the dimensions of the handle that is currently being touched
+   * (only if there is no custom handle and the entire item is treated as a handle)
+   */
+  const maybeUpdateTouchedHandleDimensions = useCallback(
     (key: string) => {
       'worklet';
       const dimensions = itemDimensions.value[key] ?? null;
-      touchedItemWidth.value = dimensions?.width ?? -1;
-      touchedItemHeight.value = dimensions?.height ?? -1;
+      touchedHandleDimensions.value = dimensions;
     },
-    [itemDimensions, touchedItemHeight, touchedItemWidth]
+    [itemDimensions, touchedHandleDimensions]
   );
 
   const checkMeasuredHeight = useCallback(
@@ -172,8 +174,8 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
     value: {
       handleItemMeasurement,
       handleItemRemoval,
-      tryMeasureContainerHeight,
-      updateTouchedItemDimensions
+      maybeUpdateTouchedHandleDimensions,
+      tryMeasureContainerHeight
     }
   };
 });

--- a/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.tsx
@@ -35,14 +35,14 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
   itemsCount
 }) => {
   const {
+    activeItemKey,
     canSwitchToAbsoluteLayout,
     containerHeight,
     containerRef,
     containerWidth,
     customHandle,
     itemDimensions,
-    touchedHandleDimensions,
-    touchedItemKey
+    snapItemDimensions
   } = useCommonValuesContext();
 
   const measuredItemsCount = useSharedValue(0);
@@ -73,8 +73,8 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
       }
 
       itemDimensions.value[key] = dimensions;
-      if (!customHandle && touchedItemKey.value === key) {
-        touchedHandleDimensions.value = dimensions;
+      if (!customHandle && activeItemKey.value === key) {
+        snapItemDimensions.value = dimensions;
       }
 
       // Update the array of item dimensions only after all items have been
@@ -110,13 +110,13 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
    * Updates the dimensions of the handle that is currently being touched
    * (only if there is no custom handle and the entire item is treated as a handle)
    */
-  const maybeUpdateTouchedHandleDimensions = useCallback(
+  const maybeUpdateSnapDimensions = useCallback(
     (key: string) => {
       'worklet';
       const dimensions = itemDimensions.value[key] ?? null;
-      touchedHandleDimensions.value = dimensions;
+      snapItemDimensions.value = dimensions;
     },
-    [itemDimensions, touchedHandleDimensions]
+    [itemDimensions, snapItemDimensions]
   );
 
   const checkMeasuredHeight = useCallback(
@@ -174,7 +174,7 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
     value: {
       handleItemMeasurement,
       handleItemRemoval,
-      maybeUpdateTouchedHandleDimensions,
+      maybeUpdateSnapDimensions,
       tryMeasureContainerHeight
     }
   };

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
@@ -39,8 +39,7 @@ export default function useItemLayoutStyles(
     activeItemPosition,
     canSwitchToAbsoluteLayout,
     dropAnimationDuration,
-    itemPositions,
-    shouldAnimateLayout
+    itemPositions
   } = useCommonValuesContext();
 
   const zIndex = useItemZIndex(key, pressProgress);
@@ -179,19 +178,9 @@ export default function useItemLayoutStyles(
       return EMPTY_OBJECT;
     }
 
-    const x = layoutX.value;
-    const y = layoutY.value;
-    let left = x;
-    let top = y;
-
-    if (shouldAnimateLayout.value) {
-      left = x !== null ? withTiming(x) : x;
-      top = y !== null ? withTiming(y) : y;
-    }
-
     return {
-      left,
-      top
+      left: layoutX.value,
+      top: layoutY.value
     };
   });
 

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
@@ -35,12 +35,12 @@ export default function useItemLayoutStyles(
   pressProgress: SharedValue<number>
 ): StyleProp<AnimatedStyle<ViewStyle>> {
   const {
+    activeItemKey,
+    activeItemPosition,
     canSwitchToAbsoluteLayout,
     dropAnimationDuration,
     itemPositions,
-    shouldAnimateLayout,
-    touchedItemKey,
-    touchedItemPosition
+    shouldAnimateLayout
   } = useCommonValuesContext();
 
   const zIndex = useItemZIndex(key, pressProgress);
@@ -106,16 +106,14 @@ export default function useItemLayoutStyles(
 
   useAnimatedReaction(
     () => {
-      const isTouched = touchedItemKey.value === key;
+      const isActive = activeItemKey.value === key;
       return {
         hasProgress: hasPressProgress.value,
-        isTouched,
-        position: isTouched
-          ? touchedItemPosition.value
-          : itemPositions.value[key]
+        isActive,
+        position: isActive ? activeItemPosition.value : itemPositions.value[key]
       };
     },
-    ({ hasProgress, isTouched, position }) => {
+    ({ hasProgress, isActive, position }) => {
       if (!position) {
         return;
       }
@@ -124,7 +122,7 @@ export default function useItemLayoutStyles(
       const newY = position.y - (layoutY.value ?? 0);
 
       if (
-        isTouched ||
+        isActive ||
         ((layoutX.value === null || layoutY.value === null) && !hasProgress)
       ) {
         // Apply the translation immediately if the item is being dragged or

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.web.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.web.ts
@@ -34,11 +34,11 @@ export default function useItemLayoutStyles(
   pressProgress: SharedValue<number>
 ): StyleProp<AnimatedStyle<ViewStyle>> {
   const {
+    activeItemKey,
+    activeItemPosition,
     canSwitchToAbsoluteLayout,
     dropAnimationDuration,
-    itemPositions,
-    touchedItemKey,
-    touchedItemPosition
+    itemPositions
   } = useCommonValuesContext();
 
   const zIndex = useItemZIndex(key, pressProgress);
@@ -49,21 +49,19 @@ export default function useItemLayoutStyles(
 
   useAnimatedReaction(
     () => {
-      const isTouched = touchedItemKey.value === key;
+      const isActive = activeItemKey.value === key;
       return {
         hasProgress: hasPressProgress.value,
-        isTouched,
-        position: isTouched
-          ? touchedItemPosition.value
-          : itemPositions.value[key]
+        isActive,
+        position: isActive ? activeItemPosition.value : itemPositions.value[key]
       };
     },
-    ({ hasProgress, isTouched, position }) => {
+    ({ hasProgress, isActive, position }) => {
       if (!position) {
         return;
       }
 
-      if (isTouched || translateX.value === null || translateY.value === null) {
+      if (isActive || translateX.value === null || translateY.value === null) {
         translateX.value = position.x;
         translateY.value = position.y;
       } else if (hasProgress) {

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.web.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.web.ts
@@ -1,9 +1,9 @@
+/* eslint-disable import/no-unused-modules */
 import type { StyleProp, ViewStyle } from 'react-native';
 import type { AnimatedStyle, SharedValue } from 'react-native-reanimated';
 import {
   useAnimatedReaction,
   useAnimatedStyle,
-  useDerivedValue,
   useSharedValue,
   withTiming
 } from 'react-native-reanimated';
@@ -38,11 +38,11 @@ export default function useItemLayoutStyles(
     activeItemPosition,
     canSwitchToAbsoluteLayout,
     dropAnimationDuration,
-    itemPositions
+    itemPositions,
+    shouldAnimateLayout
   } = useCommonValuesContext();
 
   const zIndex = useItemZIndex(key, pressProgress);
-  const hasPressProgress = useDerivedValue(() => pressProgress.value > 0);
 
   const translateX = useSharedValue<null | number>(null);
   const translateY = useSharedValue<null | number>(null);
@@ -51,20 +51,24 @@ export default function useItemLayoutStyles(
     () => {
       const isActive = activeItemKey.value === key;
       return {
-        hasProgress: hasPressProgress.value,
         isActive,
         position: isActive ? activeItemPosition.value : itemPositions.value[key]
       };
     },
-    ({ hasProgress, isActive, position }) => {
+    ({ isActive, position }) => {
       if (!position) {
         return;
       }
 
-      if (isActive || translateX.value === null || translateY.value === null) {
+      if (
+        isActive ||
+        translateX.value === null ||
+        translateY.value === null ||
+        !shouldAnimateLayout.value
+      ) {
         translateX.value = position.x;
         translateY.value = position.y;
-      } else if (hasProgress) {
+      } else {
         translateX.value = withTiming(position.x, {
           duration: dropAnimationDuration.value
         });

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
+import type { View } from 'react-native';
 import { Gesture } from 'react-native-gesture-handler';
-import { type SharedValue } from 'react-native-reanimated';
+import type { AnimatedRef, SharedValue } from 'react-native-reanimated';
 
 import { useAutoScrollContext } from '../AutoScrollProvider';
 import { useCommonValuesContext } from '../CommonValuesProvider';
@@ -8,7 +9,8 @@ import { useDragContext } from '../DragProvider';
 
 export default function useItemPanGesture(
   key: string,
-  pressProgress: SharedValue<number>
+  pressProgress: SharedValue<number>,
+  handleRef?: AnimatedRef<View>
 ) {
   const { activeItemKey, sortEnabled } = useCommonValuesContext();
   const { handleDragEnd, handleTouchStart, handleTouchesMove } =
@@ -31,16 +33,23 @@ export default function useItemPanGesture(
             manager.fail();
             return;
           }
-          handleTouchStart(e, key, pressProgress, manager.activate);
+          handleTouchStart(
+            e,
+            key,
+            pressProgress,
+            manager.activate,
+            manager.fail,
+            handleRef
+          );
+        })
+        .onTouchesMove((e, manager) => {
+          handleTouchesMove(e, manager.fail, handleRef);
         })
         .onTouchesCancelled((_, manager) => {
           manager.fail();
         })
         .onTouchesUp((_, manager) => {
           manager.end();
-        })
-        .onTouchesMove((e, manager) => {
-          handleTouchesMove(e, manager.fail);
         })
         .onFinalize(() => {
           updateStartScrollOffset?.(-1);
@@ -50,9 +59,10 @@ export default function useItemPanGesture(
       key,
       pressProgress,
       activeItemKey,
+      handleDragEnd,
+      handleRef,
       handleTouchStart,
       handleTouchesMove,
-      handleDragEnd,
       updateStartScrollOffset,
       sortEnabled
     ]

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
@@ -10,7 +10,7 @@ export default function useItemPanGesture(
   key: string,
   pressProgress: SharedValue<number>
 ) {
-  const { sortEnabled, touchedItemKey } = useCommonValuesContext();
+  const { activeItemKey, sortEnabled } = useCommonValuesContext();
   const { handleDragEnd, handleTouchStart, handleTouchesMove } =
     useDragContext();
   const { updateStartScrollOffset } = useAutoScrollContext() ?? {};
@@ -24,7 +24,7 @@ export default function useItemPanGesture(
           // if the current item is still animated to the drag end position
           // or sorting is disabled at all
           if (
-            touchedItemKey.value !== null ||
+            activeItemKey.value !== null ||
             pressProgress.value > 0 ||
             !sortEnabled.value
           ) {
@@ -49,7 +49,7 @@ export default function useItemPanGesture(
     [
       key,
       pressProgress,
-      touchedItemKey,
+      activeItemKey,
       handleTouchStart,
       handleTouchesMove,
       handleDragEnd,

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
-import type { View } from 'react-native';
 import { Gesture } from 'react-native-gesture-handler';
-import type { AnimatedRef, SharedValue } from 'react-native-reanimated';
+import type { SharedValue } from 'react-native-reanimated';
 
 import { useAutoScrollContext } from '../AutoScrollProvider';
 import { useCommonValuesContext } from '../CommonValuesProvider';
@@ -9,8 +8,7 @@ import { useDragContext } from '../DragProvider';
 
 export default function useItemPanGesture(
   key: string,
-  pressProgress: SharedValue<number>,
-  handleRef?: AnimatedRef<View>
+  pressProgress: SharedValue<number>
 ) {
   const { activeItemKey, sortEnabled } = useCommonValuesContext();
   const { handleDragEnd, handleTouchStart, handleTouchesMove } =
@@ -38,12 +36,11 @@ export default function useItemPanGesture(
             key,
             pressProgress,
             manager.activate,
-            manager.fail,
-            handleRef
+            manager.fail
           );
         })
         .onTouchesMove((e, manager) => {
-          handleTouchesMove(e, manager.fail, handleRef);
+          handleTouchesMove(e, manager.fail);
         })
         .onTouchesCancelled((_, manager) => {
           manager.fail();
@@ -60,7 +57,6 @@ export default function useItemPanGesture(
       pressProgress,
       activeItemKey,
       handleDragEnd,
-      handleRef,
       handleTouchStart,
       handleTouchesMove,
       updateStartScrollOffset,

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemZIndex.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemZIndex.ts
@@ -7,13 +7,13 @@ export default function useItemZIndex(
   key: string,
   pressProgress: SharedValue<number>
 ): SharedValue<number> {
-  const { prevTouchedItemKey, touchedItemKey } = useCommonValuesContext();
+  const { activeItemKey, prevActiveItemKey } = useCommonValuesContext();
 
   return useDerivedValue<number>(() => {
-    if (touchedItemKey.value === key) {
+    if (activeItemKey.value === key) {
       return 3;
     }
-    if (prevTouchedItemKey.value === key) {
+    if (prevActiveItemKey.value === key) {
       return 2;
     }
     if (pressProgress.value > 0) {

--- a/packages/react-native-sortables/src/providers/shared/utils.ts
+++ b/packages/react-native-sortables/src/providers/shared/utils.ts
@@ -1,4 +1,9 @@
+import type { View } from 'react-native';
+import type { TouchData } from 'react-native-gesture-handler';
+import { type AnimatedRef, measure } from 'react-native-reanimated';
+
 import { EXTRA_SWAP_OFFSET } from '../../constants';
+import type { Vector } from '../../types';
 
 export const getAdditionalSwapOffset = (gap: number, size: number) => {
   'worklet';
@@ -6,4 +11,21 @@ export const getAdditionalSwapOffset = (gap: number, size: number) => {
     EXTRA_SWAP_OFFSET,
     Math.min(gap / 2 + EXTRA_SWAP_OFFSET, (gap + size) / 2)
   );
+};
+
+export const getTouchPositionInContainer = (
+  touch: TouchData,
+  relativeRef: AnimatedRef<View>
+): Vector | null => {
+  'worklet';
+
+  const measurements = measure(relativeRef);
+  if (!measurements) {
+    return null;
+  }
+
+  return {
+    x: touch.absoluteX - measurements.pageX,
+    y: touch.absoluteY - measurements.pageY
+  };
 };

--- a/packages/react-native-sortables/src/types/props/shared.ts
+++ b/packages/react-native-sortables/src/types/props/shared.ts
@@ -94,6 +94,7 @@ export type SharedProps = Simplify<
     animateHeight?: boolean;
     hapticsEnabled?: boolean;
     sortEnabled?: Animatable<boolean>;
+    customHandle?: boolean;
     debug?: boolean;
   } & Omit<SortableCallbacks, 'onDragEnd'> &
     Partial<ActiveItemDecorationSettings> &

--- a/packages/react-native-sortables/src/types/props/shared.ts
+++ b/packages/react-native-sortables/src/types/props/shared.ts
@@ -7,8 +7,8 @@ import type { LayoutAnimation } from '../reanimated';
 import type { Animatable, AnimatableProps, Simplify } from '../utils';
 
 export type DropIndicatorComponentProps = {
-  activationProgress: SharedValue<number>;
-  touchedItemKey: SharedValue<null | string>;
+  activeAnimationProgress: SharedValue<number>;
+  activeItemKey: SharedValue<null | string>;
   dropIndex: SharedValue<number>;
   dropPosition: SharedValue<Vector>;
   orderedItemKeys: SharedValue<Array<string>>;
@@ -27,8 +27,8 @@ export type Offset = `${number}%` | number;
 
 export type ItemActivationSettings = AnimatableProps<{
   dragActivationDelay: number;
-  dragActivationDuration: number;
   dragActivationFailOffset: number;
+  activeAnimationDuration: number;
   dropAnimationDuration: number;
 }>;
 

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -33,6 +33,7 @@ export type CommonValuesContextType = {
   itemPositions: SharedValue<Record<string, Vector>>;
   touchPosition: SharedValue<Vector | null>;
   activeItemPosition: SharedValue<Vector | null>;
+  snapItemOffset: SharedValue<Vector | null>;
 
   // DIMENSIONS
   containerWidth: SharedValue<number>;
@@ -84,14 +85,9 @@ export type DragContextType = {
     key: string,
     pressProgress: SharedValue<number>,
     activate: () => void,
-    fail: () => void,
-    handleRef?: AnimatedRef<View>
+    fail: () => void
   ) => void;
-  handleTouchesMove: (
-    e: GestureTouchEvent,
-    fail: () => void,
-    handleRef?: AnimatedRef<View>
-  ) => void;
+  handleTouchesMove: (e: GestureTouchEvent, fail: () => void) => void;
   handleDragEnd: (key: string, pressProgress: SharedValue<number>) => void;
   handleOrderChange: (
     key: string,

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -38,8 +38,7 @@ export type CommonValuesContextType = {
   // DIMENSIONS
   containerWidth: SharedValue<number>;
   containerHeight: SharedValue<number>;
-  touchedItemWidth: SharedValue<number>;
-  touchedItemHeight: SharedValue<number>;
+  touchedHandleDimensions: SharedValue<Dimensions | null>;
   itemDimensions: SharedValue<Record<string, Dimensions>>;
   itemsStyleOverride: SharedValue<Maybe<ViewStyle>>;
 
@@ -57,6 +56,7 @@ export type CommonValuesContextType = {
   sortEnabled: SharedValue<boolean>;
   canSwitchToAbsoluteLayout: SharedValue<boolean>;
   shouldAnimateLayout: SharedValue<boolean>; // used only on web
+  customHandle: boolean;
 } & AnimatedValues<ActiveItemDecorationSettings> &
   AnimatedValues<ActiveItemSnapSettings> &
   AnimatedValues<ItemActivationSettings>;
@@ -67,7 +67,7 @@ export type MeasurementsContextType = {
   handleItemMeasurement: (key: string, dimensions: Dimensions) => void;
   handleItemRemoval: (key: string) => void;
   tryMeasureContainerHeight: () => void;
-  updateTouchedItemDimensions: (key: string) => void;
+  maybeUpdateTouchedHandleDimensions: (key: string) => void;
 };
 
 // AUTO SCROLL
@@ -100,6 +100,7 @@ export type DragContextType = {
 // ITEM
 
 export type ItemContextType = {
+  itemKey: string;
   pressProgress: Readonly<SharedValue<number>>;
   isBeingActivated: Readonly<SharedValue<boolean>>;
   dragActivationState: Readonly<SharedValue<DragActivationState>>;

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -33,21 +33,20 @@ export type CommonValuesContextType = {
   // POSITIONS
   itemPositions: SharedValue<Record<string, Vector>>;
   touchPosition: SharedValue<Vector | null>;
-  touchedItemPosition: SharedValue<Vector | null>;
+  activeItemPosition: SharedValue<Vector | null>;
 
   // DIMENSIONS
   containerWidth: SharedValue<number>;
   containerHeight: SharedValue<number>;
-  touchedHandleDimensions: SharedValue<Dimensions | null>;
+  snapItemDimensions: SharedValue<Dimensions | null>;
   itemDimensions: SharedValue<Record<string, Dimensions>>;
   itemsStyleOverride: SharedValue<Maybe<ViewStyle>>;
 
   // DRAG STATE
-  touchedItemKey: SharedValue<null | string>;
-  prevTouchedItemKey: SharedValue<null | string>;
+  prevActiveItemKey: SharedValue<null | string>;
   activeItemKey: SharedValue<null | string>;
   activationState: SharedValue<DragActivationState>;
-  activationProgress: SharedValue<number>;
+  activeAnimationProgress: SharedValue<number>;
   inactiveAnimationProgress: SharedValue<number>;
   activeItemDropped: SharedValue<boolean>;
 
@@ -67,7 +66,7 @@ export type MeasurementsContextType = {
   handleItemMeasurement: (key: string, dimensions: Dimensions) => void;
   handleItemRemoval: (key: string) => void;
   tryMeasureContainerHeight: () => void;
-  maybeUpdateTouchedHandleDimensions: (key: string) => void;
+  maybeUpdateSnapDimensions: (key: string) => void;
 };
 
 // AUTO SCROLL

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -1,7 +1,6 @@
-import type { ViewStyle } from 'react-native';
+import type { View, ViewStyle } from 'react-native';
 import type { GestureTouchEvent } from 'react-native-gesture-handler';
 import type { AnimatedRef, SharedValue } from 'react-native-reanimated';
-import type Animated from 'react-native-reanimated';
 
 import type {
   DebugCrossUpdater,
@@ -51,7 +50,7 @@ export type CommonValuesContextType = {
   activeItemDropped: SharedValue<boolean>;
 
   // OTHER
-  containerRef: AnimatedRef<Animated.View>;
+  containerRef: AnimatedRef<View>;
   sortEnabled: SharedValue<boolean>;
   canSwitchToAbsoluteLayout: SharedValue<boolean>;
   shouldAnimateLayout: SharedValue<boolean>; // used only on web
@@ -84,9 +83,15 @@ export type DragContextType = {
     e: GestureTouchEvent,
     key: string,
     pressProgress: SharedValue<number>,
-    onActivate: () => void
+    activate: () => void,
+    fail: () => void,
+    handleRef?: AnimatedRef<View>
   ) => void;
-  handleTouchesMove: (e: GestureTouchEvent, onFail: () => void) => void;
+  handleTouchesMove: (
+    e: GestureTouchEvent,
+    fail: () => void,
+    handleRef?: AnimatedRef<View>
+  ) => void;
   handleDragEnd: (key: string, pressProgress: SharedValue<number>) => void;
   handleOrderChange: (
     key: string,

--- a/packages/react-native-sortables/src/types/state.ts
+++ b/packages/react-native-sortables/src/types/state.ts
@@ -1,5 +1,4 @@
 export enum DragActivationState {
-  ACTIVATING = 'ACTIVATING',
   ACTIVE = 'ACTIVE',
   INACTIVE = 'INACTIVE',
   TOUCHED = 'TOUCHED'


### PR DESCRIPTION
## Description

This PR:
- adds a possibility to use a custom drag handle component instead of making the entire item draggable,
- improves item activation animation and delay before dragging starts - after changes, drag gesture can no longer be cancelled after the drag activation has started (it was misleading before as dragging could be cancelled after the item grew up),
- fixes items reordering issue after merging changes from the #247 PR

Important notes:
- when custom drag handle is used, [item snapping](https://react-native-sortables-docs.vercel.app/grid/examples/item-snap) is relative to the drag handle, not the entire item (this is much more natural behavior)

## Changes showcase

For now, the item can be dragged around, which looks weird. I will add a possibility to disable dragged item overflow, which will result in vertical drag direction without a possibility to drag the item horizontally.

| Web | Mobile |
|-|-|
| <video src="https://github.com/user-attachments/assets/ae3417d6-2e03-4fbe-98b5-28bb34b890d2" /> | <video src="https://github.com/user-attachments/assets/74c98fee-a113-4544-80fb-7112ec7a87fb" /> |
