### PR TITLE
feat: Possibility to disable container overflow by the dragged item

### DIFF
--- a/example/app/src/examples/SortableGrid/DragHandleExample.tsx
+++ b/example/app/src/examples/SortableGrid/DragHandleExample.tsx
@@ -51,6 +51,7 @@ export default function DragHandleExample() {
           columnGap={10}
           columns={columns}
           data={DATA}
+          allowOverDrag={false}
           dragActivationDelay={0}
           renderItem={renderItem}
           rowGap={10}

--- a/example/app/src/examples/SortableGrid/DragHandleExample.tsx
+++ b/example/app/src/examples/SortableGrid/DragHandleExample.tsx
@@ -48,10 +48,10 @@ export default function DragHandleExample() {
         style={flex.fill}>
         <Sortable.Grid
           activeItemScale={1}
+          allowOverDrag={false}
           columnGap={10}
           columns={columns}
           data={DATA}
-          allowOverDrag={false}
           dragActivationDelay={0}
           renderItem={renderItem}
           rowGap={10}

--- a/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
@@ -40,7 +40,9 @@ export default function SortableContainer({
     }
     return {
       height:
-        animateHeight && (!IS_WEB || shouldAnimateLayout.value)
+        animateHeight &&
+        (!IS_WEB || shouldAnimateLayout.value) &&
+        containerHeight.value !== null
           ? withTiming(containerHeight.value)
           : containerHeight.value,
       overflow:

--- a/packages/react-native-sortables/src/constants/props.ts
+++ b/packages/react-native-sortables/src/constants/props.ts
@@ -33,6 +33,7 @@ export const DEFAULT_SHARED_PROPS = {
   activeItemOpacity: 1,
   activeItemScale: 1.1,
   activeItemShadowOpacity: 0.2,
+  allowOverDrag: true,
   animateHeight: false,
   autoScrollActivationOffset: 75,
   autoScrollEnabled: true,

--- a/packages/react-native-sortables/src/providers/SharedProvider.tsx
+++ b/packages/react-native-sortables/src/providers/SharedProvider.tsx
@@ -10,7 +10,7 @@ import type {
   ActiveItemSnapSettings,
   Animatable,
   AutoScrollSettings,
-  ItemActivationSettings,
+  ItemDragSettings,
   PartialBy,
   SortableCallbacks
 } from '../types';
@@ -35,11 +35,12 @@ type SharedProviderProps = PropsWithChildren<
   } & ActiveItemDecorationSettings &
     ActiveItemSnapSettings &
     PartialBy<AutoScrollSettings, 'scrollableRef'> &
-    Required<ItemActivationSettings> &
+    Required<ItemDragSettings> &
     Required<SortableCallbacks>
 >;
 
 export default function SharedProvider({
+  allowOverDrag,
   autoScrollActivationOffset,
   autoScrollEnabled,
   autoScrollSpeed,
@@ -77,6 +78,7 @@ export default function SharedProvider({
     ),
     // Provider used for dragging and item swapping logic
     <DragProvider
+      allowOverDrag={allowOverDrag}
       hapticsEnabled={hapticsEnabled}
       onDragEnd={onDragEnd}
       onDragStart={onDragStart}

--- a/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
@@ -80,7 +80,7 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
     return {
       maxHeight: maxH,
       minHeight: maxHeight ? Math.min(minH, maxH) : minH,
-      width: containerWidth.value
+      width: containerWidth.value ?? 0
     };
   });
 

--- a/packages/react-native-sortables/src/providers/layout/flex/utils/layout.ts
+++ b/packages/react-native-sortables/src/providers/layout/flex/utils/layout.ts
@@ -321,7 +321,7 @@ export const calculateLayout = ({
   paddings
 }: FlexLayoutProps): FlexLayout | null => {
   'worklet';
-  if (limits.width === -1) {
+  if (limits.width === 0) {
     return null;
   }
 

--- a/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
@@ -114,7 +114,7 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
       width: containerWidth.value
     }),
     ({ gap, width }) => {
-      if (width === -1) {
+      if (width === null) {
         return;
       }
       const colWidth = (width + gap) / columns - gap;

--- a/packages/react-native-sortables/src/providers/layout/grid/updates/common.ts
+++ b/packages/react-native-sortables/src/providers/layout/grid/updates/common.ts
@@ -29,7 +29,11 @@ export const createGridStrategy =
 
     return ({ activeIndex, position: { x, y } }) => {
       'worklet';
-      if (!othersLayout.value) {
+      if (
+        !othersLayout.value ||
+        containerHeight.value === null ||
+        containerWidth.value === null
+      ) {
         return;
       }
       const { rowOffsets } = othersLayout.value;

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
@@ -13,7 +13,7 @@ import type {
   Animatable,
   CommonValuesContextType,
   Dimensions,
-  ItemActivationSettings,
+  ItemDragSettings,
   Maybe,
   Vector
 } from '../../types';
@@ -29,7 +29,7 @@ type CommonValuesProviderProps = PropsWithChildren<
     initialItemsStyleOverride?: ViewStyle;
   } & ActiveItemDecorationSettings &
     ActiveItemSnapSettings &
-    ItemActivationSettings
+    Omit<ItemDragSettings, 'allowOverDrag'>
 >;
 
 const { CommonValuesProvider, useCommonValuesContext } = createProvider(
@@ -67,8 +67,9 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
   const snapItemOffset = useSharedValue<Vector | null>(null);
 
   // DIMENSIONS
-  const containerWidth = useSharedValue(-1);
-  const containerHeight = useSharedValue(-1);
+  const containerWidth = useSharedValue<null | number>(null);
+  const containerHeight = useSharedValue<null | number>(null);
+  const activeItemDimensions = useSharedValue<Dimensions | null>(null);
   const snapItemDimensions = useSharedValue<Dimensions | null>(null);
   const itemDimensions = useSharedValue<Record<string, Dimensions>>({});
   const itemsStyleOverride = useSharedValue<Maybe<ViewStyle>>(
@@ -121,6 +122,7 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
       activationState,
       activeAnimationDuration,
       activeAnimationProgress,
+      activeItemDimensions,
       activeItemDropped,
       activeItemKey,
       activeItemOpacity,

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
@@ -73,6 +73,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
     snapItemOffset,
     snapOffsetX,
     snapOffsetY,
+    sortEnabled,
     touchPosition
   } = useCommonValuesContext();
   const { maybeUpdateSnapDimensions, tryMeasureContainerHeight } =
@@ -293,7 +294,15 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
     ) => {
       'worklet';
       const touch = e.allTouches[0];
-      if (!touch) {
+      if (
+        !touch ||
+        // Ignore touch if another item is already being touched/activated
+        // if the current item is still animated to the drag end position
+        // or sorting is disabled at all
+        !sortEnabled.value ||
+        pressProgress.value > 0 ||
+        activeItemKey.value !== null
+      ) {
         fail();
         return;
       }
@@ -315,11 +324,13 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       }, dragActivationDelay.value);
     },
     [
+      activeItemKey,
       activationState,
       activationTimeoutId,
       canSwitchToAbsoluteLayout,
       dragActivationDelay,
       handleDragStart,
+      sortEnabled,
       tryMeasureContainerHeight,
       touchStartTouch
     ]

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
@@ -192,7 +192,8 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
         x: activeX,
         y: activeY
       };
-    }
+    },
+    [allowOverDrag]
   );
 
   /**

--- a/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.tsx
@@ -35,6 +35,7 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
   itemsCount
 }) => {
   const {
+    activeItemDimensions,
     activeItemKey,
     canSwitchToAbsoluteLayout,
     containerHeight,
@@ -73,8 +74,11 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
       }
 
       itemDimensions.value[key] = dimensions;
-      if (!customHandle && activeItemKey.value === key) {
-        snapItemDimensions.value = dimensions;
+      if (activeItemKey.value === key) {
+        activeItemDimensions.value = dimensions;
+        if (!customHandle) {
+          snapItemDimensions.value = dimensions;
+        }
       }
 
       // Update the array of item dimensions only after all items have been
@@ -123,7 +127,7 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
     (measuredHeight: number) => {
       'worklet';
       if (
-        containerHeight.value !== -1 &&
+        containerHeight.value !== null &&
         Math.abs(measuredHeight - containerHeight.value) < OFFSET_EPS
       ) {
         containerHeightApplied.value = true;

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
@@ -2,14 +2,12 @@ import { useMemo } from 'react';
 import { Gesture } from 'react-native-gesture-handler';
 import type { SharedValue } from 'react-native-reanimated';
 
-import { useCommonValuesContext } from '../CommonValuesProvider';
 import { useDragContext } from '../DragProvider';
 
 export default function useItemPanGesture(
   key: string,
   pressProgress: SharedValue<number>
 ) {
-  const { activeItemKey, sortEnabled } = useCommonValuesContext();
   const { handleDragEnd, handleTouchStart, handleTouchesMove } =
     useDragContext();
 
@@ -18,17 +16,6 @@ export default function useItemPanGesture(
       Gesture.Manual()
         .manualActivation(true)
         .onTouchesDown((e, manager) => {
-          // Ignore touch if another item is already being touched/activated
-          // if the current item is still animated to the drag end position
-          // or sorting is disabled at all
-          if (
-            activeItemKey.value !== null ||
-            pressProgress.value > 0 ||
-            !sortEnabled.value
-          ) {
-            manager.fail();
-            return;
-          }
           handleTouchStart(
             e,
             key,
@@ -49,14 +36,6 @@ export default function useItemPanGesture(
         .onFinalize(() => {
           handleDragEnd(key, pressProgress);
         }),
-    [
-      key,
-      pressProgress,
-      activeItemKey,
-      handleDragEnd,
-      handleTouchStart,
-      handleTouchesMove,
-      sortEnabled
-    ]
+    [key, pressProgress, handleDragEnd, handleTouchStart, handleTouchesMove]
   );
 }

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 import { Gesture } from 'react-native-gesture-handler';
 import type { SharedValue } from 'react-native-reanimated';
 
-import { useAutoScrollContext } from '../AutoScrollProvider';
 import { useCommonValuesContext } from '../CommonValuesProvider';
 import { useDragContext } from '../DragProvider';
 
@@ -13,7 +12,6 @@ export default function useItemPanGesture(
   const { activeItemKey, sortEnabled } = useCommonValuesContext();
   const { handleDragEnd, handleTouchStart, handleTouchesMove } =
     useDragContext();
-  const { updateStartScrollOffset } = useAutoScrollContext() ?? {};
 
   return useMemo(
     () =>
@@ -49,7 +47,6 @@ export default function useItemPanGesture(
           manager.end();
         })
         .onFinalize(() => {
-          updateStartScrollOffset?.(-1);
           handleDragEnd(key, pressProgress);
         }),
     [
@@ -59,7 +56,6 @@ export default function useItemPanGesture(
       handleDragEnd,
       handleTouchStart,
       handleTouchesMove,
-      updateStartScrollOffset,
       sortEnabled
     ]
   );

--- a/packages/react-native-sortables/src/providers/shared/hooks/useOrderUpdater.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useOrderUpdater.ts
@@ -5,21 +5,18 @@ import { useCommonValuesContext } from '../CommonValuesProvider';
 import { useDragContext } from '../DragProvider';
 
 export default function useOrderUpdater(updater: OrderUpdater) {
-  const { activeItemKey, itemDimensions, keyToIndex, touchPosition } =
+  const { activeItemDimensions, activeItemKey, keyToIndex, touchPosition } =
     useCommonValuesContext();
   const { handleOrderChange } = useDragContext();
 
   useAnimatedReaction(
     () => ({
       activeKey: activeItemKey.value,
+      dimensions: activeItemDimensions.value,
       position: touchPosition.value
     }),
-    ({ activeKey, position }) => {
-      if (!activeKey || !position) {
-        return;
-      }
-      const dimensions = itemDimensions.value[activeKey];
-      if (!dimensions) {
+    ({ activeKey, dimensions, position }) => {
+      if (!activeKey || !dimensions || !position) {
         return;
       }
       const activeIndex = keyToIndex.value[activeKey];

--- a/packages/react-native-sortables/src/types/props/shared.ts
+++ b/packages/react-native-sortables/src/types/props/shared.ts
@@ -25,7 +25,9 @@ export type ActiveItemDecorationSettings = AnimatableProps<{
 
 export type Offset = `${number}%` | number;
 
-export type ItemActivationSettings = AnimatableProps<{
+export type ItemDragSettings = {
+  allowOverDrag: boolean;
+} & AnimatableProps<{
   dragActivationDelay: number;
   dragActivationFailOffset: number;
   activeAnimationDuration: number;
@@ -101,6 +103,6 @@ export type SharedProps = Simplify<
     Partial<ActiveItemSnapSettings> &
     Partial<AutoScrollSettings> &
     Partial<DropIndicatorSettings> &
-    Partial<ItemActivationSettings> &
+    Partial<ItemDragSettings> &
     Partial<ItemLayoutAnimationSettings>
 >;

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -12,7 +12,7 @@ import type { Dimensions, Vector } from '../layout/shared';
 import type {
   ActiveItemDecorationSettings,
   ActiveItemSnapSettings,
-  ItemActivationSettings
+  ItemDragSettings
 } from '../props/shared';
 import type { DragActivationState } from '../state';
 import type { AnimatedValues, AnyRecord, Maybe } from '../utils';
@@ -36,9 +36,10 @@ export type CommonValuesContextType = {
   snapItemOffset: SharedValue<Vector | null>;
 
   // DIMENSIONS
-  containerWidth: SharedValue<number>;
-  containerHeight: SharedValue<number>;
+  containerWidth: SharedValue<null | number>;
+  containerHeight: SharedValue<null | number>;
   snapItemDimensions: SharedValue<Dimensions | null>;
+  activeItemDimensions: SharedValue<Dimensions | null>;
   itemDimensions: SharedValue<Record<string, Dimensions>>;
   itemsStyleOverride: SharedValue<Maybe<ViewStyle>>;
 
@@ -58,7 +59,7 @@ export type CommonValuesContextType = {
   customHandle: boolean;
 } & AnimatedValues<ActiveItemDecorationSettings> &
   AnimatedValues<ActiveItemSnapSettings> &
-  AnimatedValues<ItemActivationSettings>;
+  AnimatedValues<Omit<ItemDragSettings, 'allowOverDrag'>>;
 
 // MEASUREMENTS
 
@@ -73,8 +74,8 @@ export type MeasurementsContextType = {
 
 export type AutoScrollContextType = {
   scrollOffset: SharedValue<number>;
-  dragStartScrollOffset: SharedValue<number>;
-  updateStartScrollOffset: (providedOffset?: number) => void;
+  dragStartScrollOffset: SharedValue<null | number>;
+  updateStartScrollOffset: (providedOffset?: null | number) => void;
 };
 
 // DRAG

--- a/packages/react-native-sortables/src/utils/reanimated/values.ts
+++ b/packages/react-native-sortables/src/utils/reanimated/values.ts
@@ -1,12 +1,12 @@
 import { type SharedValue } from 'react-native-reanimated';
 
 export function maybeUpdateValue(
-  target: SharedValue<number>,
+  target: SharedValue<null | number>,
   value: number,
   eps = 0.01
 ): void {
   'worklet';
-  if (Math.abs(target.value - value) > eps) {
+  if (target.value === null || Math.abs(target.value - value) > eps) {
     target.value = value;
   }
 }


### PR DESCRIPTION
## Description

This PR adds a new `allowOverDrag` property that clamps item position in such a way that it moves only within the sortable container and cannot be dragged outside of it.

This is useful e.g. for single-column grids when we want to limit item drag direction only to vertical.

## Example

| Web | Mobile |
|-|-|
| <video src="https://github.com/user-attachments/assets/64c04831-2f65-42f1-9297-6010b610ea60" /> | <video src="https://github.com/user-attachments/assets/21189525-58fe-436b-81bc-fa71af076c45" /> |
