### PR TITLE
fix: Web flex layout and mobile drop animation issues

### DIFF
--- a/example/app/src/examples/SortableFlex/FlexLayoutExample.tsx
+++ b/example/app/src/examples/SortableFlex/FlexLayoutExample.tsx
@@ -81,7 +81,7 @@ export default function FlexLayoutExample() {
   };
 
   return (
-    <Screen>
+    <Screen style={styles.container}>
       <OptionGroup label='alignContent'>
         <Dropdown
           options={ALIGN_CONTENT_OPTIONS}

--- a/example/app/src/examples/SortableFlex/FlexLayoutExample.tsx
+++ b/example/app/src/examples/SortableFlex/FlexLayoutExample.tsx
@@ -15,6 +15,7 @@ import {
   FlexCell,
   Group,
   OptionGroup,
+  Screen,
   SelectListDropdown
 } from '@/components';
 import { colors, flex, radius, sizes, spacing, text } from '@/theme';
@@ -80,7 +81,7 @@ export default function FlexLayoutExample() {
   };
 
   return (
-    <View style={styles.container}>
+    <Screen>
       <OptionGroup label='alignContent'>
         <Dropdown
           options={ALIGN_CONTENT_OPTIONS}
@@ -138,7 +139,7 @@ export default function FlexLayoutExample() {
           ))}
         </ScrollView>
       </Group>
-    </View>
+    </Screen>
   );
 }
 

--- a/packages/react-native-sortables/src/providers/layout/flex/utils/layout.ts
+++ b/packages/react-native-sortables/src/providers/layout/flex/utils/layout.ts
@@ -1,3 +1,4 @@
+import { IS_WEB } from '../../../../constants';
 import type {
   AlignContent,
   AlignItems,
@@ -155,7 +156,7 @@ const handleLayoutCalculation = (
 ) => {
   'worklet';
   const isRow = axisDirections.main === 'row';
-  const isMultiColumn = !isRow && groups.length > 1;
+  const expandMultiColumn = !IS_WEB && !isRow && groups.length > 1; // expands to max height
   const paddingHorizontal = paddings.left + paddings.right;
   const paddingVertical = paddings.top + paddings.bottom;
 
@@ -189,7 +190,7 @@ const handleLayoutCalculation = (
 
   let totalHeight = isRow
     ? contentAlignment.totalSize + paddingVertical
-    : isMultiColumn
+    : expandMultiColumn
       ? limits.maxHeight
       : limits.minHeight;
 
@@ -214,13 +215,13 @@ const handleLayoutCalculation = (
     const contentJustification = calculateAlignment(
       justifyContent,
       mainAxisGroupItemSizes,
-      isMultiColumn ? maxMainContainerSize : minMainContainerSize,
+      expandMultiColumn ? maxMainContainerSize : minMainContainerSize,
       maxMainContainerSize,
       shouldWrap,
       gaps[axisDirections.cross]
     );
 
-    if (!isRow && !isMultiColumn) {
+    if (!isRow && !expandMultiColumn) {
       totalHeight = Math.max(
         totalHeight,
         contentJustification.totalSize + paddingVertical

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
@@ -165,9 +165,6 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
         });
       }
 
-      const translate = (from: number, to: number) =>
-        from === to ? from : interpolate(progress, [0, 1], [from, to]);
-
       let tX = itemTouchOffset.x;
       let tY = itemTouchOffset.y;
 
@@ -179,6 +176,9 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
           (snapOffset?.y ?? 0) +
           getOffsetDistance(offsetY, snapDimensions.height);
       }
+
+      const translate = (from: number, to: number) =>
+        from === to ? from : interpolate(progress, [0, 1], [from, to]);
 
       let activeX = touchPosition.value.x - translate(itemTouchOffset.x, tX);
       let activeY = touchPosition.value.y - translate(itemTouchOffset.y, tY);
@@ -231,9 +231,9 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       activeItemDropped.value = false;
       prevActiveItemKey.value = activeItemKey.value;
       activeItemKey.value = key;
-      dragStartIndex.value = keyToIndex.value[key] ?? -1;
-      activeItemPosition.value = itemPositions.value[key] ?? null;
+      activeItemPosition.value = itemPosition;
       activeItemDimensions.value = itemDimensions.value[key] ?? null;
+      dragStartIndex.value = keyToIndex.value[key] ?? -1;
       activationState.value = DragActivationState.ACTIVE;
 
       updateLayer?.(LayerState.Focused);

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.web.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.web.ts
@@ -89,8 +89,10 @@ export default function useItemLayoutStyles(
     }
 
     return {
+      left: 0,
       opacity: 1,
       position: 'absolute',
+      top: 0,
       transform: [
         { translateX: translateX.value },
         { translateY: translateY.value }


### PR DESCRIPTION
## Description

This PR fixes:
- issues with multi column flex layout on web (when items wrap into multiple columns),
- problem with padding (I had to explicitly set `top`/`left` to 0 for absolute sortable grid items to ignore the container padding used only for the first, `relative` render),
- glitchy animation on the released item that was previously dragged on mobile (glitch happened when reordering animation started for some items after the active item release). Problem was caused by multiple `withTiming` assignments to `translateX` and `translateY`, when one overridden another (cancelling the previous one)