### PR TITLE
feat: Expose layout transition prop

### DIFF
--- a/example/app/src/examples/SortableFlex/DataChangeExample.tsx
+++ b/example/app/src/examples/SortableFlex/DataChangeExample.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import Animated, { useAnimatedRef } from 'react-native-reanimated';
 import Sortable from 'react-native-sortables';
@@ -146,11 +146,7 @@ export default function DataChangeExample() {
               hapticsEnabled
               onDragEnd={({ order }) => setData(order(data))}>
               {data.map(item => (
-                <Sortable.Pressable
-                  key={item}
-                  onPress={onRemoveItem.bind(null, item)}>
-                  <FlexCell size='large'>{item}</FlexCell>
-                </Sortable.Pressable>
+                <FlexItem item={item} onRemoveItem={onRemoveItem} key={item} />
               ))}
             </Sortable.Flex>
 
@@ -163,6 +159,21 @@ export default function DataChangeExample() {
     </Screen>
   );
 }
+
+type FlexItemProps = {
+  item: string;
+  onRemoveItem: (item: string) => void;
+};
+
+// It is recommended to use memo for items to prevent re-renders of all flex items
+// when the parent component re-renders
+const FlexItem = memo(function FlexItem({ item, onRemoveItem }: FlexItemProps) {
+  return (
+    <Sortable.Pressable key={item} onPress={onRemoveItem.bind(null, item)}>
+      <FlexCell size='large'>{item}</FlexCell>
+    </Sortable.Pressable>
+  );
+});
 
 const styles = StyleSheet.create({
   row: {

--- a/example/app/src/examples/SortableFlex/DataChangeExample.tsx
+++ b/example/app/src/examples/SortableFlex/DataChangeExample.tsx
@@ -146,7 +146,7 @@ export default function DataChangeExample() {
               hapticsEnabled
               onDragEnd={({ order }) => setData(order(data))}>
               {data.map(item => (
-                <FlexItem item={item} onRemoveItem={onRemoveItem} key={item} />
+                <FlexItem item={item} key={item} onRemoveItem={onRemoveItem} />
               ))}
             </Sortable.Flex>
 

--- a/example/app/src/examples/SortableGrid/DataChangeExample.tsx
+++ b/example/app/src/examples/SortableGrid/DataChangeExample.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import Animated, { useAnimatedRef } from 'react-native-reanimated';
 import Sortable, { type SortableGridRenderItem } from 'react-native-sortables';
@@ -89,11 +89,7 @@ export default function DataChangeExample() {
   }, []);
 
   const renderItem = useCallback<SortableGridRenderItem<string>>(
-    ({ item }) => (
-      <Sortable.Pressable onPress={onRemoveItem.bind(null, item)}>
-        <GridCard>{item}</GridCard>
-      </Sortable.Pressable>
-    ),
+    ({ item }) => <GridItem item={item} onRemoveItem={onRemoveItem} />,
     [onRemoveItem]
   );
 
@@ -169,6 +165,22 @@ export default function DataChangeExample() {
     </Screen>
   );
 }
+
+type GridItemProps = {
+  item: string;
+  onRemoveItem: (item: string) => void;
+};
+
+// It is recommended to use memo for items to prevent re-renders of the entire grid
+// on item order changes (renderItem takes and index argument, thus it must be called
+// after every order change)
+const GridItem = memo(function GridItem({ item, onRemoveItem }: GridItemProps) {
+  return (
+    <Sortable.Pressable onPress={onRemoveItem.bind(null, item)}>
+      <GridCard>{item}</GridCard>
+    </Sortable.Pressable>
+  );
+});
 
 const styles = StyleSheet.create({
   row: {

--- a/packages/react-native-sortables/src/components/SortableFlex.tsx
+++ b/packages/react-native-sortables/src/components/SortableFlex.tsx
@@ -24,6 +24,7 @@ function SortableFlex(props: SortableFlexProps) {
       dropIndicatorStyle,
       itemEntering,
       itemExiting,
+      itemLayout,
       showDropIndicator,
       ...sharedProps
     }
@@ -55,6 +56,7 @@ function SortableFlex(props: SortableFlexProps) {
           dropIndicatorStyle={dropIndicatorStyle}
           itemEntering={itemEntering}
           itemExiting={itemExiting}
+          itemLayout={itemLayout}
           showDropIndicator={showDropIndicator}
           style={styleProps}
         />
@@ -68,13 +70,17 @@ type SortableFlexInnerProps = {
   style: ViewStyle;
 } & DropIndicatorSettings &
   Required<
-    Pick<SortableFlexProps, 'animateHeight' | 'itemEntering' | 'itemExiting'>
+    Pick<
+      SortableFlexProps,
+      'animateHeight' | 'itemEntering' | 'itemExiting' | 'itemLayout'
+    >
   >;
 
 function SortableFlexInner({
   childrenArray,
   itemEntering,
   itemExiting,
+  itemLayout,
   style,
   ...containerProps
 }: SortableFlexInnerProps) {
@@ -85,7 +91,8 @@ function SortableFlexInner({
           entering={itemEntering}
           exiting={itemExiting}
           itemKey={key}
-          key={key}>
+          key={key}
+          layout={itemLayout}>
           {child}
         </DraggableView>
       ))}

--- a/packages/react-native-sortables/src/components/SortableGrid.tsx
+++ b/packages/react-native-sortables/src/components/SortableGrid.tsx
@@ -17,6 +17,7 @@ import {
 import type {
   DropIndicatorSettings,
   LayoutAnimation,
+  LayoutTransition,
   SortableGridProps,
   SortableGridRenderItem
 } from '../types';
@@ -47,6 +48,7 @@ function SortableGrid<I>(props: SortableGridProps<I>) {
       dropIndicatorStyle,
       itemEntering,
       itemExiting,
+      itemLayout,
       showDropIndicator,
       ...sharedProps
     }
@@ -92,6 +94,7 @@ function SortableGrid<I>(props: SortableGridProps<I>) {
           itemEntering={itemEntering}
           itemExiting={itemExiting}
           itemKeys={itemKeys}
+          itemLayout={itemLayout}
           renderItem={renderItem}
           rowGap={rowGapValue}
           showDropIndicator={showDropIndicator}
@@ -114,6 +117,7 @@ type SortableGridInnerProps<I> = {
       | 'data'
       | 'itemEntering'
       | 'itemExiting'
+      | 'itemLayout'
       | 'renderItem'
     >
   >;
@@ -125,6 +129,7 @@ function SortableGridInner<I>({
   itemEntering,
   itemExiting,
   itemKeys,
+  itemLayout,
   renderItem,
   rowGap,
   ...containerProps
@@ -152,6 +157,7 @@ function SortableGridInner<I>({
           item={item}
           itemKey={key}
           key={key}
+          layout={itemLayout}
           renderItem={renderItem}
           style={animatedItemStyle}
         />
@@ -167,6 +173,7 @@ type SortableGridItemProps<I> = {
   renderItem: SortableGridRenderItem<I>;
   entering: LayoutAnimation;
   exiting: LayoutAnimation;
+  layout: LayoutTransition;
   style: ViewStyle;
 };
 

--- a/packages/react-native-sortables/src/components/SortableGrid.tsx
+++ b/packages/react-native-sortables/src/components/SortableGrid.tsx
@@ -170,14 +170,19 @@ type SortableGridItemProps<I> = {
   style: ViewStyle;
 };
 
-const SortableGridItem = typedMemo(function <I>({
+function SortableGridItem<I>({
   index,
   item,
   renderItem,
   ...rest
 }: SortableGridItemProps<I>) {
-  return <DraggableView {...rest}>{renderItem({ index, item })}</DraggableView>;
-});
+  const children = useMemo(
+    () => renderItem({ index, item }),
+    [renderItem, index, item]
+  );
+
+  return <DraggableView {...rest}>{children}</DraggableView>;
+}
 
 const styles = StyleSheet.create({
   gridContainer: {

--- a/packages/react-native-sortables/src/components/shared/DraggableView.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView.tsx
@@ -1,7 +1,6 @@
 import { memo, useEffect } from 'react';
 import type { ViewProps } from 'react-native';
 import Animated, {
-  LinearTransition,
   useDerivedValue,
   useSharedValue
 } from 'react-native-reanimated';
@@ -13,7 +12,7 @@ import {
   useItemLayoutStyles,
   useMeasurementsContext
 } from '../../providers';
-import type { LayoutAnimation } from '../../types';
+import type { LayoutAnimation, LayoutTransition } from '../../types';
 import ItemDecoration from './ItemDecoration';
 import { SortableHandleInternal } from './SortableHandle';
 
@@ -21,6 +20,7 @@ type DraggableViewProps = {
   itemKey: string;
   entering?: LayoutAnimation;
   exiting?: LayoutAnimation;
+  layout?: LayoutTransition;
 } & ViewProps;
 
 function DraggableView({
@@ -28,6 +28,7 @@ function DraggableView({
   entering,
   exiting,
   itemKey: key,
+  layout,
   style,
   ...viewProps
 }: DraggableViewProps) {
@@ -49,10 +50,14 @@ function DraggableView({
       pressProgress={pressProgress}
       // Keep onLayout the closest to the children to measure the real item size
       // (without paddings or other style changes made to the wrapper component)
-      onLayout={({ nativeEvent: { layout } }) => {
+      onLayout={({
+        nativeEvent: {
+          layout: { height, width }
+        }
+      }) => {
         handleItemMeasurement(key, {
-          height: layout.height,
-          width: layout.width
+          height,
+          width
         });
       }}>
       {children}
@@ -62,7 +67,7 @@ function DraggableView({
   return (
     <Animated.View
       {...viewProps}
-      layout={IS_WEB ? undefined : LinearTransition}
+      layout={IS_WEB ? undefined : layout}
       style={[style, layoutStyles]}>
       <ItemContextProvider
         isBeingActivated={isBeingActivated}

--- a/packages/react-native-sortables/src/components/shared/DraggableView.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { memo, useEffect } from 'react';
 import type { ViewProps } from 'react-native';
 import Animated, {
   LinearTransition,
@@ -23,7 +23,7 @@ type DraggableViewProps = {
   exiting?: LayoutAnimation;
 } & ViewProps;
 
-export default function DraggableView({
+function DraggableView({
   children,
   entering,
   exiting,
@@ -79,3 +79,5 @@ export default function DraggableView({
     </Animated.View>
   );
 }
+
+export default memo(DraggableView);

--- a/packages/react-native-sortables/src/constants/props.ts
+++ b/packages/react-native-sortables/src/constants/props.ts
@@ -1,4 +1,5 @@
 import type { ViewStyle } from 'react-native';
+import { LinearTransition } from 'react-native-reanimated';
 
 import { DefaultDropIndicator } from '../components/defaults';
 import type {
@@ -20,12 +21,17 @@ export const STYLE_PROPS = ['dropIndicatorStyle'] as const;
 /**
  * DEFAULT SHARED PROPS
  */
-type OptionalSharedProps =
+type OptionalSharedProps = keyof ItemLayoutAnimationSettings;
+
+type ExcludedSharedProps =
   | 'scrollableRef'
-  | keyof ItemLayoutAnimationSettings
   | keyof Omit<SortableCallbacks, 'onDragEnd'>;
 
-type DefaultSharedProps = DefaultProps<SharedProps, OptionalSharedProps>;
+type DefaultSharedProps = DefaultProps<
+  SharedProps,
+  OptionalSharedProps,
+  ExcludedSharedProps
+>;
 
 export const DEFAULT_SHARED_PROPS = {
   DropIndicatorComponent: DefaultDropIndicator,
@@ -59,10 +65,8 @@ export const DEFAULT_SHARED_PROPS = {
   // fixed in `react-native-reanimated` in the future.
   itemEntering: IS_WEB ? undefined : SortableItemEntering,
   itemExiting: IS_WEB ? undefined : SortableItemExiting,
-  onDragStart: undefined,
-  onOrderChange: undefined,
+  itemLayout: IS_WEB ? undefined : LinearTransition,
   overDrag: 'both',
-  scrollableRef: undefined,
   showDropIndicator: false,
   snapOffsetX: '50%',
   snapOffsetY: '50%',
@@ -72,7 +76,11 @@ export const DEFAULT_SHARED_PROPS = {
 /**
  * DEFAULT SORTABLE GRID PROPS
  */
-type ExcludedFromDefaultGridProps = 'data' | 'onDragEnd' | 'renderItem';
+type ExcludedFromDefaultGridProps =
+  | 'data'
+  | 'onDragEnd'
+  | 'renderItem'
+  | ExcludedSharedProps;
 
 type DefaultSortableGridProps = DefaultProps<
   Omit<SortableGridProps<unknown>, keyof DefaultSharedProps>,
@@ -108,7 +116,7 @@ type OptionalDefaultFlexProps =
   | 'rowGap'
   | 'width';
 
-type ExcludedFromDefaultFlexProps = 'onDragEnd';
+type ExcludedFromDefaultFlexProps = 'onDragEnd' | ExcludedSharedProps;
 
 type DefaultSortableFlexProps = DefaultProps<
   Omit<SortableFlexProps, keyof DefaultSharedProps>,

--- a/packages/react-native-sortables/src/types/props/shared.ts
+++ b/packages/react-native-sortables/src/types/props/shared.ts
@@ -3,7 +3,7 @@ import type { ViewStyle } from 'react-native';
 import type { AnimatedRef, SharedValue } from 'react-native-reanimated';
 
 import type { Vector } from '../layout/shared';
-import type { LayoutAnimation } from '../reanimated';
+import type { LayoutAnimation, LayoutTransition } from '../reanimated';
 import type { Animatable, AnimatableProps, Simplify } from '../utils';
 
 export type DropIndicatorComponentProps = {
@@ -59,6 +59,7 @@ export type DropIndicatorSettings = {
 export type ItemLayoutAnimationSettings = {
   itemEntering: LayoutAnimation | undefined;
   itemExiting: LayoutAnimation | undefined;
+  itemLayout: LayoutTransition | undefined;
 };
 
 export type DragStartParams = {

--- a/packages/react-native-sortables/src/types/reanimated.ts
+++ b/packages/react-native-sortables/src/types/reanimated.ts
@@ -1,9 +1,15 @@
 import type {
   BaseAnimationBuilder,
-  EntryExitAnimationFunction
+  EntryExitAnimationFunction,
+  LayoutAnimationFunction
 } from 'react-native-reanimated';
 
 export type LayoutAnimation =
   | BaseAnimationBuilder
   | EntryExitAnimationFunction
+  | typeof BaseAnimationBuilder;
+
+export type LayoutTransition =
+  | BaseAnimationBuilder
+  | LayoutAnimationFunction
   | typeof BaseAnimationBuilder;

--- a/packages/react-native-sortables/src/utils/props.ts
+++ b/packages/react-native-sortables/src/utils/props.ts
@@ -32,6 +32,9 @@ export const getPropsWithDefaults = <
   for (const key in props) {
     if (props[key] !== undefined) {
       propsWithDefaults[key] = props[key];
+    } else {
+      // Remove prop if it was explicitly set to undefined by the user
+      delete propsWithDefaults[key];
     }
   }
 


### PR DESCRIPTION
## Description

This PR makes items layout transition customizable (new prop: `itemLayout`). Layout transition is used only on mobile (as web implementation of reanimated layout transitions is ver buggy). It determines how items are animated when their order change or positions change as a result of item insertion/removal before other items.

## Example recording

| LinearTransition (default) | CurvedTransition |
|-|-|
| <video src="" /> | <video src="" /> |

