### PR TITLE
fix: Sortable flex fragment children

### DIFF
--- a/example/app/src/examples/SortableFlex/PlaygroundExample.tsx
+++ b/example/app/src/examples/SortableFlex/PlaygroundExample.tsx
@@ -10,30 +10,13 @@ const DATA = getCategories(IS_WEB ? 30 : 10);
 export default function Flex() {
   return (
     <ScrollScreen>
-      <Sortable.Flex
-        gap={10}
-        padding={10}
-        onDragEnd={a => {
-          console.log('onDragEnd', a);
-        }}>
+      <Sortable.Flex gap={10} padding={10}>
         {/* You can render anything within the Sortable.Flex component */}
-        <>
-          <>
-            {DATA.map(item => (
-              <View key={item} style={styles.cell}>
-                <Text style={styles.text}>{item}</Text>
-              </View>
-            ))}
-          </>
-          <></>
-          <></>
-          <></>
-          {DATA.slice(0, 3).map(item => (
-            <View key={item} style={styles.cell}>
-              <Text style={styles.text}>{item}</Text>
-            </View>
-          ))}
-        </>
+        {DATA.map(item => (
+          <View key={item} style={styles.cell}>
+            <Text style={styles.text}>{item}</Text>
+          </View>
+        ))}
       </Sortable.Flex>
     </ScrollScreen>
   );

--- a/example/app/src/examples/SortableFlex/PlaygroundExample.tsx
+++ b/example/app/src/examples/SortableFlex/PlaygroundExample.tsx
@@ -10,13 +10,30 @@ const DATA = getCategories(IS_WEB ? 30 : 10);
 export default function Flex() {
   return (
     <ScrollScreen>
-      <Sortable.Flex gap={10} padding={10}>
+      <Sortable.Flex
+        gap={10}
+        padding={10}
+        onDragEnd={a => {
+          console.log('onDragEnd', a);
+        }}>
         {/* You can render anything within the Sortable.Flex component */}
-        {DATA.map(item => (
-          <View key={item} style={styles.cell}>
-            <Text style={styles.text}>{item}</Text>
-          </View>
-        ))}
+        <>
+          <>
+            {DATA.map(item => (
+              <View key={item} style={styles.cell}>
+                <Text style={styles.text}>{item}</Text>
+              </View>
+            ))}
+          </>
+          <></>
+          <></>
+          <></>
+          {DATA.slice(0, 3).map(item => (
+            <View key={item} style={styles.cell}>
+              <Text style={styles.text}>{item}</Text>
+            </View>
+          ))}
+        </>
       </Sortable.Flex>
     </ScrollScreen>
   );

--- a/packages/react-native-sortables/src/utils/children.ts
+++ b/packages/react-native-sortables/src/utils/children.ts
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from 'react';
-import { Children, isValidElement } from 'react';
+import { Children, Fragment, isValidElement } from 'react';
 
 import { logger } from './logs';
 
@@ -10,6 +10,14 @@ export const validateChildren = (
     (acc: Array<[string, ReactElement]>, child, index) => {
       if (!isValidElement(child)) {
         return acc;
+      }
+
+      // Handle React Fragments by recursively processing their children
+      if (child.type === Fragment) {
+        const fragmentChildren = validateChildren(
+          (child.props as { children: ReactNode }).children
+        );
+        return [...acc, ...fragmentChildren];
       }
 
       const key = child.key as string;


### PR DESCRIPTION
## Description

This PR adds React Fragment components filtering out from the `Sortable.Flex` component children.

## How to test

I used the following code to test if it works as expected.

<details>
 <summary>Code snippet</summary>

```tsx
import { StyleSheet, Text, View } from 'react-native';
import Sortable from 'react-native-sortables';

import { ScrollScreen } from '@/components';
import { colors, text } from '@/theme';
import { getCategories, IS_WEB } from '@/utils';

const DATA = getCategories(IS_WEB ? 30 : 10);

export default function Flex() {
  return (
    <ScrollScreen>
      <Sortable.Flex
        gap={10}
        padding={10}
        onDragEnd={a => {
          console.log('onDragEnd', a);
        }}>
        {/* You can render anything within the Sortable.Flex component */}
        <>
          <>
            {DATA.map(item => (
              <View key={item} style={styles.cell}>
                <Text style={styles.text}>{item}</Text>
              </View>
            ))}
          </>
          <></>
          <></>
          <></>
          {DATA.slice(0, 3).map(item => (
            <View key={item} style={styles.cell}>
              <Text style={styles.text}>{item}</Text>
            </View>
          ))}
        </>
      </Sortable.Flex>
    </ScrollScreen>
  );
}

const styles = StyleSheet.create({
  cell: {
    alignItems: 'center',
    backgroundColor: '#36877F',
    borderRadius: 9999,
    justifyContent: 'center',
    padding: 10
  },
  text: {
    ...text.label2,
    color: colors.white
  }
});
```
</details>