### PR TITLE
fix: Invalid item activation on iOS Fabric after container scroll

### DIFF
--- a/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
@@ -213,21 +213,35 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       'worklet';
       const containerMeasurements = measure(containerRef);
       const itemPosition = itemPositions.value[key];
+      const dimensions = itemDimensions.value[key];
 
-      if (!containerMeasurements || !itemPosition) {
+      if (!containerMeasurements || !itemPosition || !dimensions) {
+        fail();
+        return;
+      }
+
+      const touchX = touch.absoluteX - containerMeasurements.pageX;
+      const touchY = touch.absoluteY - containerMeasurements.pageY;
+
+      // Validate the touch position (must be within the item's bounds)
+      // (we need this because of this bug in react-native-gesture-handler on Fabric:
+      // https://github.com/software-mansion/react-native-gesture-handler/issues/3411)
+      if (
+        touchX < itemPosition.x ||
+        touchX > itemPosition.x + dimensions.width ||
+        touchY < itemPosition.y ||
+        touchY > itemPosition.y + dimensions.height
+      ) {
         fail();
         return;
       }
 
       dragStartTouch.value = touch;
-      touchPosition.value = {
-        x: touch.absoluteX - containerMeasurements.pageX,
-        y: touch.absoluteY - containerMeasurements.pageY
-      };
+      touchPosition.value = { x: touchX, y: touchY };
       dragStartTouchPosition.value = touchPosition.value;
       dragStartItemTouchOffset.value = {
-        x: touchPosition.value.x - itemPosition.x,
-        y: touchPosition.value.y - itemPosition.y
+        x: touchX - itemPosition.x,
+        y: touchY - itemPosition.y
       };
 
       activeAnimationProgress.value = 0;

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
@@ -224,8 +224,8 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       const touchY = touch.absoluteY - containerMeasurements.pageY;
 
       // Validate the touch position (must be within the item's bounds)
-      // (we need this because of this bug in react-native-gesture-handler on Fabric:
-      // https://github.com/software-mansion/react-native-gesture-handler/issues/3411)
+      // (we need this because measure returns wrong position on Fabric
+      // when the container was scrolled a while before the drag activation)
       if (
         touchX < itemPosition.x ||
         touchX > itemPosition.x + dimensions.width ||


### PR DESCRIPTION
## Description

This PR fixes drag activation with wrong initial position. This issue is caused by incorrect measurements being returned by the `measure` function from `react-native-reanimated` (only on the New Architecture, the Old Architecture works fine).

After changes, when the touch is outside of the activated item bounds, it will be simply ignored and the gesture will fail.

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/b7f96a6b-c8fd-4af7-ad84-100af48067b4" /> | <video src="https://github.com/user-attachments/assets/514b3033-f338-451d-98ec-687c4ad278c5" /> |
