### PR TITLE
fix: Don't skip entering and exiting animations on user's views, improve layout animations docs

### DIFF
--- a/packages/docs/docs/flex/props.mdx
+++ b/packages/docs/docs/flex/props.mdx
@@ -551,9 +551,16 @@ type DropIndicatorComponentProps = {
 
 ## Layout Animations
 
-Layout animations control the **appearance or disappearance animations** of items **added or removed from the flex container**.
+Layout animations control how items animate when their positions change and when they are added or removed from the flex container.
 
-:::warning
+:::note
+
+- Item **entering** animations are **not** triggered during the **initial render** of the flex container
+- Item **exiting** animations are **not** triggered when the **entire flex container is unmounted**
+
+:::
+
+:::warning Warning (Web)
 
 There are some **differences** in the **layout animations** implementation on **Web**:
 
@@ -563,6 +570,8 @@ There are some **differences** in the **layout animations** implementation on **
 :::
 
 ### itemEntering
+
+Layout animation to use when an item is added to the flex container after the initial render.
 
 | type              | default                           | required |
 | ----------------- | --------------------------------- | -------- |
@@ -587,6 +596,8 @@ type LayoutAnimation =
 ---
 
 ### itemExiting
+
+Layout animation to use when an item is removed from the flex container (except when the entire flex container is unmounted).
 
 | type              | default                          | required |
 | ----------------- | -------------------------------- | -------- |
@@ -634,7 +645,7 @@ type LayoutTransition =
 
 </details>
 
-:::warning
+:::warning Warning (Web)
 
 This prop is **not supported** on Web.
 
@@ -767,16 +778,6 @@ type SortableFlexStrategy = 'insert' | SortableFlexStrategyFactory;
 
 ---
 
-### hapticsEnabled
-
-Whether haptics are enabled. Vibrations are fired when the **pressed item becomes active**, the **order of items changes** or the drag gesture ends and the **item is dropped**.
-
-| type      | default | required |
-| --------- | ------- | -------- |
-| `boolean` | false   | NO       |
-
----
-
 ### customHandle
 
 Controls whether drag gestures should be restricted to a custom handle component.
@@ -792,6 +793,14 @@ When `customHandle` is enabled, you **must** include a `Sortable.Handle` compone
 :::
 
 ---
+
+### hapticsEnabled
+
+Whether haptics are enabled. Vibrations are fired when the **pressed item becomes active**, the **order of items changes** or the drag gesture ends and the **item is dropped**.
+
+| type      | default | required |
+| --------- | ------- | -------- |
+| `boolean` | false   | NO       |
 
 :::important
 

--- a/packages/docs/docs/grid/props.mdx
+++ b/packages/docs/docs/grid/props.mdx
@@ -431,20 +431,25 @@ type DropIndicatorComponentProps = {
 
 ## Layout Animations
 
-Layout animations control the **appearance or disappearance animations** of items **added or removed from the grid**.
+Layout animations control how items animate when their positions change and when they are added or removed from the grid.
 
-:::warning
+:::note
 
+- Item **entering** animations are **not** triggered during the **initial render** of the grid
+- Item **exiting** animations are **not** triggered when the **entire grid is unmounted**
+
+:::
+
+:::warning Warning (Web)
 There are some **differences** in the **layout animations** implementation on **Web**:
 
 - `itemLayout` is **ignored** since Web implementation doesn't use **Reanimated** layout transitions for items reordering
 - `itemEntering` and `itemExiting` don't have default values due to the inconsistent behavior, but you can provide your own animations that will be used instead
-
-:::
+  :::
 
 ### itemEntering
 
-Layout animation to use when an item is added to the grid.
+Layout animation to use when an item is added to the grid after the initial render of the grid.
 
 | type              | default                           | required |
 | ----------------- | --------------------------------- | -------- |
@@ -470,7 +475,7 @@ type LayoutAnimation =
 
 ### itemExiting
 
-Layout animation to use when an item is removed from the grid.
+Layout animation to use when an item is removed from the grid (except when the entire grid is unmounted).
 
 | type              | default                          | required |
 | ----------------- | -------------------------------- | -------- |
@@ -502,7 +507,7 @@ Layout transition to use when items are reordered.
 | ------------------ | ----------------------------- | -------- |
 | `LayoutTransition` | LinearTransition\* / null\*\* | NO       |
 
-\*Library default `itemsLayout` implementation for native platforms
+\*Used as a default value on native platforms
 
 \*\*No default value on Web
 
@@ -518,7 +523,7 @@ type LayoutTransition =
 
 </details>
 
-:::warning
+:::warning Warning (Web)
 
 This prop is **not supported** on Web.
 

--- a/packages/react-native-sortables/src/components/shared/DraggableView.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect } from 'react';
 import type { ViewProps } from 'react-native';
 import Animated, {
+  LayoutAnimationConfig,
   useDerivedValue,
   useSharedValue
 } from 'react-native-reanimated';
@@ -35,9 +36,9 @@ function DraggableView({
   const { activeItemKey, customHandle } = useCommonValuesContext();
   const { handleItemMeasurement, handleItemRemoval } = useMeasurementsContext();
 
-  const isBeingActivated = useDerivedValue(() => activeItemKey.value === key);
-  const pressProgress = useSharedValue(0);
-  const layoutStyles = useItemLayoutStyles(key, pressProgress);
+  const activationAnimationProgress = useSharedValue(0);
+  const isActive = useDerivedValue(() => activeItemKey.value === key);
+  const layoutStyles = useItemLayoutStyles(key, activationAnimationProgress);
 
   useEffect(() => {
     return () => handleItemRemoval(key);
@@ -45,9 +46,9 @@ function DraggableView({
 
   const innerComponent = (
     <ItemDecoration
-      isBeingActivated={isBeingActivated}
+      isActive={isActive}
       itemKey={key}
-      pressProgress={pressProgress}
+      activationAnimationProgress={activationAnimationProgress}
       // Keep onLayout the closest to the children to measure the real item size
       // (without paddings or other style changes made to the wrapper component)
       onLayout={({
@@ -60,7 +61,9 @@ function DraggableView({
           width
         });
       }}>
-      {children}
+      <LayoutAnimationConfig skipEntering={false} skipExiting={false}>
+        {children}
+      </LayoutAnimationConfig>
     </ItemDecoration>
   );
 
@@ -70,9 +73,9 @@ function DraggableView({
       layout={IS_WEB ? undefined : layout}
       style={[style, layoutStyles]}>
       <ItemContextProvider
-        isBeingActivated={isBeingActivated}
+        isActive={isActive}
         itemKey={key}
-        pressProgress={pressProgress}>
+        activationAnimationProgress={activationAnimationProgress}>
         <Animated.View entering={entering} exiting={exiting}>
           {customHandle ? (
             innerComponent

--- a/packages/react-native-sortables/src/components/shared/DraggableView.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView.tsx
@@ -46,9 +46,9 @@ function DraggableView({
 
   const innerComponent = (
     <ItemDecoration
+      activationAnimationProgress={activationAnimationProgress}
       isActive={isActive}
       itemKey={key}
-      activationAnimationProgress={activationAnimationProgress}
       // Keep onLayout the closest to the children to measure the real item size
       // (without paddings or other style changes made to the wrapper component)
       onLayout={({
@@ -73,9 +73,9 @@ function DraggableView({
       layout={IS_WEB ? undefined : layout}
       style={[style, layoutStyles]}>
       <ItemContextProvider
+        activationAnimationProgress={activationAnimationProgress}
         isActive={isActive}
-        itemKey={key}
-        activationAnimationProgress={activationAnimationProgress}>
+        itemKey={key}>
         <Animated.View entering={entering} exiting={exiting}>
           {customHandle ? (
             innerComponent

--- a/packages/react-native-sortables/src/components/shared/ItemDecoration.tsx
+++ b/packages/react-native-sortables/src/components/shared/ItemDecoration.tsx
@@ -21,9 +21,9 @@ type ItemDecorationProps = {
 } & ViewProps;
 
 export default function ItemDecoration({
+  activationAnimationProgress,
   isActive,
   itemKey: key,
-  activationAnimationProgress,
   ...rest
 }: ItemDecorationProps) {
   const {

--- a/packages/react-native-sortables/src/components/shared/ItemDecoration.tsx
+++ b/packages/react-native-sortables/src/components/shared/ItemDecoration.tsx
@@ -14,16 +14,16 @@ import { useCommonValuesContext } from '../../providers';
 import AnimatedOnLayoutView from './AnimatedOnLayoutView';
 
 type ItemDecorationProps = {
-  isBeingActivated: SharedValue<boolean>;
-  pressProgress: SharedValue<number>;
+  isActive: SharedValue<boolean>;
+  activationAnimationProgress: SharedValue<number>;
   onLayout: NonNullable<ViewProps['onLayout']>;
   itemKey: string;
 } & ViewProps;
 
 export default function ItemDecoration({
-  isBeingActivated,
+  isActive,
   itemKey: key,
-  pressProgress,
+  activationAnimationProgress,
   ...rest
 }: ItemDecorationProps) {
   const {
@@ -39,19 +39,19 @@ export default function ItemDecoration({
   } = useCommonValuesContext();
 
   const adjustedInactiveProgress = useDerivedValue(() => {
-    if (isBeingActivated.value || prevActiveItemKey.value === key) {
+    if (isActive.value || prevActiveItemKey.value === key) {
       return withTiming(0, { duration: activationAnimationDuration.value });
     }
 
     return interpolate(
-      pressProgress.value,
+      activationAnimationProgress.value,
       [0, 1],
       [inactiveAnimationProgress.value, 0]
     );
   });
 
   const animatedStyle = useAnimatedStyle(() => {
-    const progress = pressProgress.value;
+    const progress = activationAnimationProgress.value;
     const zeroProgressOpacity = interpolate(
       adjustedInactiveProgress.value,
       [0, 1],

--- a/packages/react-native-sortables/src/components/shared/SortableHandle.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableHandle.tsx
@@ -28,10 +28,10 @@ export function SortableHandle({
     snapItemDimensions,
     snapItemOffset
   } = useCommonValuesContext();
-  const { itemKey, pressProgress } = useItemContext();
+  const { itemKey, activationAnimationProgress } = useItemContext();
 
   const viewRef = useAnimatedRef<View>();
-  const gesture = useItemPanGesture(itemKey, pressProgress);
+  const gesture = useItemPanGesture(itemKey, activationAnimationProgress);
 
   const measureHandle = useCallback(() => {
     'worklet';
@@ -92,9 +92,9 @@ export function SortableHandleInternal({
 }: {
   children: React.ReactNode;
 }) {
-  const { itemKey, pressProgress } = useItemContext();
+  const { itemKey, activationAnimationProgress } = useItemContext();
 
-  const gesture = useItemPanGesture(itemKey, pressProgress);
+  const gesture = useItemPanGesture(itemKey, activationAnimationProgress);
 
   return <GestureDetector gesture={gesture}>{children}</GestureDetector>;
 }

--- a/packages/react-native-sortables/src/components/shared/SortableHandle.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableHandle.tsx
@@ -28,7 +28,7 @@ export function SortableHandle({
     snapItemDimensions,
     snapItemOffset
   } = useCommonValuesContext();
-  const { itemKey, activationAnimationProgress } = useItemContext();
+  const { activationAnimationProgress, itemKey } = useItemContext();
 
   const viewRef = useAnimatedRef<View>();
   const gesture = useItemPanGesture(itemKey, activationAnimationProgress);
@@ -92,7 +92,7 @@ export function SortableHandleInternal({
 }: {
   children: React.ReactNode;
 }) {
-  const { itemKey, activationAnimationProgress } = useItemContext();
+  const { activationAnimationProgress, itemKey } = useItemContext();
 
   const gesture = useItemPanGesture(itemKey, activationAnimationProgress);
 

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
@@ -207,7 +207,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
     (
       touch: TouchData,
       key: string,
-      pressProgress: SharedValue<number>,
+      activationAnimationProgress: SharedValue<number>,
       fail: () => void
     ) => {
       'worklet';
@@ -267,7 +267,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
 
       inactiveAnimationProgress.value = hasInactiveAnimation ? animate() : 0;
       activeAnimationProgress.value = animate();
-      pressProgress.value = animate();
+      activationAnimationProgress.value = animate();
 
       haptics.medium();
       stableOnDragStart({
@@ -309,7 +309,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
     (
       e: GestureTouchEvent,
       key: string,
-      pressProgress: SharedValue<number>,
+      activationAnimationProgress: SharedValue<number>,
       activate: () => void,
       fail: () => void
     ) => {
@@ -321,7 +321,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
         // if the current item is still animated to the drag end position
         // or sorting is disabled at all
         !sortEnabled.value ||
-        pressProgress.value > 0 ||
+        activationAnimationProgress.value > 0 ||
         activeItemKey.value !== null
       ) {
         fail();
@@ -341,7 +341,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       // e.g. while scrolling the ScrollView
       activationTimeoutId.value = setAnimatedTimeout(() => {
         activate();
-        handleDragStart(touch, key, pressProgress, fail);
+        handleDragStart(touch, key, activationAnimationProgress, fail);
       }, dragActivationDelay.value);
     },
     [
@@ -407,7 +407,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
   );
 
   const handleDragEnd = useCallback(
-    (key: string, pressProgress: SharedValue<number>) => {
+    (key: string, activationAnimationProgress: SharedValue<number>) => {
       'worklet';
       dragStartIndex.value = -1;
       touchStartTouch.value = null;
@@ -440,7 +440,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       const animate = (callback?: (finished: boolean | undefined) => void) =>
         withTiming(0, { duration: dropAnimationDuration.value }, callback);
 
-      pressProgress.value = animate();
+      activationAnimationProgress.value = animate();
       inactiveAnimationProgress.value = animate();
 
       clearAnimatedTimeout(activationTimeoutId.value);

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
@@ -32,7 +32,7 @@ const NO_TRANSLATION_STYLE: ViewStyle = {
 
 export default function useItemLayoutStyles(
   key: string,
-  pressProgress: SharedValue<number>
+  activationAnimationProgress: SharedValue<number>
 ): StyleProp<AnimatedStyle<ViewStyle>> {
   const {
     activeItemKey,
@@ -43,9 +43,11 @@ export default function useItemLayoutStyles(
     itemPositions
   } = useCommonValuesContext();
 
-  const zIndex = useItemZIndex(key, pressProgress);
-  const hasPressProgress = useDerivedValue(() => pressProgress.value > 0);
+  const zIndex = useItemZIndex(key, activationAnimationProgress);
   const isReleased = useSharedValue(true);
+  const hasProgress = useDerivedValue(
+    () => activationAnimationProgress.value > 0
+  );
 
   const translateX = useSharedValue<null | number>(null);
   const translateY = useSharedValue<null | number>(null);
@@ -55,7 +57,7 @@ export default function useItemLayoutStyles(
   // Inactive item updater
   useAnimatedReaction(
     () => ({
-      hasProgress: hasPressProgress.value,
+      hasProgress: hasProgress.value,
       isActive: activeItemKey.value === key,
       position: itemPositions.value[key]
     }),

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
@@ -45,7 +45,7 @@ export default function useItemLayoutStyles(
 
   const zIndex = useItemZIndex(key, activationAnimationProgress);
   const isReleased = useSharedValue(true);
-  const hasProgress = useDerivedValue(
+  const hasActivationProgress = useDerivedValue(
     () => activationAnimationProgress.value > 0
   );
 
@@ -57,7 +57,7 @@ export default function useItemLayoutStyles(
   // Inactive item updater
   useAnimatedReaction(
     () => ({
-      hasProgress: hasProgress.value,
+      hasProgress: hasActivationProgress.value,
       isActive: activeItemKey.value === key,
       position: itemPositions.value[key]
     }),

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.web.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.web.ts
@@ -31,7 +31,7 @@ const NO_TRANSLATION_STYLE: ViewStyle = {
 
 export default function useItemLayoutStyles(
   key: string,
-  pressProgress: SharedValue<number>
+  activationAnimationProgress: SharedValue<number>
 ): StyleProp<AnimatedStyle<ViewStyle>> {
   const {
     activeItemDropped,
@@ -44,7 +44,7 @@ export default function useItemLayoutStyles(
     shouldAnimateLayout
   } = useCommonValuesContext();
 
-  const zIndex = useItemZIndex(key, pressProgress);
+  const zIndex = useItemZIndex(key, activationAnimationProgress);
 
   const translateX = useSharedValue<null | number>(null);
   const translateY = useSharedValue<null | number>(null);

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
@@ -6,7 +6,7 @@ import { useDragContext } from '../DragProvider';
 
 export default function useItemPanGesture(
   key: string,
-  pressProgress: SharedValue<number>
+  activationAnimationProgress: SharedValue<number>
 ) {
   const { handleDragEnd, handleTouchStart, handleTouchesMove } =
     useDragContext();
@@ -19,7 +19,7 @@ export default function useItemPanGesture(
           handleTouchStart(
             e,
             key,
-            pressProgress,
+            activationAnimationProgress,
             manager.activate,
             manager.fail
           );
@@ -34,8 +34,14 @@ export default function useItemPanGesture(
           manager.end();
         })
         .onFinalize(() => {
-          handleDragEnd(key, pressProgress);
+          handleDragEnd(key, activationAnimationProgress);
         }),
-    [key, pressProgress, handleDragEnd, handleTouchStart, handleTouchesMove]
+    [
+      key,
+      activationAnimationProgress,
+      handleDragEnd,
+      handleTouchStart,
+      handleTouchesMove
+    ]
   );
 }

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemZIndex.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemZIndex.ts
@@ -5,7 +5,7 @@ import { useCommonValuesContext } from '../CommonValuesProvider';
 
 export default function useItemZIndex(
   key: string,
-  pressProgress: SharedValue<number>
+  activationAnimationProgress: SharedValue<number>
 ): SharedValue<number> {
   const { activeItemKey, prevActiveItemKey } = useCommonValuesContext();
 
@@ -16,7 +16,7 @@ export default function useItemZIndex(
     if (prevActiveItemKey.value === key) {
       return 2;
     }
-    if (pressProgress.value > 0) {
+    if (activationAnimationProgress.value > 0) {
       return 1;
     }
     return 0;

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -91,12 +91,15 @@ export type DragContextType = {
   handleTouchStart: (
     e: GestureTouchEvent,
     key: string,
-    pressProgress: SharedValue<number>,
+    activationAnimationProgress: SharedValue<number>,
     activate: () => void,
     fail: () => void
   ) => void;
   handleTouchesMove: (e: GestureTouchEvent, fail: () => void) => void;
-  handleDragEnd: (key: string, pressProgress: SharedValue<number>) => void;
+  handleDragEnd: (
+    key: string,
+    activationAnimationProgress: SharedValue<number>
+  ) => void;
   handleOrderChange: (
     key: string,
     fromIndex: number,
@@ -109,9 +112,9 @@ export type DragContextType = {
 
 export type ItemContextType = {
   itemKey: string;
-  pressProgress: Readonly<SharedValue<number>>;
-  isBeingActivated: Readonly<SharedValue<boolean>>;
+  isActive: Readonly<SharedValue<boolean>>;
   dragActivationState: Readonly<SharedValue<DragActivationState>>;
+  activationAnimationProgress: Readonly<SharedValue<number>>;
 };
 
 // LAYER


### PR DESCRIPTION
## Description

I use `LayoutAnimationConfig` to skip `itemEntering` and `itemExiting` animation from being applied when the entire sortable component renders or is unmounted. This is intentional but confusing, so I improved the description in docs to make it clear how these props are supposed to be used and how they work.

I also didn't unset `skipEntering` and `skipExiting` for views that the user renders within the sortable component, which is an invalid behavior preventing users from using any kind of `entering`/`exiting` reanimated layout animation. To fix this issue, I simply added another `LayoutAnimationConfig` that unsets `skipEntering` and `skipExiting` (sets them to `false`).