### PR TITLE
feat: Customizable reorder trigger origin

### DIFF
--- a/example/app/src/examples/SortableFlex/DragHandleExample.tsx
+++ b/example/app/src/examples/SortableFlex/DragHandleExample.tsx
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import Animated, { useAnimatedRef } from 'react-native-reanimated';
-import type { SortableOverDrag } from 'react-native-sortables';
+import type { OverDrag } from 'react-native-sortables';
 import Sortable from 'react-native-sortables';
 
 import { OptionGroup, SimpleDropdown } from '@/components';
@@ -14,15 +14,10 @@ import { iconSizes } from '../../theme/icons';
 
 const DATA = getCategories(30);
 
-const OVER_DRAG: Array<SortableOverDrag> = [
-  'both',
-  'horizontal',
-  'vertical',
-  'none'
-];
+const OVER_DRAG: Array<OverDrag> = ['both', 'horizontal', 'vertical', 'none'];
 
 export default function DragHandleExample() {
-  const [overDrag, setOverDrag] = useState<SortableOverDrag>('both');
+  const [overDrag, setOverDrag] = useState<OverDrag>('both');
   const scrollableRef = useAnimatedRef<Animated.ScrollView>();
 
   return (

--- a/example/app/src/examples/SortableGrid/DragHandleExample.tsx
+++ b/example/app/src/examples/SortableGrid/DragHandleExample.tsx
@@ -3,10 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { useCallback, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import Animated, { useAnimatedRef } from 'react-native-reanimated';
-import type {
-  SortableGridRenderItem,
-  SortableOverDrag
-} from 'react-native-sortables';
+import type { OverDrag, SortableGridRenderItem } from 'react-native-sortables';
 import Sortable from 'react-native-sortables';
 
 import { OptionGroup, SimpleDropdown, TabSelector } from '@/components';
@@ -15,16 +12,11 @@ import { colors, flex, radius, sizes, spacing, style, text } from '@/theme';
 const DATA = Array.from({ length: 20 }, (_, index) => `Item ${index + 1}`);
 
 const COLUMNS = [1, 2, 3, 4];
-const OVER_DRAG: Array<SortableOverDrag> = [
-  'both',
-  'horizontal',
-  'vertical',
-  'none'
-];
+const OVER_DRAG: Array<OverDrag> = ['both', 'horizontal', 'vertical', 'none'];
 
 export default function DragHandleExample() {
   const [columns, setColumns] = useState(1);
-  const [overDrag, setOverDrag] = useState<SortableOverDrag>('both');
+  const [overDrag, setOverDrag] = useState<OverDrag>('both');
   const scrollableRef = useAnimatedRef<Animated.ScrollView>();
 
   const renderItem = useCallback<SortableGridRenderItem<string>>(

--- a/packages/react-native-sortables/src/components/SortableFlex.tsx
+++ b/packages/react-native-sortables/src/components/SortableFlex.tsx
@@ -35,6 +35,7 @@ function SortableFlex(props: SortableFlexProps) {
       itemEntering,
       itemExiting,
       itemsLayout,
+      reorderTriggerOrigin,
       showDropIndicator,
       ...sharedProps
     }
@@ -72,6 +73,7 @@ function SortableFlex(props: SortableFlexProps) {
           key={useStrategyKey(strategy)}
           predefinedStrategies={FLEX_STRATEGIES}
           strategy={strategy}
+          triggerOrigin={reorderTriggerOrigin}
           useAdditionalValues={useFlexLayoutContext}
         />
         <SortableFlexInner

--- a/packages/react-native-sortables/src/components/SortableGrid.tsx
+++ b/packages/react-native-sortables/src/components/SortableGrid.tsx
@@ -48,6 +48,7 @@ function SortableGrid<I>(props: SortableGridProps<I>) {
       itemEntering,
       itemExiting,
       itemsLayout,
+      reorderTriggerOrigin,
       showDropIndicator,
       ...sharedProps
     }
@@ -86,6 +87,7 @@ function SortableGrid<I>(props: SortableGridProps<I>) {
           key={useStrategyKey(strategy)}
           predefinedStrategies={GRID_STRATEGIES}
           strategy={strategy}
+          triggerOrigin={reorderTriggerOrigin}
           useAdditionalValues={useGridLayoutContext}
         />
         <SortableGridInner

--- a/packages/react-native-sortables/src/constants/props.ts
+++ b/packages/react-native-sortables/src/constants/props.ts
@@ -63,6 +63,7 @@ export const DEFAULT_SHARED_PROPS = {
   onDragStart: undefined,
   onOrderChange: undefined,
   overDrag: 'both',
+  reorderTriggerOrigin: 'center',
   scrollableRef: undefined,
   showDropIndicator: false,
   snapOffsetX: '50%',

--- a/packages/react-native-sortables/src/index.ts
+++ b/packages/react-native-sortables/src/index.ts
@@ -19,6 +19,8 @@ export type {
   DropIndicatorComponentProps,
   OrderChangeCallback,
   OrderChangeParams,
+  OverDrag,
+  ReorderTriggerOrigin,
   SortableFlexProps,
   SortableFlexStrategyFactory,
   SortableFlexStyle,
@@ -26,8 +28,7 @@ export type {
   SortableGridDragEndParams,
   SortableGridProps,
   SortableGridRenderItem,
-  SortableGridStrategyFactory,
-  OverDrag as SortableOverDrag
+  SortableGridStrategyFactory
 } from './types';
 
 const Sortable = {

--- a/packages/react-native-sortables/src/providers/SharedProvider.tsx
+++ b/packages/react-native-sortables/src/providers/SharedProvider.tsx
@@ -40,7 +40,7 @@ type SharedProviderProps = PropsWithChildren<
   } & ActiveItemDecorationSettings &
     ActiveItemSnapSettings &
     PartialBy<AutoScrollSettings, 'scrollableRef'> &
-    Required<ItemDragSettings> &
+    Required<Omit<ItemDragSettings, 'reorderTriggerOrigin'>> &
     Required<SortableCallbacks>
 >;
 

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
@@ -34,7 +34,7 @@ type CommonValuesProviderProps = PropsWithChildren<
     initialItemsStyleOverride?: ViewStyle;
   } & ActiveItemDecorationSettings &
     ActiveItemSnapSettings &
-    Omit<ItemDragSettings, 'overDrag'>
+    Omit<ItemDragSettings, 'overDrag' | 'reorderTriggerOrigin'>
 >;
 
 const { CommonValuesProvider, useCommonValuesContext } = createProvider(

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
@@ -13,7 +13,6 @@ import {
   withTiming
 } from 'react-native-reanimated';
 
-import { useDebugContext } from '../../debug';
 import { useHaptics, useJSStableCallback } from '../../hooks';
 import type {
   DragContextType,
@@ -81,9 +80,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
   const { updateLayer } = useLayerContext() ?? {};
   const { scrollOffsetDiff, updateStartScrollOffset } =
     useAutoScrollContext() ?? {};
-  const debugContext = useDebugContext();
 
-  const debugCross = debugContext?.useDebugCross();
   const haptics = useHaptics(hapticsEnabled);
 
   const hasHorizontalOverDrag =
@@ -150,7 +147,6 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
         !startTouchPosition
       ) {
         touchPosition.value = null;
-        if (debugCross) debugCross.set({ position: null });
         return;
       }
 
@@ -158,13 +154,6 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
         x: startTouchPosition.x + (translation?.x ?? 0) + (offsetDiff?.x ?? 0),
         y: startTouchPosition.y + (translation?.y ?? 0) + (offsetDiff?.y ?? 0)
       };
-
-      if (debugCross) {
-        debugCross.set({
-          color: '#00007e',
-          position: touchPosition.value
-        });
-      }
 
       let tX = itemTouchOffset.x;
       let tY = itemTouchOffset.y;
@@ -425,7 +414,6 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
         prevActiveItemKey.value = activeItemKey.value;
         activeItemKey.value = null;
         updateLayer?.(LayerState.Intermediate);
-        debugCross?.set({ position: null });
         haptics.medium();
 
         stableOnDragEnd({
@@ -462,7 +450,6 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       activationTimeoutId,
       activeAnimationProgress,
       activationState,
-      debugCross,
       dropAnimationDuration,
       dragStartIndex,
       dragStartItemTouchOffset,

--- a/packages/react-native-sortables/src/providers/shared/components/OrderUpdaterComponent.tsx
+++ b/packages/react-native-sortables/src/providers/shared/components/OrderUpdaterComponent.tsx
@@ -23,6 +23,7 @@ export function useStrategyKey(strategy: AnyStrategyFactory | string) {
 function OrderUpdaterComponent<P extends PredefinedStrategies>({
   predefinedStrategies,
   strategy,
+  triggerOrigin,
   useAdditionalValues
 }: OrderUpdaterProps<P>) {
   const factory =
@@ -38,7 +39,7 @@ function OrderUpdaterComponent<P extends PredefinedStrategies>({
     ...useAdditionalValues()
   });
 
-  useOrderUpdater(updater);
+  useOrderUpdater(updater, triggerOrigin);
 
   return null;
 }

--- a/packages/react-native-sortables/src/providers/shared/hooks/useOrderUpdater.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useOrderUpdater.ts
@@ -1,27 +1,60 @@
 import { useAnimatedReaction } from 'react-native-reanimated';
 
-import type { OrderUpdater } from '../../../types';
+import type {
+  OrderUpdater,
+  ReorderTriggerOrigin,
+  Vector
+} from '../../../types';
 import { useCommonValuesContext } from '../CommonValuesProvider';
 import { useDragContext } from '../DragProvider';
 
-export default function useOrderUpdater(updater: OrderUpdater) {
-  const { activeItemDimensions, activeItemKey, keyToIndex, touchPosition } =
-    useCommonValuesContext();
+export default function useOrderUpdater(
+  updater: OrderUpdater,
+  triggerOrigin: ReorderTriggerOrigin
+) {
+  const {
+    activeItemDimensions,
+    activeItemKey,
+    activeItemPosition,
+    keyToIndex,
+    touchPosition
+  } = useCommonValuesContext();
   const { handleOrderChange } = useDragContext();
+
+  const isCenter = triggerOrigin === 'center';
 
   useAnimatedReaction(
     () => ({
       activeKey: activeItemKey.value,
       dimensions: activeItemDimensions.value,
-      position: touchPosition.value
+      positions: {
+        activeItem: activeItemPosition.value,
+        touch: touchPosition.value
+      }
     }),
-    ({ activeKey, dimensions, position }) => {
-      if (!activeKey || !dimensions || !position) {
+    ({ activeKey, dimensions, positions }) => {
+      if (
+        !activeKey ||
+        !dimensions ||
+        !positions.touch ||
+        !positions.activeItem
+      ) {
         return;
       }
+
       const activeIndex = keyToIndex.value[activeKey];
       if (activeIndex === undefined) {
         return;
+      }
+
+      let position: Vector;
+      if (isCenter) {
+        position = {
+          x: positions.activeItem.x + dimensions.width / 2,
+          y: positions.activeItem.y + dimensions.height / 2
+        };
+      } else {
+        position = positions.touch;
       }
 
       const newOrder = updater({

--- a/packages/react-native-sortables/src/providers/shared/hooks/useOrderUpdater.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useOrderUpdater.ts
@@ -1,5 +1,6 @@
 import { useAnimatedReaction } from 'react-native-reanimated';
 
+import { useDebugContext } from '../../../debug';
 import type {
   OrderUpdater,
   ReorderTriggerOrigin,
@@ -20,6 +21,9 @@ export default function useOrderUpdater(
     touchPosition
   } = useCommonValuesContext();
   const { handleOrderChange } = useDragContext();
+  const debugContext = useDebugContext();
+
+  const debugCross = debugContext?.useDebugCross();
 
   const isCenter = triggerOrigin === 'center';
 
@@ -39,6 +43,7 @@ export default function useOrderUpdater(
         !positions.touch ||
         !positions.activeItem
       ) {
+        if (debugCross) debugCross.set({ position: null });
         return;
       }
 
@@ -55,6 +60,10 @@ export default function useOrderUpdater(
         };
       } else {
         position = positions.touch;
+      }
+
+      if (debugCross) {
+        debugCross.set({ color: '#00007e', position });
       }
 
       const newOrder = updater({

--- a/packages/react-native-sortables/src/types/props/shared.ts
+++ b/packages/react-native-sortables/src/types/props/shared.ts
@@ -25,9 +25,11 @@ export type ActiveItemDecorationSettings = AnimatableProps<{
 
 export type Offset = `${number}%` | number;
 export type OverDrag = 'both' | 'horizontal' | 'none' | 'vertical';
+export type ReorderTriggerOrigin = 'center' | 'touch';
 
 export type ItemDragSettings = {
   overDrag: OverDrag;
+  reorderTriggerOrigin: ReorderTriggerOrigin;
 } & AnimatableProps<{
   dragActivationDelay: number;
   activationAnimationDuration: number;

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -12,7 +12,8 @@ import type { Dimensions, Vector } from '../layout/shared';
 import type {
   ActiveItemDecorationSettings,
   ActiveItemSnapSettings,
-  ItemDragSettings
+  ItemDragSettings,
+  ReorderTriggerOrigin
 } from '../props/shared';
 import type { DragActivationState } from '../state';
 import type { AnimatedValues, AnyRecord, Maybe } from '../utils';
@@ -65,7 +66,7 @@ export type CommonValuesContextType = {
   customHandle: boolean;
 } & AnimatedValues<ActiveItemDecorationSettings> &
   AnimatedValues<ActiveItemSnapSettings> &
-  AnimatedValues<Omit<ItemDragSettings, 'overDrag'>>;
+  AnimatedValues<Omit<ItemDragSettings, 'overDrag' | 'reorderTriggerOrigin'>>;
 
 // MEASUREMENTS
 
@@ -169,5 +170,6 @@ export type OrderUpdaterProps<
 > = {
   predefinedStrategies: P;
   strategy: AnyStrategyFactory | keyof P;
+  triggerOrigin: ReorderTriggerOrigin;
   useAdditionalValues: () => AnyRecord;
 };


### PR DESCRIPTION
## Description

This PR adds a possibility to customize the reorder trigger origin (i.e. the location of the point that will trigger order change).

It now makes it possible to choose between the `center` and the `touch` location and replaces the previous default `touch` location by the `center` location which seems more intuitive.

## Example recordings

You can see the location of the `reorderTriggerOrigin` after enabling the debug mode with the `debug` property.

| `touch` (previous default) | `center` (current default) |
|-|-|
| <video src="https://github.com/user-attachments/assets/a6bb80da-f2d5-4413-9169-04e4e304c577" /> | <video src="https://github.com/user-attachments/assets/ec89614a-0821-4e23-8683-d9e42e44854f" /> |
