### PR TITLE
fix: Android crashes on gesture failure, horizontal scrollable issues

### DIFF
--- a/example/app/src/components/items/GridCard.tsx
+++ b/example/app/src/components/items/GridCard.tsx
@@ -20,14 +20,16 @@ export default function GridCard({
 }: GridCardProps) {
   return (
     <View
-      style={[
+      // Need to flatten the style manually as something broke in react native
+      // 0.78 and properties specified later on don't override previous ones
+      style={StyleSheet.flatten([
         styles.card,
         active && styles.activeCard,
         height !== undefined || width !== undefined
           ? { aspectRatio: 'auto', height, width }
           : {},
         style
-      ]}>
+      ])}>
       {typeof children === 'string' ? (
         <Text style={styles.text}>{children}</Text>
       ) : (

--- a/example/app/src/examples/SortableGrid/features/HorizontalAutoScrollExample.tsx
+++ b/example/app/src/examples/SortableGrid/features/HorizontalAutoScrollExample.tsx
@@ -130,7 +130,7 @@ function VerticalSameSizeItems() {
   );
   return (
     <>
-      <Text style={styles.subTitle}>Same width items</Text>
+      <Text style={styles.subTitle}>Same height items</Text>
       <Animated.ScrollView
         contentContainerStyle={styles.container}
         ref={scrollableRef}

--- a/example/app/src/examples/SortableGrid/features/HorizontalAutoScrollExample.tsx
+++ b/example/app/src/examples/SortableGrid/features/HorizontalAutoScrollExample.tsx
@@ -8,12 +8,10 @@ import { GridCard, Group, ScrollScreen, Section } from '@/components';
 import { IS_WEB, MAX_CONTENT_WIDTH } from '@/constants';
 import { spacing, text } from '@/theme';
 
-const DATA = Array.from({ length: 2 }, (_, index) => `Item ${index + 1}`);
+const DATA = Array.from({ length: 18 }, (_, index) => `Item ${index + 1}`);
 
 // Horizontal grid
-const ROWS = 1;
-
-// Horizontal grid
+const ROWS = 3;
 const ROW_HEIGHT = 75;
 
 // Vertical grid

--- a/example/app/src/examples/SortableGrid/features/HorizontalAutoScrollExample.tsx
+++ b/example/app/src/examples/SortableGrid/features/HorizontalAutoScrollExample.tsx
@@ -8,10 +8,12 @@ import { GridCard, Group, ScrollScreen, Section } from '@/components';
 import { IS_WEB, MAX_CONTENT_WIDTH } from '@/constants';
 import { spacing, text } from '@/theme';
 
-const DATA = Array.from({ length: 18 }, (_, index) => `Item ${index + 1}`);
+const DATA = Array.from({ length: 2 }, (_, index) => `Item ${index + 1}`);
 
 // Horizontal grid
-const ROWS = 3;
+const ROWS = 1;
+
+// Horizontal grid
 const ROW_HEIGHT = 75;
 
 // Vertical grid
@@ -130,7 +132,7 @@ function VerticalSameSizeItems() {
   );
   return (
     <>
-      <Text style={styles.subTitle}>Different width items</Text>
+      <Text style={styles.subTitle}>Same width items</Text>
       <Animated.ScrollView
         contentContainerStyle={styles.container}
         ref={scrollableRef}

--- a/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
@@ -103,8 +103,8 @@ export default function SortableContainer({
     const ctrl = controlledContainerDimensions.value;
 
     return {
-      minHeight: ctrl.height ? containerHeight.value : undefined,
-      minWidth: ctrl.width ? containerWidth.value : undefined
+      height: ctrl.height ? containerHeight.value : undefined,
+      width: ctrl.width ? containerWidth.value : undefined
     };
   });
 

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.tsx
@@ -335,7 +335,6 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       // e.g. while scrolling the ScrollView
       activationTimeoutId.value = setAnimatedTimeout(() => {
         if (!canSwitchToAbsoluteLayout.value) {
-          fail();
           return;
         }
         activate();


### PR DESCRIPTION
## Description

Fixes problems described in the #291 issue

It also fixes broken grid card width after the RN upgrade (seems to be a RN style flattening issue).

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/c5e0a96a-2cdc-465c-a8e6-dae70b3054f0" /> | <video src="https://github.com/user-attachments/assets/5414a2a0-a6ec-40a3-aca3-520f0afacab9" /> |
