### PR TITLE
fix: Default keyExtractor behavior for numeric values

### DIFF
--- a/packages/docs/docs/grid/props.mdx
+++ b/packages/docs/docs/grid/props.mdx
@@ -60,9 +60,9 @@ type SortableGridRenderItemInfo<T> = {
 
 Used to extract a unique key for each item. Key is used for the identification of the item when items are reordered.
 
-| type                                 | default | required |
-| ------------------------------------ | ------- | -------- |
-| `(item: T, index: number) => string` | YES\*   | NO       |
+| type                  | default | required |
+| --------------------- | ------- | -------- |
+| `(item: T) => string` | YES\*   | NO       |
 
 \*Default `keyExtractor` implementation works as follows:
 

--- a/packages/docs/docs/grid/props.mdx
+++ b/packages/docs/docs/grid/props.mdx
@@ -64,11 +64,14 @@ Used to extract a unique key for each item. Key is used for the identification o
 | ------------------------------------ | ------- | -------- |
 | `(item: T, index: number) => string` | YES\*   | NO       |
 
-\*Default `keyExtractor` implementation returns item if it is a string, `id` or `key` property if the item is an object and has one of those properties or stringified item in all other cases.
+\*Default `keyExtractor` implementation works as follows:
+
+- If item is an object and has `id` or `key` property, the value of that property is returned
+- Otherwise, item is stringified and returned (inefficient for large objects, a custom `keyExtractor` implementation is recommended)
 
 :::important
 
-If your data items are **objects** that have neither `id` nor `key` properties, you **should always** provide a custom `keyExtractor` implementation.
+If your data items are **objects** that have neither `id` nor `key` properties, it is **strongly recommended** to provide a custom `keyExtractor` implementation returning a unique string for each item.
 
 :::
 

--- a/packages/react-native-sortables/src/components/SortableGrid.tsx
+++ b/packages/react-native-sortables/src/components/SortableGrid.tsx
@@ -77,10 +77,7 @@ function SortableGrid<I>(props: SortableGridProps<I>) {
     width: !isVertical // width is controlled for horizontal grids
   }));
 
-  const itemKeys = useMemo(
-    () => data.map(item => keyExtractor(item)),
-    [data, keyExtractor]
-  );
+  const itemKeys = useMemo(() => data.map(keyExtractor), [data, keyExtractor]);
 
   const onDragEnd = useDragEndHandler(_onDragEnd, params => ({
     ...params,

--- a/packages/react-native-sortables/src/components/SortableGrid.tsx
+++ b/packages/react-native-sortables/src/components/SortableGrid.tsx
@@ -78,7 +78,7 @@ function SortableGrid<I>(props: SortableGridProps<I>) {
   }));
 
   const itemKeys = useMemo(
-    () => data.map((item, index) => keyExtractor(item, index)),
+    () => data.map(item => keyExtractor(item)),
     [data, keyExtractor]
   );
 

--- a/packages/react-native-sortables/src/types/props/grid.ts
+++ b/packages/react-native-sortables/src/types/props/grid.ts
@@ -99,16 +99,14 @@ export type SortableGridProps<I> = Simplify<
     onDragEnd?: SortableGridDragEndCallback<I>;
     /** Function to extract a unique key for each item
      * @param item The item to get key from
-     * @param index Index of the item in the data array
      * @returns Unique string key
      * @default Returns:
-     * - the item itself if it's a string
-     * - item.id or item.key if the object has either property
-     * - stringified item otherwise
+     * - If item is an object with id or key property, returns that property value
+     * - Otherwise returns stringified item (inefficient for large objects, custom implementation recommended)
      * @important If your data items are objects that have neither id nor key properties,
-     * it is recommended to provide a custom keyExtractor implementation.
+     * it is strongly recommended to provide a custom keyExtractor implementation.
      */
-    keyExtractor?: (item: I, index: number) => string;
+    keyExtractor?: (item: I) => string;
 
     /** Number of columns in the grid.
      *

--- a/packages/react-native-sortables/src/utils/keys.ts
+++ b/packages/react-native-sortables/src/utils/keys.ts
@@ -5,11 +5,7 @@ const hasProp = <O extends object, P extends string>(
   return prop in object;
 };
 
-export const defaultKeyExtractor = <I>(item: I, index: number): string => {
-  if (typeof item === 'string') {
-    return item;
-  }
-
+export const defaultKeyExtractor = <I>(item: I): string => {
   if (typeof item === 'object' && item !== null) {
     if (hasProp(item, 'id')) {
       return String(item.id);
@@ -19,5 +15,5 @@ export const defaultKeyExtractor = <I>(item: I, index: number): string => {
     }
   }
 
-  return String(index);
+  return String(item);
 };


### PR DESCRIPTION
## Description

Just a small fix for incorrect behavior when numeric values were passed. I incorrectly used the item index as a key, which caused layout flickering after items were reordred and rendered them in wrong positions.