### PR TITLE
feat: Add sortableKeys and defaultSortableExtractor for enhanced item sorting functionality

### DIFF
--- a/example/app/src/examples/SortableGrid/features/NonSortablesExample.tsx
+++ b/example/app/src/examples/SortableGrid/features/NonSortablesExample.tsx
@@ -1,0 +1,228 @@
+import { memo, useCallback, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Animated, { useAnimatedRef } from 'react-native-reanimated';
+import Sortable, { type SortableGridRenderItem } from 'react-native-sortables';
+
+import {
+  Button,
+  GridCard,
+  Group,
+  Screen,
+  Section,
+  Stagger
+} from '@/components';
+import { IS_WEB } from '@/constants';
+import { colors, flex, spacing, text } from '@/theme';
+import { getItems } from '@/utils';
+
+type ItemType = {
+  key: number;
+  value: string;
+  sortable: boolean;
+};
+
+const AVAILABLE_DATA: Array<ItemType> = getItems(18).map((item, index) => {
+  return {
+    key: index,
+    sortable: index % 5 !== 0,
+    value: item
+  };
+});
+const COLUMNS = 4;
+
+export default function NonSortablesExample() {
+  const scrollableRef = useAnimatedRef<Animated.ScrollView>();
+  const [data, setData] = useState<Array<ItemType>>(
+    AVAILABLE_DATA.slice(0, 12)
+  );
+
+  const getNewItem = useCallback((currentData: Array<ItemType>) => {
+    if (currentData.length >= AVAILABLE_DATA.length) {
+      return null;
+    }
+    for (const item of AVAILABLE_DATA) {
+      if (
+        currentData.filter(dataItem => dataItem.key === item.key).length === 0
+      ) {
+        return item;
+      }
+    }
+    return null;
+  }, []);
+
+  const prependItem = useCallback(() => {
+    setData(prevData => {
+      const newItem = getNewItem(prevData);
+      if (newItem) {
+        return [newItem, ...prevData];
+      }
+      return prevData;
+    });
+  }, [getNewItem]);
+
+  const insertItem = useCallback(() => {
+    setData(prevData => {
+      const newItem = getNewItem(prevData);
+
+      if (newItem) {
+        const index = Math.floor(Math.random() * (prevData.length - 1));
+        return [...prevData.slice(0, index), newItem, ...prevData.slice(index)];
+      }
+      return prevData;
+    });
+  }, [getNewItem]);
+
+  const appendItem = useCallback(() => {
+    setData(prevData => {
+      const newItem = getNewItem(prevData);
+      if (newItem) {
+        return [...prevData, newItem];
+      }
+      return prevData;
+    });
+  }, [getNewItem]);
+
+  const shuffleItems = useCallback(() => {
+    setData(prevData => {
+      const shuffledData = [...prevData];
+      for (let i = shuffledData.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [shuffledData[i], shuffledData[j]] = [
+          shuffledData[j]!,
+          shuffledData[i]!
+        ];
+      }
+      return shuffledData;
+    });
+  }, []);
+
+  const sortItems = useCallback(() => {
+    setData(prevData =>
+      [...prevData].sort(
+        (a, b) => +a.value.split(' ')[1]! - +b.value.split(' ')[1]!
+      )
+    );
+  }, []);
+
+  const onRemoveItem = useCallback((item: string) => {
+    setData(prevData => prevData.filter(i => i.value !== item));
+  }, []);
+
+  const renderItem = useCallback<SortableGridRenderItem<ItemType>>(
+    ({ item }) => <GridItem item={item} onRemoveItem={onRemoveItem} />,
+    [onRemoveItem]
+  );
+
+  const additionDisabled = data.length >= AVAILABLE_DATA.length;
+  const reorderDisabled = data.length < 2;
+
+  const menuSections = [
+    {
+      buttons: [
+        { disabled: additionDisabled, onPress: prependItem, title: 'Prepend' },
+        { disabled: additionDisabled, onPress: insertItem, title: 'Insert' },
+        { disabled: additionDisabled, onPress: appendItem, title: 'Append' }
+      ],
+      description: 'Prepend/Insert/Append items to the list',
+      title: 'Modify number of items'
+    },
+    {
+      buttons: [
+        { disabled: reorderDisabled, onPress: shuffleItems, title: 'Shuffle' },
+        { disabled: reorderDisabled, onPress: sortItems, title: 'Sort' }
+      ],
+      description: 'Reorder items in the list',
+      title: 'Change order of items'
+    }
+  ];
+
+  return (
+    <Screen includeNavBarHeight>
+      {/* Need to set flex: 1 for the ScrollView parent component in order
+      // to ensure that it occupies the entire available space */}
+      <Stagger
+        wrapperStye={index =>
+          index === 2 ? (IS_WEB ? flex.shrink : flex.fill) : {}
+        }>
+        {menuSections.map(({ buttons, description, title }) => (
+          <Section description={description} key={title} title={title}>
+            <View style={styles.row}>
+              {buttons.map(btnProps => (
+                <Button {...btnProps} key={btnProps.title} />
+              ))}
+            </View>
+          </Section>
+        ))}
+
+        <Group padding='none' style={[flex.fill, styles.scrollViewGroup]}>
+          <Animated.ScrollView
+            contentContainerStyle={styles.scrollViewContent}
+            ref={scrollableRef}
+            // @ts-expect-error - overflowY is needed for proper behavior on web
+            style={[flex.fill, IS_WEB && { overflowY: 'scroll' }]}>
+            <Group withMargin={false} bordered center>
+              <Text style={styles.title}>Above SortableGrid</Text>
+            </Group>
+
+            <Sortable.Grid<ItemType>
+              columnGap={spacing.sm}
+              columns={COLUMNS}
+              data={data}
+              renderItem={renderItem}
+              rowGap={spacing.xs}
+              scrollableRef={scrollableRef}
+              animateHeight
+              hapticsEnabled
+              onDragEnd={({ data: newData }) => setData(newData)}
+            />
+
+            <Group withMargin={false} bordered center>
+              <Text style={styles.title}>Below SortableGrid</Text>
+            </Group>
+          </Animated.ScrollView>
+        </Group>
+      </Stagger>
+    </Screen>
+  );
+}
+
+type GridItemProps = {
+  item: ItemType;
+  onRemoveItem: (item: string) => void;
+};
+
+// It is recommended to use memo for items to prevent re-renders of the entire grid
+// on item order changes (renderItem takes and index argument, thus it must be called
+// after every order change)
+const GridItem = memo(function GridItem({ item, onRemoveItem }: GridItemProps) {
+  return (
+    <Sortable.Pressable onPress={onRemoveItem.bind(null, item.value)}>
+      <GridCard
+        style={{ ...(!item.sortable ? { backgroundColor: '#c2c2c2' } : {}) }}>
+        {item.value}
+      </GridCard>
+    </Sortable.Pressable>
+  );
+});
+
+const styles = StyleSheet.create({
+  row: {
+    columnGap: spacing.sm,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    rowGap: spacing.xs
+  },
+  scrollViewContent: {
+    gap: spacing.sm,
+    padding: spacing.sm
+  },
+  scrollViewGroup: {
+    overflow: 'hidden',
+    paddingHorizontal: spacing.none,
+    paddingVertical: spacing.none
+  },
+  title: {
+    ...text.subHeading2,
+    color: colors.foreground3
+  }
+});

--- a/example/app/src/examples/SortableGrid/features/index.ts
+++ b/example/app/src/examples/SortableGrid/features/index.ts
@@ -6,4 +6,5 @@ export { default as DifferentSizeItems } from './DifferentSizeItems';
 export { default as DragHandleExample } from './DragHandleExample';
 export { default as DropIndicatorExample } from './DropIndicatorExample';
 export { default as HorizontalAutoScrollExample } from './HorizontalAutoScrollExample';
+export { default as NonSortablesExample } from './NonSortablesExample';
 export { default as OrderingStrategyExample } from './OrderingStrategyExample';

--- a/example/app/src/examples/navigation/routes.ts
+++ b/example/app/src/examples/navigation/routes.ts
@@ -4,6 +4,7 @@ import { IS_WEB } from '@/constants';
 import * as SortableFlex from '@/examples/SortableFlex';
 import * as SortableGrid from '@/examples/SortableGrid';
 
+import { NonSortablesExample } from '../SortableGrid/features';
 import type { Routes } from './types';
 
 const routes: Routes = {
@@ -30,6 +31,10 @@ const routes: Routes = {
           DataChange: {
             Component: SortableGrid.features.DataChangeExample,
             name: 'Data Change'
+          },
+          NonSortablesExample: {
+            Component: NonSortablesExample,
+            name: 'Non Sortables'
           },
           DifferentSizeItems: {
             Component: SortableGrid.features.DifferentSizeItems,

--- a/packages/react-native-sortables/src/components/SortableFlex.tsx
+++ b/packages/react-native-sortables/src/components/SortableFlex.tsx
@@ -67,6 +67,7 @@ function SortableFlex(props: SortableFlexProps) {
       controlledContainerDimensions={controlledContainerDimensions}
       initialItemsStyleOverride={styles.styleOverride}
       itemKeys={itemKeys}
+      sortableKeys={itemKeys}
       onDragEnd={onDragEnd}>
       <FlexLayoutProvider {...styleProps} itemsCount={itemKeys.length}>
         <OrderUpdaterComponent

--- a/packages/react-native-sortables/src/components/SortableGrid.tsx
+++ b/packages/react-native-sortables/src/components/SortableGrid.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from 'react';
 import { StyleSheet } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
-import { useAnimatedStyle, useDerivedValue } from 'react-native-reanimated';
+import {
+  useAnimatedStyle,
+  useDerivedValue
+} from 'react-native-reanimated';
 
 import { DEFAULT_SORTABLE_GRID_PROPS } from '../constants';
 import { useAnimatableValue, useDragEndHandler } from '../hooks';
@@ -10,6 +13,7 @@ import {
   GridLayoutProvider,
   OrderUpdaterComponent,
   SharedProvider,
+  useCommonValuesContext,
   useGridLayoutContext,
   useStrategyKey
 } from '../providers';
@@ -135,7 +139,6 @@ function SortableGrid<I>(props: SortableGridProps<I>) {
           rowGap={rowGapValue}
           rowHeight={rowHeight!} // must be specified for horizontal grids
           showDropIndicator={showDropIndicator}
-          sortableKeys={sortableKeys}
         />
       </GridLayoutProvider>
     </SharedProvider>
@@ -144,7 +147,6 @@ function SortableGrid<I>(props: SortableGridProps<I>) {
 
 type SortableGridInnerProps<I> = {
   itemKeys: Array<string>;
-  sortableKeys: Array<string>;
   rowGap: SharedValue<number>;
   columnGap: SharedValue<number>;
   groups: number;
@@ -177,7 +179,6 @@ function SortableGridInner<I>({
   renderItem,
   rowGap,
   rowHeight,
-  sortableKeys,
   ...containerProps
 }: SortableGridInnerProps<I>) {
   const animatedInnerStyle = useAnimatedStyle(() => ({
@@ -186,6 +187,8 @@ function SortableGridInner<I>({
     marginHorizontal: -columnGap.value / 2,
     marginVertical: -rowGap.value / 2
   }));
+
+  const { sortableKeys } = useCommonValuesContext();
 
   const animatedItemStyle = useAnimatedStyle(() => ({
     flexBasis: `${100 / groups}%`,
@@ -226,7 +229,7 @@ function SortableGridItem<I>({
   index,
   item,
   renderItem,
-  sortable = true,
+  sortable,
   ...rest
 }: SortableGridItemProps<I>) {
   const children = useMemo(

--- a/packages/react-native-sortables/src/components/shared/DropIndicator.tsx
+++ b/packages/react-native-sortables/src/components/shared/DropIndicator.tsx
@@ -36,11 +36,8 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
     indexToKey,
     itemDimensions,
     itemPositions,
-    keyToIndex,
-    sortableKeys
+    keyToIndex
   } = useCommonValuesContext();
-
-  console.log(sortableKeys);
 
   // Clone the array in order to prevent user from mutating the internal state
   const orderedItemKeys = useDerivedValue(() => [...indexToKey.value]);
@@ -58,20 +55,15 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
       dropped: activeItemDropped.value,
       kToI: keyToIndex.value,
       key: activeItemKey.value,
-      positions: itemPositions.value,
-      sortableKeys: sortableKeys
+      positions: itemPositions.value
     }),
-    ({ dropped, kToI, key, positions, sortableKeys }) => {
-      if (sortableKeys.includes(key ?? '')) {
+    ({ dropped, kToI, key, positions }) => {
         if (key !== null) {
           dropIndex.value = kToI[key] ?? 0;
           dropPosition.value = positions[key] ?? { x: 0, y: 0 };
           dimensions.value = itemDimensions.value[key] ?? null;
 
-          const update = (
-            target: SharedValue<null | number>,
-            value: number
-          ) => {
+        const update = (target: SharedValue<null | number>, value: number) => {
             if (target.value === null || prevUpdateItemKey.value === null) {
               target.value = value;
             } else {
@@ -89,7 +81,6 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
         }
         prevUpdateItemKey.value = key;
       }
-    }
   );
 
   const animatedStyle = useAnimatedStyle(() => {

--- a/packages/react-native-sortables/src/components/shared/DropIndicator.tsx
+++ b/packages/react-native-sortables/src/components/shared/DropIndicator.tsx
@@ -36,8 +36,11 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
     indexToKey,
     itemDimensions,
     itemPositions,
-    keyToIndex
+    keyToIndex,
+    sortableKeys
   } = useCommonValuesContext();
+
+  console.log(sortableKeys);
 
   // Clone the array in order to prevent user from mutating the internal state
   const orderedItemKeys = useDerivedValue(() => [...indexToKey.value]);
@@ -55,31 +58,37 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
       dropped: activeItemDropped.value,
       kToI: keyToIndex.value,
       key: activeItemKey.value,
-      positions: itemPositions.value
+      positions: itemPositions.value,
+      sortableKeys: sortableKeys
     }),
-    ({ dropped, kToI, key, positions }) => {
-      if (key !== null) {
-        dropIndex.value = kToI[key] ?? 0;
-        dropPosition.value = positions[key] ?? { x: 0, y: 0 };
-        dimensions.value = itemDimensions.value[key] ?? null;
+    ({ dropped, kToI, key, positions, sortableKeys }) => {
+      if (sortableKeys.includes(key ?? '')) {
+        if (key !== null) {
+          dropIndex.value = kToI[key] ?? 0;
+          dropPosition.value = positions[key] ?? { x: 0, y: 0 };
+          dimensions.value = itemDimensions.value[key] ?? null;
 
-        const update = (target: SharedValue<null | number>, value: number) => {
-          if (target.value === null || prevUpdateItemKey.value === null) {
-            target.value = value;
-          } else {
-            target.value = withTiming(value, {
-              easing: Easing.out(Easing.ease)
-            });
-          }
-        };
+          const update = (
+            target: SharedValue<null | number>,
+            value: number
+          ) => {
+            if (target.value === null || prevUpdateItemKey.value === null) {
+              target.value = value;
+            } else {
+              target.value = withTiming(value, {
+                easing: Easing.out(Easing.ease)
+              });
+            }
+          };
 
-        update(x, dropPosition.value.x);
-        update(y, dropPosition.value.y);
-      } else if (dropped) {
-        x.value = null;
-        y.value = null;
+          update(x, dropPosition.value.x);
+          update(y, dropPosition.value.y);
+        } else if (dropped) {
+          x.value = null;
+          y.value = null;
+        }
+        prevUpdateItemKey.value = key;
       }
-      prevUpdateItemKey.value = key;
     }
   );
 

--- a/packages/react-native-sortables/src/components/shared/NonDraggableView.tsx
+++ b/packages/react-native-sortables/src/components/shared/NonDraggableView.tsx
@@ -1,0 +1,76 @@
+import { memo, useEffect } from 'react';
+import type { ViewProps } from 'react-native';
+import Animated, {
+  useDerivedValue,
+  useSharedValue
+} from 'react-native-reanimated';
+
+import { IS_WEB } from '../../constants';
+import {
+  ItemContextProvider,
+  useItemLayoutStyles,
+  useMeasurementsContext
+} from '../../providers';
+import type { LayoutTransition } from '../../types';
+import ItemDecoration from './ItemDecoration';
+
+type NonDraggableViewProps = {
+  itemKey: string;
+  layout: LayoutTransition | undefined;
+} & ViewProps;
+
+function NonDraggableView({
+  children,
+  itemKey: key,
+  layout,
+  style,
+  ...viewProps
+}: NonDraggableViewProps) {
+  const { handleItemMeasurement, handleItemRemoval } = useMeasurementsContext();
+
+  const activationAnimationProgress = useSharedValue(0);
+  const isActive = useDerivedValue(() => false);
+  const layoutStyles = useItemLayoutStyles(key, activationAnimationProgress);
+
+  useEffect(() => {
+    return () => handleItemRemoval(key);
+  }, [key, handleItemRemoval]);
+
+  const innerComponent = (
+    <ItemDecoration
+      activationAnimationProgress={activationAnimationProgress}
+      isActive={isActive}
+      itemKey={key}
+      // Keep onLayout the closest to the children to measure the real item size
+      // (without paddings or other style changes made to the wrapper component)
+      pointerEvents='none'
+      onLayout={({
+        nativeEvent: {
+          layout: { height, width }
+        }
+      }) => {
+        handleItemMeasurement(key, {
+          height,
+          width
+        });
+      }}>
+      {children}
+    </ItemDecoration>
+  );
+
+  return (
+    <Animated.View
+      {...viewProps}
+      layout={IS_WEB ? undefined : layout}
+      style={[style, layoutStyles]}>
+      <ItemContextProvider
+        activationAnimationProgress={activationAnimationProgress}
+        isActive={isActive}
+        itemKey={key}>
+        <Animated.View>{innerComponent}</Animated.View>
+      </ItemContextProvider>
+    </Animated.View>
+  );
+}
+
+export default memo(NonDraggableView);

--- a/packages/react-native-sortables/src/constants/props.ts
+++ b/packages/react-native-sortables/src/constants/props.ts
@@ -9,7 +9,7 @@ import type {
   SortableFlexProps,
   SortableGridProps
 } from '../types';
-import { defaultKeyExtractor } from '../utils/keys';
+import { defaultKeyExtractor, defaultSortableExtractor } from '../utils/keys';
 import { SortableItemEntering, SortableItemExiting } from './layoutAnimations';
 import { IS_WEB } from './platform';
 
@@ -88,6 +88,7 @@ export const DEFAULT_SORTABLE_GRID_PROPS = {
   columns: 1,
   keyExtractor: defaultKeyExtractor,
   rowGap: 0,
+  sortableExtractor: defaultSortableExtractor,
   strategy: 'insert'
 } satisfies DefaultSortableGridProps;
 

--- a/packages/react-native-sortables/src/providers/SharedProvider.tsx
+++ b/packages/react-native-sortables/src/providers/SharedProvider.tsx
@@ -30,6 +30,7 @@ import { ContextProviderComposer } from './utils';
 type SharedProviderProps = PropsWithChildren<
   {
     itemKeys: Array<string>;
+    sortableKeys?: Array<string>;
     sortEnabled: Animatable<boolean>;
     hapticsEnabled: boolean;
     customHandle: boolean;

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.tsx
@@ -33,6 +33,7 @@ type CommonValuesProviderProps = PropsWithChildren<
     controlledContainerDimensions: SharedValue<ControlledContainerDimensions>;
     itemsLayoutTransitionMode: ItemsLayoutTransitionMode;
     initialItemsStyleOverride?: ViewStyle;
+    sortableKeys?: Array<string>;
   } & ActiveItemDecorationSettings &
     ActiveItemSnapSettings &
     Omit<ItemDragSettings, 'overDrag' | 'reorderTriggerOrigin'>
@@ -58,7 +59,8 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
   itemsLayoutTransitionMode,
   snapOffsetX: _snapOffsetX,
   snapOffsetY: _snapOffsetY,
-  sortEnabled: _sortEnabled
+  sortEnabled: _sortEnabled,
+  sortableKeys = itemKeys
 }) => {
   const prevKeysRef = useRef<Array<string>>([]);
 
@@ -184,6 +186,7 @@ const { CommonValuesProvider, useCommonValuesContext } = createProvider(
       snapOffsetX,
       snapOffsetY,
       sortEnabled,
+      sortableKeys,
       touchPosition
     }
   };

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
@@ -38,7 +38,8 @@ export default function useItemLayoutStyles(
     animateLayoutOnReorderOnly,
     canSwitchToAbsoluteLayout,
     dropAnimationDuration,
-    itemPositions
+    itemPositions,
+    sortableKeys
   } = useCommonValuesContext();
 
   const zIndex = useItemZIndex(key, activationAnimationProgress);
@@ -57,7 +58,7 @@ export default function useItemLayoutStyles(
     () => ({
       canSwitchToAbsolute: canSwitchToAbsoluteLayout.value,
       hasProgress: hasActivationProgress.value,
-      isActive: activeItemKey.value === key,
+      isActive: activeItemKey.value === key && sortableKeys.includes(key),
       position: itemPositions.value[key]
     }),
     ({ canSwitchToAbsolute, hasProgress, isActive, position }) => {
@@ -122,7 +123,7 @@ export default function useItemLayoutStyles(
   // Active item updater
   useAnimatedReaction(
     () => ({
-      isActive: activeItemKey.value === key,
+      isActive: activeItemKey.value === key && sortableKeys.includes(key),
       position: activeItemPosition.value
     }),
     ({ isActive, position }) => {

--- a/packages/react-native-sortables/src/types/props/grid.ts
+++ b/packages/react-native-sortables/src/types/props/grid.ts
@@ -108,6 +108,15 @@ export type SortableGridProps<I> = Simplify<
      */
     keyExtractor?: (item: I) => string;
 
+    /** Function to extract a sortable property for each item
+     * @param item The item to get sortable property from
+     * @returns Boolean value indicating whether the item is sortable
+     * @default Returns:
+     * - If item is an object with sortable property, returns that property value
+     * - Otherwise returns true
+     */
+    sortableExtractor?: (item: I) => boolean;
+
     /** Number of columns in the grid.
      *
      * Used to create a vertical grid layout where items flow from top to bottom,

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -35,6 +35,7 @@ export type CommonValuesContextType = {
   // ORDER
   indexToKey: SharedValue<Array<string>>;
   keyToIndex: SharedValue<Record<string, number>>;
+  sortableKeys: Array<string>;
 
   // POSITIONS
   itemPositions: SharedValue<Record<string, Vector>>;

--- a/packages/react-native-sortables/src/utils/keys.ts
+++ b/packages/react-native-sortables/src/utils/keys.ts
@@ -17,3 +17,12 @@ export const defaultKeyExtractor = <I>(item: I): string => {
 
   return String(item);
 };
+
+export const defaultSortableExtractor = <I>(item: I): boolean => {
+  if (typeof item === 'object' && item !== null) {
+    if (hasProp(item, 'sortable')) {
+      return Boolean(item.sortable);
+    }
+  }
+  return true;
+};


### PR DESCRIPTION
Fixes #304 

# Description

This PR adds a `sortable` property to the Item type which will be used internally to calculate the `sortableKeys`, which will eventually disallow some items on the list to change their positions on the list. 

It was initially designed to become a "plus" indicator which stays appended to all items on the grid, but turned out to be another feature for the plugin :) 

It also adds an example page on the simulator to show it's effects, which looks like: 


https://github.com/user-attachments/assets/89519b06-c489-40b9-876d-6f668e17cf39

