### PR TITLE
fix: onPress not working after disabling drag

### DIFF
--- a/packages/react-native-sortables/src/components/shared/createSortableTouchable.tsx
+++ b/packages/react-native-sortables/src/components/shared/createSortableTouchable.tsx
@@ -1,5 +1,4 @@
 import { type ComponentType, useCallback } from 'react';
-import { useAnimatedReaction, useSharedValue } from 'react-native-reanimated';
 
 import { useCommonValuesContext } from '../../providers';
 import type { AnyFunction, Maybe } from '../../types';
@@ -46,32 +45,15 @@ export default function createSortableTouchable<P extends AnyPressHandlers>(
 ): ComponentType<P> {
   function Wrapper({ onPress, ...rest }: P) {
     const { activationState } = useCommonValuesContext();
-    const isCancelled = useSharedValue(false);
-
-    useAnimatedReaction(
-      () => ({
-        dragState: activationState.value
-      }),
-      ({ dragState }) => {
-        // Cancels when the item is active
-        if (dragState === DragActivationState.ACTIVE) {
-          isCancelled.value = true;
-        }
-        // Resets state when the item is touched again
-        else if (dragState === DragActivationState.TOUCHED) {
-          isCancelled.value = false;
-        }
-      }
-    );
 
     const handlePress = useCallback(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (...args: Array<any>) => {
-        if (isCancelled.value) return;
+        if (activationState.value !== DragActivationState.INACTIVE) return;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         onPress?.(...args);
       },
-      [isCancelled, onPress]
+      [activationState, onPress]
     );
 
     return <Component {...(rest as P)} onPress={handlePress} />;


### PR DESCRIPTION
## Description

Fixes #306 

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/2957ce00-a85d-497a-9ea9-dee859a302b0" /> | <video src="https://github.com/user-attachments/assets/bbdd5de9-6fb9-4a7a-aa9b-0cda3a688255" /> |

<details>
 <summary>Code snippet</summary>

```tsx
import { useMemo, useState } from 'react';
import { Button } from 'react-native';
import Sortable from 'react-native-sortables';

export default function BadGrid() {
  const [isSelecting, setIsSelecting] = useState(false);

  const data = useMemo(() => new Array(20).fill(0).map((_, i) => i), []);

  console.log({ isSelecting });

  const renderItem = () => (
    <Sortable.TouchableOpacity
      style={{ backgroundColor: 'red', height: 64, width: 64 }}
      onPress={() => console.log('hello')}
    />
  );

  return (
    <>
      <Sortable.Grid
        columns={3}
        data={data}
        renderItem={renderItem}
        sortEnabled={!isSelecting}
      />
      <Button title='Press' onPress={() => setIsSelecting(!isSelecting)} />
    </>
  );
}
```
</details>