### PR TITLE
feat: Delayed absolute layout initialization before sorting is enabled for the first time

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,6 +13,7 @@ module.exports = {
         allowObjectStart: true,
         allowArrayStart: true
       }
-    ]
+    ],
+    'perfectionist/sort-enums': 'off'
   }
 };

--- a/example/app/src/components/inputs/Button.tsx
+++ b/example/app/src/components/inputs/Button.tsx
@@ -1,10 +1,14 @@
 import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
 import { StyleSheet, Text, TouchableOpacity } from 'react-native';
+import Animated, { LinearTransition } from 'react-native-reanimated';
 
 import { colors, radius, spacing, text } from '@/theme';
 import { lighten } from '@/utils';
 
 type ButtonVariant = 'big' | 'small';
+
+const AnimatedTouchableOpacity =
+  Animated.createAnimatedComponent(TouchableOpacity);
 
 const VARIANT_STYLES: Record<
   ButtonVariant,
@@ -44,8 +48,9 @@ export default function Button({
   const variantStyles = VARIANT_STYLES[variant];
 
   return (
-    <TouchableOpacity
+    <AnimatedTouchableOpacity
       disabled={disabled}
+      layout={LinearTransition}
       style={[
         styles.button,
         disabled && styles.disabled,
@@ -53,8 +58,10 @@ export default function Button({
         style
       ]}
       onPress={onPress}>
-      <Text style={[styles.text, variantStyles.text]}>{title}</Text>
-    </TouchableOpacity>
+      <Text key={title} style={[styles.text, variantStyles.text]}>
+        {title}
+      </Text>
+    </AnimatedTouchableOpacity>
   );
 }
 

--- a/packages/react-native-sortables/src/components/shared/DraggableView/DraggableView.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/DraggableView.tsx
@@ -53,7 +53,7 @@ function DraggableView({
   const activationAnimationProgress = useSharedValue(0);
   const isActive = useDerivedValue(() => activeItemKey.value === key);
   const layoutStyles = useItemLayoutStyles(key, activationAnimationProgress);
-  const decorationStyle = useItemDecorationStyles(
+  const decorationStyles = useItemDecorationStyles(
     key,
     isActive,
     activationAnimationProgress
@@ -64,7 +64,7 @@ function DraggableView({
   }, [key, removeItemMeasurements]);
 
   const sharedCellProps = {
-    decorationStyle,
+    decorationStyles,
     handleItemMeasurement,
     itemKey: key,
     itemsOverridesStyle

--- a/packages/react-native-sortables/src/components/shared/DraggableView/ItemCell.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/ItemCell.tsx
@@ -13,7 +13,7 @@ import type {
 import AnimatedOnLayoutView from '../AnimatedOnLayoutView';
 
 export type ItemCellProps = PropsWithChildren<{
-  decorationStyle: AnimatedStyleProp;
+  decorationStyles: AnimatedStyleProp;
   itemsOverridesStyle: AnimatedStyle<ViewStyle>;
   cellStyle: AnimatedStyleProp;
   onMeasure: MeasureCallback;
@@ -26,7 +26,7 @@ export type ItemCellProps = PropsWithChildren<{
 export default function ItemCell({
   cellStyle,
   children,
-  decorationStyle,
+  decorationStyles,
   entering,
   exiting,
   itemStyle,
@@ -39,7 +39,7 @@ export default function ItemCell({
       <AnimatedOnLayoutView
         entering={entering}
         exiting={exiting}
-        style={[itemsOverridesStyle, decorationStyle, itemStyle]}
+        style={[itemsOverridesStyle, decorationStyles, itemStyle]}
         onLayout={({
           nativeEvent: {
             layout: { height, width }

--- a/packages/react-native-sortables/src/components/shared/DraggableView/TeleportedItemCell.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/TeleportedItemCell.tsx
@@ -21,7 +21,7 @@ export default function TeleportedItemCell({
   activationAnimationProgress,
   baseCellStyle,
   children,
-  decorationStyle,
+  decorationStyles,
   isActive,
   itemKey,
   itemsOverridesStyle,
@@ -39,7 +39,7 @@ export default function TeleportedItemCell({
   return (
     <ItemCell
       cellStyle={[baseCellStyle, teleportedItemStyles]}
-      decorationStyle={decorationStyle}
+      decorationStyles={decorationStyles}
       itemsOverridesStyle={itemsOverridesStyle}
       onMeasure={(width, height) => {
         onMeasure(width, height);

--- a/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
@@ -10,13 +10,17 @@ import Animated, {
   withTiming
 } from 'react-native-reanimated';
 
-import { IS_WEB } from '../../constants';
+import { EMPTY_OBJECT, IS_WEB } from '../../constants';
 import { DebugOutlet } from '../../debug';
 import {
   useCommonValuesContext,
   useMeasurementsContext
 } from '../../providers';
-import type { DropIndicatorSettings, Overflow } from '../../types';
+import {
+  AbsoluteLayoutState,
+  type DropIndicatorSettings,
+  type Overflow
+} from '../../types';
 import AnimatedOnLayoutView from './AnimatedOnLayoutView';
 import DropIndicator from './DropIndicator';
 
@@ -42,20 +46,21 @@ export default function SortableContainer({
   style
 }: AnimatedHeightContainerProps) {
   const {
+    absoluteLayoutState,
     activeItemDropped,
     activeItemKey,
-    canSwitchToAbsoluteLayout,
     containerHeight,
     containerRef,
     containerWidth,
     controlledContainerDimensions,
     shouldAnimateLayout
   } = useCommonValuesContext();
-  const { handleHelperContainerMeasurement } = useMeasurementsContext();
+  const { handleHelperContainerMeasurement, measurementsContainerRef } =
+    useMeasurementsContext();
 
   const outerContainerStyle = useAnimatedStyle(() => {
-    if (!canSwitchToAbsoluteLayout.value) {
-      return {};
+    if (absoluteLayoutState.value !== AbsoluteLayoutState.Complete) {
+      return EMPTY_OBJECT;
     }
 
     const maybeAnimate = (value: null | number, animate: boolean) =>
@@ -82,8 +87,8 @@ export default function SortableContainer({
   }, [animateHeight, animateWidth]);
 
   const innerContainerStyle = useAnimatedStyle(() => {
-    if (!canSwitchToAbsoluteLayout.value) {
-      return {};
+    if (absoluteLayoutState.value !== AbsoluteLayoutState.Complete) {
+      return EMPTY_OBJECT;
     }
 
     const minHeight =
@@ -100,6 +105,10 @@ export default function SortableContainer({
   });
 
   const animatedMeasurementsContainerStyle = useAnimatedStyle(() => {
+    if (absoluteLayoutState.value === AbsoluteLayoutState.Pending) {
+      return EMPTY_OBJECT;
+    }
+
     const ctrl = controlledContainerDimensions.value;
 
     return {
@@ -119,6 +128,7 @@ export default function SortableContainer({
         />
       )}
       <AnimatedOnLayoutView
+        ref={measurementsContainerRef}
         style={[StyleSheet.absoluteFill, animatedMeasurementsContainerStyle]}
         onLayout={handleHelperContainerMeasurement}
       />

--- a/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
@@ -59,7 +59,7 @@ export default function SortableContainer({
     useMeasurementsContext();
 
   const outerContainerStyle = useAnimatedStyle(() => {
-    if (absoluteLayoutState.value !== AbsoluteLayoutState.Complete) {
+    if (absoluteLayoutState.value !== AbsoluteLayoutState.COMPLETE) {
       return EMPTY_OBJECT;
     }
 
@@ -87,7 +87,7 @@ export default function SortableContainer({
   }, [animateHeight, animateWidth]);
 
   const innerContainerStyle = useAnimatedStyle(() => {
-    if (absoluteLayoutState.value !== AbsoluteLayoutState.Complete) {
+    if (absoluteLayoutState.value !== AbsoluteLayoutState.COMPLETE) {
       return EMPTY_OBJECT;
     }
 
@@ -105,7 +105,7 @@ export default function SortableContainer({
   });
 
   const animatedMeasurementsContainerStyle = useAnimatedStyle(() => {
-    if (absoluteLayoutState.value === AbsoluteLayoutState.Pending) {
+    if (absoluteLayoutState.value === AbsoluteLayoutState.PENDING) {
       return EMPTY_OBJECT;
     }
 

--- a/packages/react-native-sortables/src/debug/providers/DebugOutlet.tsx
+++ b/packages/react-native-sortables/src/debug/providers/DebugOutlet.tsx
@@ -25,21 +25,21 @@ const DebugOutlet = memo(function DebugOutlet() {
     <>
       {Object.entries(debugViews).map(([key, { props, type }]) => {
         switch (type) {
-          case DebugComponentType.Cross:
+          case DebugComponentType.CROSS:
             return (
               <DebugCross
                 key={key}
                 props={props as SharedValue<DebugCrossProps>}
               />
             );
-          case DebugComponentType.Line:
+          case DebugComponentType.LINE:
             return (
               <DebugLine
                 key={key}
                 props={props as SharedValue<DebugLineProps>}
               />
             );
-          case DebugComponentType.Rect:
+          case DebugComponentType.RECT:
             return (
               <DebugRect
                 key={key}

--- a/packages/react-native-sortables/src/debug/providers/DebugProvider.tsx
+++ b/packages/react-native-sortables/src/debug/providers/DebugProvider.tsx
@@ -163,29 +163,29 @@ const { DebugProvider, useDebugContext } = createProvider('Debug', {
   );
 
   const useDebugLine = useCallback(
-    () => useDebugComponent(DebugComponentType.Line),
+    () => useDebugComponent(DebugComponentType.LINE),
     [useDebugComponent]
   );
 
   const useDebugRect = useCallback(
-    () => useDebugComponent(DebugComponentType.Rect),
+    () => useDebugComponent(DebugComponentType.RECT),
     [useDebugComponent]
   );
 
   const useDebugCross = useCallback(
-    () => useDebugComponent(DebugComponentType.Cross),
+    () => useDebugComponent(DebugComponentType.CROSS),
     [useDebugComponent]
   );
 
   const useDebugLines = useCallback(
     (keysOrCount: Array<string> | number) =>
-      useDebugComponents(DebugComponentType.Line, keysOrCount),
+      useDebugComponents(DebugComponentType.LINE, keysOrCount),
     [useDebugComponents]
   );
 
   const useDebugRects = useCallback(
     (keysOrCount: Array<string> | number) =>
-      useDebugComponents(DebugComponentType.Rect, keysOrCount),
+      useDebugComponents(DebugComponentType.RECT, keysOrCount),
     [useDebugComponents]
   );
 

--- a/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
@@ -8,11 +8,12 @@ import {
 
 import { type DEFAULT_SORTABLE_FLEX_PROPS, IS_WEB } from '../../../constants';
 import { useDebugContext } from '../../../debug';
-import type {
-  FlexLayout,
-  FlexLayoutContextType,
-  RequiredBy,
-  SortableFlexStyle
+import {
+  AbsoluteLayoutState,
+  type FlexLayout,
+  type FlexLayoutContextType,
+  type RequiredBy,
+  type SortableFlexStyle
 } from '../../../types';
 import { haveEqualPropValues } from '../../../utils';
 import { useCommonValuesContext, useMeasurementsContext } from '../../shared';
@@ -55,6 +56,7 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
   width
 }) => {
   const {
+    absoluteLayoutState,
     controlledContainerDimensions,
     indexToKey,
     itemDimensions,
@@ -145,6 +147,10 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
                 paddings: paddings.value
               },
         (props, previousProps) => {
+          if (absoluteLayoutState.value === AbsoluteLayoutState.Pending) {
+            return;
+          }
+
           onChange(
             props && calculateLayout(props),
             // Animate layout only if parent container is not resized
@@ -165,7 +171,8 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
       rowGap,
       itemDimensions,
       dimensionsLimits,
-      paddings
+      paddings,
+      absoluteLayoutState
     ]
   );
 

--- a/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
@@ -147,7 +147,7 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
                 paddings: paddings.value
               },
         (props, previousProps) => {
-          if (absoluteLayoutState.value === AbsoluteLayoutState.Pending) {
+          if (absoluteLayoutState.value === AbsoluteLayoutState.PENDING) {
             return;
           }
 

--- a/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
@@ -9,10 +9,11 @@ import {
 import { IS_WEB } from '../../../constants';
 import { useDebugContext } from '../../../debug';
 import { useAnimatableValue } from '../../../hooks';
-import type {
-  Animatable,
-  GridLayout,
-  GridLayoutContextType
+import {
+  AbsoluteLayoutState,
+  type Animatable,
+  type GridLayout,
+  type GridLayoutContextType
 } from '../../../types';
 import { useCommonValuesContext, useMeasurementsContext } from '../../shared';
 import { createProvider } from '../../utils';
@@ -43,6 +44,7 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
   rowHeight
 }) => {
   const {
+    absoluteLayoutState,
     indexToKey,
     itemDimensions,
     itemPositions,
@@ -126,6 +128,10 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
           numGroups
         }),
         (props, previousProps) => {
+          if (absoluteLayoutState.value === AbsoluteLayoutState.Pending) {
+            return;
+          }
+
           onChange(
             calculateLayout(props),
             // Animate layout only if parent container is not resized
@@ -136,7 +142,15 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
           );
         }
       ),
-    [mainGroupSize, mainGap, crossGap, numGroups, isVertical, itemDimensions]
+    [
+      mainGroupSize,
+      mainGap,
+      crossGap,
+      numGroups,
+      isVertical,
+      itemDimensions,
+      absoluteLayoutState
+    ]
   );
 
   const useGridLayout = useCallback(

--- a/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
@@ -128,7 +128,7 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
           numGroups
         }),
         (props, previousProps) => {
-          if (absoluteLayoutState.value === AbsoluteLayoutState.Pending) {
+          if (absoluteLayoutState.value === AbsoluteLayoutState.PENDING) {
             return;
           }
 

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
@@ -2,7 +2,6 @@ import { type PropsWithChildren, useEffect, useMemo, useRef } from 'react';
 import type { View, ViewStyle } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
 import {
-  useAnimatedReaction,
   useAnimatedRef,
   useAnimatedStyle,
   useDerivedValue,
@@ -143,20 +142,6 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
         prevKeysRef.current = itemKeys;
       }
     }, [itemKeys, indexToKey]);
-
-    useAnimatedReaction(
-      () => sortEnabled.value,
-      enabled => {
-        if (
-          enabled &&
-          absoluteLayoutState.value === AbsoluteLayoutState.PENDING
-        ) {
-          // Transition from the relative (Pending) to the Absolute (Complete)
-          // layout when sorting is enabled for the first time
-          absoluteLayoutState.value = AbsoluteLayoutState.TRANSITION;
-        }
-      }
-    );
 
     const itemsOverridesStyle = useAnimatedStyle(() => ({
       ...itemsStyleOverride.value

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
@@ -130,7 +130,7 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
     // OTHER
     const containerRef = useAnimatedRef<View>();
     const sortEnabled = useAnimatableValue(_sortEnabled);
-    const absoluteLayoutState = useSharedValue(AbsoluteLayoutState.Pending);
+    const absoluteLayoutState = useSharedValue(AbsoluteLayoutState.PENDING);
     const shouldAnimateLayout = useSharedValue(true);
     const animateLayoutOnReorderOnly = useDerivedValue(
       () => itemsLayoutTransitionMode === 'reorder',
@@ -149,11 +149,11 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
       enabled => {
         if (
           enabled &&
-          absoluteLayoutState.value === AbsoluteLayoutState.Pending
+          absoluteLayoutState.value === AbsoluteLayoutState.PENDING
         ) {
           // Transition from the relative (Pending) to the Absolute (Complete)
           // layout when sorting is enabled for the first time
-          absoluteLayoutState.value = AbsoluteLayoutState.Transition;
+          absoluteLayoutState.value = AbsoluteLayoutState.TRANSITION;
         }
       }
     );

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.ts
@@ -21,7 +21,11 @@ import type {
   SortableCallbacks,
   Vector
 } from '../../types';
-import { DragActivationState, LayerState } from '../../types';
+import {
+  AbsoluteLayoutState,
+  DragActivationState,
+  LayerState
+} from '../../types';
 import {
   clearAnimatedTimeout,
   getOffsetDistance,
@@ -54,6 +58,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
   overDrag
 }) => {
   const {
+    absoluteLayoutState,
     activationAnimationDuration,
     activationState,
     activeAnimationProgress,
@@ -61,7 +66,6 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
     activeItemDropped,
     activeItemKey,
     activeItemPosition,
-    canSwitchToAbsoluteLayout,
     containerHeight,
     containerRef,
     containerWidth,
@@ -341,8 +345,8 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
         return;
       }
 
-      if (!canSwitchToAbsoluteLayout.value) {
-        measureContainer?.();
+      if (absoluteLayoutState.value !== AbsoluteLayoutState.Complete) {
+        measureContainer();
       }
 
       touchStartTouch.value = touch;
@@ -354,7 +358,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       // Start handling touch after a delay to prevent accidental activation
       // e.g. while scrolling the ScrollView
       activationTimeoutId.value = setAnimatedTimeout(() => {
-        if (!canSwitchToAbsoluteLayout.value) {
+        if (absoluteLayoutState.value !== AbsoluteLayoutState.Complete) {
           return;
         }
         activate();
@@ -368,11 +372,11 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       }, dragActivationDelay.value);
     },
     [
+      absoluteLayoutState,
       activeItemKey,
       activationState,
       activationTimeoutId,
       currentTouch,
-      canSwitchToAbsoluteLayout,
       dragActivationDelay,
       handleDragStart,
       sortEnabled,

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.ts
@@ -275,7 +275,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       dragStartIndex.value = keyToIndex.value[key] ?? -1;
       activationState.value = DragActivationState.ACTIVE;
 
-      updateLayer?.(LayerState.Focused);
+      updateLayer?.(LayerState.FOCUSED);
       updateStartScrollOffset?.();
 
       const hasInactiveAnimation =
@@ -345,7 +345,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
         return;
       }
 
-      if (absoluteLayoutState.value !== AbsoluteLayoutState.Complete) {
+      if (absoluteLayoutState.value !== AbsoluteLayoutState.COMPLETE) {
         measureContainer();
       }
 
@@ -358,7 +358,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       // Start handling touch after a delay to prevent accidental activation
       // e.g. while scrolling the ScrollView
       activationTimeoutId.value = setAnimatedTimeout(() => {
-        if (absoluteLayoutState.value !== AbsoluteLayoutState.Complete) {
+        if (absoluteLayoutState.value !== AbsoluteLayoutState.COMPLETE) {
           return;
         }
         activate();
@@ -453,7 +453,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       if (activeItemKey.value !== null) {
         prevActiveItemKey.value = activeItemKey.value;
         activeItemKey.value = null;
-        updateLayer?.(LayerState.Intermediate);
+        updateLayer?.(LayerState.INTERMEDIATE);
         haptics.medium();
 
         stableOnDragEnd({
@@ -477,7 +477,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       activationTimeoutId.value = setAnimatedTimeout(() => {
         prevActiveItemKey.value = null;
         activeItemDropped.value = true;
-        updateLayer?.(LayerState.Idle);
+        updateLayer?.(LayerState.IDLE);
       }, dropAnimationDuration.value);
     },
     [

--- a/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
@@ -35,7 +35,8 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
     controlledContainerDimensions,
     itemDimensions,
     measuredContainerHeight,
-    measuredContainerWidth
+    measuredContainerWidth,
+    sortEnabled
   } = useCommonValuesContext();
 
   const measurementsContainerRef = useAnimatedRef<View>();
@@ -162,6 +163,21 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
       applyMeasuredContainerDimensions(measurements);
     }
   }, [applyMeasuredContainerDimensions, measurementsContainerRef]);
+
+  useAnimatedReaction(
+    () => sortEnabled.value,
+    enabled => {
+      if (
+        absoluteLayoutState.value === AbsoluteLayoutState.PENDING &&
+        enabled
+      ) {
+        // Transition from the relative (Pending) to the Absolute (Complete)
+        // layout when sorting is enabled for the first time
+        absoluteLayoutState.value = AbsoluteLayoutState.TRANSITION;
+        itemDimensions.modify();
+      }
+    }
+  );
 
   useAnimatedReaction(
     () => ({

--- a/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
@@ -71,7 +71,7 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
         // and the layout cannot be changed to absolute (e.g. because sorting
         // hasn't been enabled yet)
         const canUpdateDimensions =
-          absoluteLayoutState.value !== AbsoluteLayoutState.Pending;
+          absoluteLayoutState.value !== AbsoluteLayoutState.PENDING;
         // If this is the first time all items have been measured, update
         // dimensions immediately to avoid unnecessary delays
         if (!initialItemMeasurementsCompleted.value) {
@@ -129,7 +129,7 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
       measuredContainerHeight.value = dimensions.height;
       measuredContainerWidth.value = dimensions.width;
 
-      if (absoluteLayoutState.value === AbsoluteLayoutState.Complete) {
+      if (absoluteLayoutState.value === AbsoluteLayoutState.COMPLETE) {
         if (!controlledContainerDimensions.value.height) {
           containerHeight.value = dimensions.height;
         }
@@ -180,7 +180,7 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
     }) => {
       if (
         // Update only if absolute layout is during the transition state
-        absoluteLayoutState.value !== AbsoluteLayoutState.Transition ||
+        absoluteLayoutState.value !== AbsoluteLayoutState.TRANSITION ||
         !itemMeasurementsCompleted ||
         measuredHeight === null ||
         measuredWidth === null ||
@@ -193,7 +193,7 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
         return;
       }
 
-      absoluteLayoutState.value = AbsoluteLayoutState.Complete;
+      absoluteLayoutState.value = AbsoluteLayoutState.COMPLETE;
     }
   );
 

--- a/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
@@ -10,7 +10,11 @@ import {
 
 import { OFFSET_EPS } from '../../constants';
 import { useUIStableCallback } from '../../hooks';
-import type { Dimensions, MeasurementsContextType } from '../../types';
+import {
+  AbsoluteLayoutState,
+  type Dimensions,
+  type MeasurementsContextType
+} from '../../types';
 import { areDimensionsDifferent, useAnimatedDebounce } from '../../utils';
 import { createProvider } from '../utils';
 import { useCommonValuesContext } from './CommonValuesProvider';
@@ -23,9 +27,9 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
   'Measurements'
 )<MeasurementsProviderProps, MeasurementsContextType>(({ itemsCount }) => {
   const {
+    absoluteLayoutState,
     activeItemDimensions,
     activeItemKey,
-    canSwitchToAbsoluteLayout,
     containerHeight,
     containerWidth,
     controlledContainerDimensions,
@@ -63,12 +67,17 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
       // Update the array of item dimensions only after all items have been
       // measured to reduce the number of times animated reactions are triggered
       if (measuredItemsCount.value === itemsCount) {
+        // Don't update dimensions if the sortable component is first rendered
+        // and the layout cannot be changed to absolute (e.g. because sorting
+        // hasn't been enabled yet)
+        const canUpdateDimensions =
+          absoluteLayoutState.value !== AbsoluteLayoutState.Pending;
         // If this is the first time all items have been measured, update
         // dimensions immediately to avoid unnecessary delays
         if (!initialItemMeasurementsCompleted.value) {
           initialItemMeasurementsCompleted.value = true;
-          itemDimensions.modify();
-        } else {
+          if (canUpdateDimensions) itemDimensions.modify();
+        } else if (canUpdateDimensions) {
           // In all other cases, debounce the update in case multiple items
           // change their size at the same time
           debounce(itemDimensions.modify, 100);
@@ -120,7 +129,7 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
       measuredContainerHeight.value = dimensions.height;
       measuredContainerWidth.value = dimensions.width;
 
-      if (canSwitchToAbsoluteLayout.value) {
+      if (absoluteLayoutState.value === AbsoluteLayoutState.Complete) {
         if (!controlledContainerDimensions.value.height) {
           containerHeight.value = dimensions.height;
         }
@@ -130,7 +139,7 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
       }
     },
     [
-      canSwitchToAbsoluteLayout,
+      absoluteLayoutState,
       containerHeight,
       containerWidth,
       controlledContainerDimensions,
@@ -170,7 +179,8 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
       measuredWidth
     }) => {
       if (
-        canSwitchToAbsoluteLayout.value ||
+        // Update only if absolute layout is during the transition state
+        absoluteLayoutState.value !== AbsoluteLayoutState.Transition ||
         !itemMeasurementsCompleted ||
         measuredHeight === null ||
         measuredWidth === null ||
@@ -183,7 +193,7 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
         return;
       }
 
-      canSwitchToAbsoluteLayout.value = true;
+      absoluteLayoutState.value = AbsoluteLayoutState.Complete;
     }
   );
 

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemDecorationStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemDecorationStyles.ts
@@ -11,13 +11,8 @@ import {
 } from 'react-native-reanimated';
 
 import { IS_WEB } from '../../../constants';
-import { AbsoluteLayoutState, type AnimatedStyleProp } from '../../../types';
+import { type AnimatedStyleProp } from '../../../types';
 import { useCommonValuesContext } from '../CommonValuesProvider';
-
-const DISABLED_STYLE: ViewStyle = {
-  elevation: 0,
-  shadowOpacity: 0
-};
 
 export default function useItemDecorationStyles(
   itemKey: string,
@@ -25,7 +20,6 @@ export default function useItemDecorationStyles(
   activationAnimationProgress: SharedValue<number>
 ): AnimatedStyleProp {
   const {
-    absoluteLayoutState,
     activationAnimationDuration,
     activeItemOpacity,
     activeItemScale,
@@ -49,10 +43,6 @@ export default function useItemDecorationStyles(
   });
 
   const animatedStyle = useAnimatedStyle(() => {
-    if (absoluteLayoutState.value !== AbsoluteLayoutState.COMPLETE) {
-      return DISABLED_STYLE;
-    }
-
     const progress = activationAnimationProgress.value;
     const zeroProgressOpacity = interpolate(
       adjustedInactiveProgress.value,

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemDecorationStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemDecorationStyles.ts
@@ -11,8 +11,13 @@ import {
 } from 'react-native-reanimated';
 
 import { IS_WEB } from '../../../constants';
-import type { AnimatedStyleProp } from '../../../types';
+import { AbsoluteLayoutState, type AnimatedStyleProp } from '../../../types';
 import { useCommonValuesContext } from '../CommonValuesProvider';
+
+const DISABLED_STYLE: ViewStyle = {
+  elevation: 0,
+  shadowOpacity: 0
+};
 
 export default function useItemDecorationStyles(
   itemKey: string,
@@ -20,6 +25,7 @@ export default function useItemDecorationStyles(
   activationAnimationProgress: SharedValue<number>
 ): AnimatedStyleProp {
   const {
+    absoluteLayoutState,
     activationAnimationDuration,
     activeItemOpacity,
     activeItemScale,
@@ -43,6 +49,10 @@ export default function useItemDecorationStyles(
   });
 
   const animatedStyle = useAnimatedStyle(() => {
+    if (absoluteLayoutState.value !== AbsoluteLayoutState.Complete) {
+      return DISABLED_STYLE;
+    }
+
     const progress = activationAnimationProgress.value;
     const zeroProgressOpacity = interpolate(
       adjustedInactiveProgress.value,

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemDecorationStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemDecorationStyles.ts
@@ -49,7 +49,7 @@ export default function useItemDecorationStyles(
   });
 
   const animatedStyle = useAnimatedStyle(() => {
-    if (absoluteLayoutState.value !== AbsoluteLayoutState.Complete) {
+    if (absoluteLayoutState.value !== AbsoluteLayoutState.COMPLETE) {
       return DISABLED_STYLE;
     }
 

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
@@ -9,7 +9,11 @@ import {
 } from 'react-native-reanimated';
 
 import { EMPTY_OBJECT } from '../../../constants';
-import type { AnimatedStyleProp, Vector } from '../../../types';
+import {
+  AbsoluteLayoutState,
+  type AnimatedStyleProp,
+  type Vector
+} from '../../../types';
 import { useCommonValuesContext } from '../CommonValuesProvider';
 import useItemZIndex from './useItemZIndex';
 
@@ -34,10 +38,10 @@ export default function useItemLayoutStyles(
   activationAnimationProgress: SharedValue<number>
 ): AnimatedStyleProp {
   const {
+    absoluteLayoutState,
     activeItemKey,
     activeItemPosition,
     animateLayoutOnReorderOnly,
-    canSwitchToAbsoluteLayout,
     itemPositions
   } = useCommonValuesContext();
 
@@ -53,12 +57,12 @@ export default function useItemLayoutStyles(
   useAnimatedReaction(
     () => ({
       activationProgress: activationAnimationProgress.value,
-      canSwitchToAbsolute: canSwitchToAbsoluteLayout.value,
+      canApply: absoluteLayoutState.value === AbsoluteLayoutState.Complete,
       isActive: activeItemKey.value === key,
       position: itemPositions.value[key]
     }),
-    ({ activationProgress, canSwitchToAbsolute, isActive, position }) => {
-      if (!canSwitchToAbsolute) {
+    ({ activationProgress, canApply, isActive, position }) => {
+      if (!canApply) {
         // This affects all items rendered during the initial render when
         // the absolute layout is not yet enabled. All of these items have
         // no translation at the beginning and layoutX and layoutY are
@@ -142,7 +146,7 @@ export default function useItemLayoutStyles(
 
   const animatedTranslationStyle = useAnimatedStyle(() => {
     if (
-      !canSwitchToAbsoluteLayout.value &&
+      absoluteLayoutState.value !== AbsoluteLayoutState.Complete &&
       (layoutX.value === null || layoutY.value === null)
     ) {
       return RELATIVE_STYLE;
@@ -164,7 +168,7 @@ export default function useItemLayoutStyles(
   });
 
   const animatedLayoutStyle = useAnimatedStyle(() => {
-    if (!canSwitchToAbsoluteLayout.value) {
+    if (absoluteLayoutState.value !== AbsoluteLayoutState.Complete) {
       return EMPTY_OBJECT;
     }
 

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
@@ -57,7 +57,7 @@ export default function useItemLayoutStyles(
   useAnimatedReaction(
     () => ({
       activationProgress: activationAnimationProgress.value,
-      canApply: absoluteLayoutState.value === AbsoluteLayoutState.Complete,
+      canApply: absoluteLayoutState.value === AbsoluteLayoutState.COMPLETE,
       isActive: activeItemKey.value === key,
       position: itemPositions.value[key]
     }),
@@ -146,7 +146,7 @@ export default function useItemLayoutStyles(
 
   const animatedTranslationStyle = useAnimatedStyle(() => {
     if (
-      absoluteLayoutState.value !== AbsoluteLayoutState.Complete &&
+      absoluteLayoutState.value !== AbsoluteLayoutState.COMPLETE &&
       (layoutX.value === null || layoutY.value === null)
     ) {
       return RELATIVE_STYLE;
@@ -168,7 +168,7 @@ export default function useItemLayoutStyles(
   });
 
   const animatedLayoutStyle = useAnimatedStyle(() => {
-    if (absoluteLayoutState.value !== AbsoluteLayoutState.Complete) {
+    if (absoluteLayoutState.value !== AbsoluteLayoutState.COMPLETE) {
       return EMPTY_OBJECT;
     }
 

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.web.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.web.ts
@@ -99,7 +99,7 @@ export default function useItemLayoutStyles(
   );
 
   return useAnimatedStyle(() => {
-    if (absoluteLayoutState.value !== AbsoluteLayoutState.Complete) {
+    if (absoluteLayoutState.value !== AbsoluteLayoutState.COMPLETE) {
       return RELATIVE_STYLE;
     }
 

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.web.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.web.ts
@@ -8,7 +8,7 @@ import {
   withTiming
 } from 'react-native-reanimated';
 
-import type { AnimatedStyleProp } from '../../../types';
+import { AbsoluteLayoutState, type AnimatedStyleProp } from '../../../types';
 import { useCommonValuesContext } from '../CommonValuesProvider';
 import useItemZIndex from './useItemZIndex';
 
@@ -35,11 +35,11 @@ export default function useItemLayoutStyles(
   activationAnimationProgress: SharedValue<number>
 ): AnimatedStyleProp {
   const {
+    absoluteLayoutState,
     activeItemDropped,
     activeItemKey,
     activeItemPosition,
     animateLayoutOnReorderOnly,
-    canSwitchToAbsoluteLayout,
     dropAnimationDuration,
     itemPositions,
     shouldAnimateLayout
@@ -99,7 +99,7 @@ export default function useItemLayoutStyles(
   );
 
   return useAnimatedStyle(() => {
-    if (!canSwitchToAbsoluteLayout.value) {
+    if (absoluteLayoutState.value !== AbsoluteLayoutState.Complete) {
       return RELATIVE_STYLE;
     }
 

--- a/packages/react-native-sortables/src/types/debug.ts
+++ b/packages/react-native-sortables/src/types/debug.ts
@@ -5,9 +5,9 @@ import type { Vector } from './layout/shared';
 import type { AnyRecord, Maybe } from './utils';
 
 export enum DebugComponentType {
-  Cross = 'cross',
-  Line = 'line',
-  Rect = 'rect'
+  CROSS = 'cross',
+  LINE = 'line',
+  RECT = 'rect'
 }
 
 export type DebugCrossProps = (
@@ -110,17 +110,17 @@ type CreateDebugComponentUpdater<
 };
 
 export type DebugComponentUpdater<T extends DebugComponentType> =
-  T extends DebugComponentType.Line
+  T extends DebugComponentType.LINE
     ? CreateDebugComponentUpdater<T, DebugLineProps>
-    : T extends DebugComponentType.Rect
+    : T extends DebugComponentType.RECT
       ? CreateDebugComponentUpdater<T, DebugRectProps>
-      : T extends DebugComponentType.Cross
+      : T extends DebugComponentType.CROSS
         ? CreateDebugComponentUpdater<T, DebugCrossProps>
         : never;
 
-export type DebugLineUpdater = DebugComponentUpdater<DebugComponentType.Line>;
-export type DebugCrossUpdater = DebugComponentUpdater<DebugComponentType.Cross>;
-export type DebugRectUpdater = DebugComponentUpdater<DebugComponentType.Rect>;
+export type DebugLineUpdater = DebugComponentUpdater<DebugComponentType.LINE>;
+export type DebugCrossUpdater = DebugComponentUpdater<DebugComponentType.CROSS>;
+export type DebugRectUpdater = DebugComponentUpdater<DebugComponentType.RECT>;
 
 export type DebugViews = Record<
   number,

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -20,7 +20,11 @@ import type {
   ItemDragSettings,
   ReorderTriggerOrigin
 } from '../props/shared';
-import type { DragActivationState } from '../state';
+import type {
+  AbsoluteLayoutState,
+  DragActivationState,
+  LayerState
+} from '../state';
 import type { AnimatedValues, AnyRecord, Maybe } from '../utils';
 
 // COMMON VALUES
@@ -65,7 +69,7 @@ export type CommonValuesContextType = {
   // OTHER
   containerRef: AnimatedRef<View>;
   sortEnabled: SharedValue<boolean>;
-  canSwitchToAbsoluteLayout: SharedValue<boolean>;
+  absoluteLayoutState: SharedValue<AbsoluteLayoutState>;
   shouldAnimateLayout: SharedValue<boolean>; // used only on web
   animateLayoutOnReorderOnly: SharedValue<boolean>;
   customHandle: boolean;
@@ -78,6 +82,7 @@ export type CommonValuesContextType = {
 // MEASUREMENTS
 
 export type MeasurementsContextType = {
+  measurementsContainerRef: AnimatedRef<View>;
   applyControlledContainerDimensions: (dimensions: Partial<Dimensions>) => void;
   handleItemMeasurement: (key: string, dimensions: Dimensions) => void;
   removeItemMeasurements: (key: string) => void;
@@ -126,12 +131,6 @@ export type ItemContextType = {
 };
 
 // LAYER
-
-export enum LayerState {
-  Focused = 2,
-  Idle = 0,
-  Intermediate = 1
-}
 
 export type LayerContextType = {
   updateLayer: (state: LayerState) => void;

--- a/packages/react-native-sortables/src/types/state.ts
+++ b/packages/react-native-sortables/src/types/state.ts
@@ -1,13 +1,13 @@
 export enum DragActivationState {
-  ACTIVE = 'ACTIVE',
   INACTIVE = 'INACTIVE',
-  TOUCHED = 'TOUCHED'
+  TOUCHED = 'TOUCHED',
+  ACTIVE = 'ACTIVE'
 }
 
 export enum LayerState {
-  Focused = 2,
-  Idle = 0,
-  Intermediate = 1
+  IDLE = 0,
+  INTERMEDIATE = 1,
+  FOCUSED = 2
 }
 
 /**
@@ -19,17 +19,17 @@ export enum AbsoluteLayoutState {
    * Initial state when the layout is relative. This occurs before sorting
    * is enabled for the first time and any measurements have been made.
    */
-  Pending = 1,
+  PENDING = 1,
 
   /**
    * Intermediate state when the layout can be changed to absolute, but
    * measurements haven't been completed yet.
    */
-  Transition = 2,
+  TRANSITION = 2,
 
   /**
    * Final state when the absolute layout can be applied, after all measurements
    * have been completed.
    */
-  Complete = 3
+  COMPLETE = 3
 }

--- a/packages/react-native-sortables/src/types/state.ts
+++ b/packages/react-native-sortables/src/types/state.ts
@@ -3,3 +3,33 @@ export enum DragActivationState {
   INACTIVE = 'INACTIVE',
   TOUCHED = 'TOUCHED'
 }
+
+export enum LayerState {
+  Focused = 2,
+  Idle = 0,
+  Intermediate = 1
+}
+
+/**
+ * Represents the state of absolute positioning layout in sortable components.
+ * @enum {number}
+ */
+export enum AbsoluteLayoutState {
+  /**
+   * Initial state when the layout is relative. This occurs before sorting
+   * is enabled for the first time and any measurements have been made.
+   */
+  Pending = 1,
+
+  /**
+   * Intermediate state when the layout can be changed to absolute, but
+   * measurements haven't been completed yet.
+   */
+  Transition = 2,
+
+  /**
+   * Final state when the absolute layout can be applied, after all measurements
+   * have been completed.
+   */
+  Complete = 3
+}


### PR DESCRIPTION
## Description

This PR adds delayed absolute layout initialization when the `sortEnabled` prop os the sortable component is set to false. It reduces the number of calculations and applied animated styles to the minimum to make the initial render of the sortable component less demanding and calculates and applied the absolute layout only after the `sortEnabled` was set to `true` for the first time.