### PR TITLE
fix: Active portal not working on Android

### DIFF
--- a/example/app/src/components/misc/ActionSheetDropdown.tsx
+++ b/example/app/src/components/misc/ActionSheetDropdown.tsx
@@ -2,16 +2,16 @@ import { Portal } from '@gorhom/portal';
 import type { JSX, PropsWithChildren, ReactNode } from 'react';
 import { useRef, useState } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
-import { Dimensions, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Dimensions, StyleSheet, View } from 'react-native';
 import {
   Gesture,
   GestureDetector,
-  Pressable
+  Pressable,
+  TouchableOpacity
 } from 'react-native-gesture-handler';
 import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
   FadeIn,
-  FadeOut,
   interpolate,
   useAnimatedRef,
   useAnimatedStyle,
@@ -267,10 +267,7 @@ function DropdownContent({
 
   return (
     <Animated.View style={[dropdownStyle, animatedDropdownStyle]}>
-      <Animated.View
-        entering={FadeIn}
-        exiting={FadeOut}
-        style={styles.boxNoneEvents}>
+      <Animated.View entering={FadeIn}>
         <View style={[{ maxHeight: dropdownMaxHeight }, rest]}>
           <Animated.ScrollView
             contentContainerStyle={paddingAndMargin}
@@ -358,17 +355,14 @@ function ScrollBar({
 }
 
 type BackdropProps = {
-  handleClose?: () => void;
+  handleClose: () => void;
 };
 
 function Backdrop({ handleClose }: BackdropProps): JSX.Element {
   return (
-    <Animated.View
-      entering={FadeIn}
-      exiting={FadeOut}
-      style={[styles.backdrop, styles.boxNoneEvents]}>
-      <Pressable style={styles.backdrop} onPress={handleClose} />
-    </Animated.View>
+    <Pressable style={StyleSheet.absoluteFill} onPress={handleClose}>
+      <Animated.View entering={FadeIn} style={styles.backdrop} />
+    </Pressable>
   );
 }
 
@@ -376,9 +370,6 @@ const styles = StyleSheet.create({
   backdrop: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(0, 0, 0, 0.2)'
-  },
-  boxNoneEvents: {
-    pointerEvents: 'box-none'
   },
   scrollBarThumb: {
     backgroundColor: 'rgba(0, 0, 0, 0.5)',

--- a/packages/react-native-sortables/src/components/shared/DraggableView/ActiveItemPortal.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/ActiveItemPortal.tsx
@@ -9,7 +9,6 @@ import {
   useSharedValue
 } from 'react-native-reanimated';
 
-import { IS_WEB } from '../../../constants';
 import { usePortalContext, useTeleportedItemId } from '../../../providers';
 import type { AnimatedStyleProp, MeasureCallback } from '../../../types';
 
@@ -19,7 +18,7 @@ const TELEPORTED_ITEM_STYLE: ViewStyle = {
 };
 
 const NOT_TELEPORTED_ITEM_STYLE: ViewStyle = {
-  maxHeight: IS_WEB ? 9999 : 'auto', // 'auto' doesn't trigger onLayout on web
+  maxHeight: 9999, // 'auto' doesn't trigger onLayout on web/android
   overflow: 'visible'
 };
 

--- a/packages/react-native-sortables/src/providers/shared/PortalOutletProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/PortalOutletProvider.tsx
@@ -17,7 +17,7 @@ const { PortalOutletProvider, usePortalOutletContext } = createProvider(
 
   return {
     children: (
-      <View ref={portalOutletRef} style={styles.container}>
+      <View collapsable={false} ref={portalOutletRef} style={styles.container}>
         {children}
       </View>
     ),

--- a/packages/react-native-sortables/src/providers/shared/PortalProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/PortalProvider.tsx
@@ -65,14 +65,14 @@ const { PortalProvider, usePortalContext } = createProvider('Portal', {
 
   return {
     children: (
-      <>
+      <Fragment>
         {children}
         <PortalOutletProvider>
           {Object.entries(teleportedNodes).map(([key, node]) => (
             <Fragment key={key}>{node}</Fragment>
           ))}
         </PortalOutletProvider>
-      </>
+      </Fragment>
     ),
     value: {
       activeItemAbsolutePosition,


### PR DESCRIPTION
## Description

It didn't work because the portal provider outlet was collapsed. Settings `collapsible` to false on the portal outlet and adding a few other changes fixes the issue.
