### PR TITLE
feat: Add a possibility to enable or disable the portal provider

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,6 +14,13 @@ module.exports = {
         allowArrayStart: true
       }
     ],
-    'perfectionist/sort-enums': 'off'
+    'perfectionist/sort-enums': 'off',
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'enumMember',
+        format: ['UPPER_CASE']
+      }
+    ]
   }
 };

--- a/example/app/src/components/inputs/Switch.tsx
+++ b/example/app/src/components/inputs/Switch.tsx
@@ -9,6 +9,10 @@ import Animated, {
 import { colors, radius, sizes, spacing, text } from '@/theme';
 import { lighten } from '@/utils';
 
+const TRACK_HEIGHT = sizes.xxs;
+const TRACK_PADDING = spacing.xxxs;
+const THUMB_SIZE = TRACK_HEIGHT - 2 * TRACK_PADDING;
+
 type SwitchOption<V> = { label: string; value: V };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,7 +44,7 @@ export default function Switch<V>({
 
   const animatedThumbStyle = useAnimatedStyle(() => ({
     left: `${progress.value * 100}%`,
-    transform: [{ translateX: `${-progress.value * 100}%` }]
+    transform: [{ translateX: -progress.value * THUMB_SIZE }]
   }));
 
   return (
@@ -80,8 +84,8 @@ const styles = StyleSheet.create({
   track: {
     backgroundColor: colors.background3,
     borderRadius: radius.full,
-    height: sizes.xxs,
-    padding: spacing.xxxs,
+    height: TRACK_HEIGHT,
+    padding: TRACK_PADDING,
     width: sizes.sm
   }
 });

--- a/example/app/src/examples/navigation/ExamplesStackNavigator.tsx
+++ b/example/app/src/examples/navigation/ExamplesStackNavigator.tsx
@@ -74,20 +74,16 @@ function createStackNavigator(routes: Routes): React.ComponentType {
       []
     );
 
-    const content = (
-      <BottomNavBarHeightProvider>
-        <View style={styles.container}>
-          {navigatorComponent}
-          <BottomNavBar homeRouteName='Examples' routes={routes} />
-        </View>
-      </BottomNavBarHeightProvider>
+    return (
+      <Sortable.PortalProvider enabled={settings.activeItemPortalEnabled}>
+        <BottomNavBarHeightProvider>
+          <View style={styles.container}>
+            {navigatorComponent}
+            <BottomNavBar homeRouteName='Examples' routes={routes} />
+          </View>
+        </BottomNavBarHeightProvider>
+      </Sortable.PortalProvider>
     );
-
-    if (settings.activeItemPortalEnabled) {
-      return <Sortable.PortalProvider>{content}</Sortable.PortalProvider>;
-    }
-
-    return content;
   }
 
   return function WrappedNavigator() {

--- a/packages/react-native-sortables/src/components/shared/DraggableView/ActiveItemPortal.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/ActiveItemPortal.tsx
@@ -1,72 +1,50 @@
 import type { PropsWithChildren, ReactNode } from 'react';
 import { useEffect } from 'react';
-import type { ViewStyle } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
-import {
-  runOnJS,
-  useAnimatedReaction,
-  useAnimatedStyle,
-  useSharedValue
-} from 'react-native-reanimated';
+import { runOnJS, useAnimatedReaction } from 'react-native-reanimated';
 
-import { usePortalContext, useTeleportedItemId } from '../../../providers';
-import type { AnimatedStyleProp, MeasureCallback } from '../../../types';
-
-const TELEPORTED_ITEM_STYLE: ViewStyle = {
-  maxHeight: 0,
-  overflow: 'hidden'
-};
-
-const NOT_TELEPORTED_ITEM_STYLE: ViewStyle = {
-  maxHeight: 9999, // 'auto' doesn't trigger onLayout on web/android
-  overflow: 'visible'
-};
+import { usePortalContext } from '../../../providers';
+import { ItemPortalState } from '../../../types';
 
 type ActiveItemPortalProps = PropsWithChildren<{
-  itemKey: string;
+  teleportedItemId: string;
   activationAnimationProgress: SharedValue<number>;
-  onMeasureItem: MeasureCallback;
-  renderItemCell: (
-    onMeasure: MeasureCallback,
-    itemStyle?: AnimatedStyleProp
-  ) => ReactNode;
+  portalState: SharedValue<ItemPortalState>;
   renderTeleportedItemCell: () => ReactNode;
 }>;
 
 export default function ActiveItemPortal({
   activationAnimationProgress,
   children,
-  itemKey: key,
-  onMeasureItem,
-  renderItemCell,
-  renderTeleportedItemCell
+  portalState,
+  renderTeleportedItemCell,
+  teleportedItemId
 }: ActiveItemPortalProps) {
-  const teleportedItemId = useTeleportedItemId(key);
   const { subscribe, teleport } = usePortalContext()!;
-  const canEnableTeleport = useSharedValue(true);
-  const isTeleported = useSharedValue(false);
 
   useEffect(() => {
     const unsubscribe = subscribe(teleportedItemId, teleported => {
-      isTeleported.value = teleported;
+      if (teleported) {
+        portalState.value = ItemPortalState.TELEPORTED;
+      }
     });
 
     return () => {
       unsubscribe();
       teleport(teleportedItemId, null);
     };
-  }, [isTeleported, subscribe, teleport, teleportedItemId]);
+  }, [portalState, subscribe, teleport, teleportedItemId]);
 
   useEffect(() => {
-    if (isTeleported.value) {
+    if (portalState.value === ItemPortalState.TELEPORTED) {
       // Renders a component in the portal outlet
       teleport(teleportedItemId, renderTeleportedItemCell());
     }
   }, [
+    portalState,
     teleportedItemId,
     renderTeleportedItemCell,
     teleport,
-    isTeleported,
     children
   ]);
 
@@ -74,36 +52,20 @@ export default function ActiveItemPortal({
     teleport(teleportedItemId, renderTeleportedItemCell());
   };
 
-  const onMeasure = (width: number, height: number) => {
-    if (canEnableTeleport.value) {
-      onMeasureItem(width, height);
-    } else if (!isTeleported.value && height > 0 && width > 0) {
-      // canEnableTeleport is false when the item is already teleported
-      // We want to use this instead of isTeleported as isTeleported is set
-      // to false before to make the not teleported item back visible
-      teleport(teleportedItemId, null);
-      canEnableTeleport.value = true;
-    }
-  };
-
-  const animatedItemStyle = useAnimatedStyle(() =>
-    isTeleported.value ? TELEPORTED_ITEM_STYLE : NOT_TELEPORTED_ITEM_STYLE
-  );
-
   useAnimatedReaction(
     () => activationAnimationProgress.value,
     progress => {
-      if (progress > 0 && canEnableTeleport.value) {
-        canEnableTeleport.value = false;
+      if (progress > 0 && portalState.value === ItemPortalState.IDLE) {
+        portalState.value = ItemPortalState.TELEPORTING;
         runOnJS(enableTeleport)();
-      } else if (progress === 0) {
-        isTeleported.value = false;
+      } else if (
+        progress === 0 &&
+        portalState.value === ItemPortalState.TELEPORTED
+      ) {
+        portalState.value = ItemPortalState.EXITING;
       }
     }
   );
 
-  // Renders a component within the sortable container
-  // (it cannot be unmounted as it is responsible for gesture handling,
-  // we can just remove its children when they are already teleported)
-  return renderItemCell(onMeasure, animatedItemStyle);
+  return null;
 }

--- a/packages/react-native-sortables/src/components/shared/DraggableView/ItemCell.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/ItemCell.tsx
@@ -20,7 +20,6 @@ export type ItemCellProps = PropsWithChildren<{
   entering?: LayoutAnimation;
   exiting?: LayoutAnimation;
   layout?: LayoutTransition;
-  itemStyle?: AnimatedStyleProp;
 }>;
 
 export default function ItemCell({
@@ -29,7 +28,6 @@ export default function ItemCell({
   decorationStyles,
   entering,
   exiting,
-  itemStyle,
   itemsOverridesStyle,
   layout,
   onMeasure
@@ -39,7 +37,7 @@ export default function ItemCell({
       <AnimatedOnLayoutView
         entering={entering}
         exiting={exiting}
-        style={[itemsOverridesStyle, decorationStyles, itemStyle]}
+        style={[itemsOverridesStyle, decorationStyles]}
         onLayout={({
           nativeEvent: {
             layout: { height, width }

--- a/packages/react-native-sortables/src/components/shared/DraggableView/TeleportedItemCell.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/TeleportedItemCell.tsx
@@ -2,8 +2,8 @@ import type { SharedValue } from 'react-native-reanimated';
 import { LayoutAnimationConfig } from 'react-native-reanimated';
 
 import {
+  useItemDecorationStyles,
   usePortalContext,
-  useTeleportedItemId,
   useTeleportedItemStyles
 } from '../../../providers';
 import type { AnimatedStyleProp } from '../../../types';
@@ -14,23 +14,31 @@ type TeleportedItemCellProps = {
   activationAnimationProgress: SharedValue<number>;
   baseCellStyle: AnimatedStyleProp;
   isActive: SharedValue<boolean>;
+  teleportedItemId: string;
   itemKey: string;
-} & Omit<ItemCellProps, 'cellStyle' | 'entering' | 'exiting' | 'layout'>;
+} & Omit<
+  ItemCellProps,
+  'cellStyle' | 'decorationStyles' | 'entering' | 'exiting' | 'layout'
+>;
 
 export default function TeleportedItemCell({
   activationAnimationProgress,
   baseCellStyle,
   children,
-  decorationStyles,
   isActive,
   itemKey,
   itemsOverridesStyle,
-  onMeasure
+  onMeasure,
+  teleportedItemId
 }: TeleportedItemCellProps) {
-  const teleportedItemId = useTeleportedItemId(itemKey);
   const { notifyRendered } = usePortalContext()!;
 
   const teleportedItemStyles = useTeleportedItemStyles(
+    itemKey,
+    isActive,
+    activationAnimationProgress
+  );
+  const decorationStyles = useItemDecorationStyles(
     itemKey,
     isActive,
     activationAnimationProgress

--- a/packages/react-native-sortables/src/providers/shared/PortalProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/PortalProvider.tsx
@@ -12,11 +12,12 @@ import { PortalOutletProvider } from './PortalOutletProvider';
 
 type PortalProviderProps = {
   children: ReactNode;
+  enabled?: boolean;
 };
 
 const { PortalProvider, usePortalContext } = createProvider('Portal', {
   guarded: false
-})<PortalProviderProps, PortalContextType>(({ children }) => {
+})<PortalProviderProps, PortalContextType>(({ children, enabled }) => {
   const subscribersRef = useRef<Record<string, Set<PortalSubscription>>>({});
   const [teleportedNodes, setTeleportedNodes] = useState<
     Record<string, React.ReactNode>
@@ -74,6 +75,7 @@ const { PortalProvider, usePortalContext } = createProvider('Portal', {
         </PortalOutletProvider>
       </Fragment>
     ),
+    enabled,
     value: {
       activeItemAbsolutePosition,
       notifyRendered,

--- a/packages/react-native-sortables/src/providers/shared/hooks/index.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/index.ts
@@ -5,5 +5,4 @@ export { default as useItemPanGesture } from './useItemPanGesture';
 export { default as useItemZIndex } from './useItemZIndex';
 export { default as useLayoutDebugRects } from './useLayoutDebugRects';
 export { default as useOrderUpdater } from './useOrderUpdater';
-export { default as useTeleportedItemId } from './useTeleportedItemId';
 export { default as useTeleportedItemStyles } from './useTeleportedItemStyles';

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemDecorationStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemDecorationStyles.ts
@@ -17,7 +17,16 @@ import { useCommonValuesContext } from '../CommonValuesProvider';
 
 const TELEPORTED_ITEM_STYLE: ViewStyle = {
   maxHeight: 0,
-  opacity: 0
+  opacity: 0,
+  ...Platform.select({
+    android: {
+      elevation: 0
+    },
+    default: {},
+    native: {
+      shadowOpacity: 0
+    }
+  })
 };
 
 const NOT_TELEPORTED_ITEM_STYLE: ViewStyle = {

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
@@ -9,11 +9,8 @@ import {
 } from 'react-native-reanimated';
 
 import { EMPTY_OBJECT } from '../../../constants';
-import {
-  AbsoluteLayoutState,
-  type AnimatedStyleProp,
-  type Vector
-} from '../../../types';
+import type { AnimatedStyleProp, Vector } from '../../../types';
+import { AbsoluteLayoutState } from '../../../types';
 import { useCommonValuesContext } from '../CommonValuesProvider';
 import useItemZIndex from './useItemZIndex';
 

--- a/packages/react-native-sortables/src/providers/shared/hooks/useTeleportedItemId.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useTeleportedItemId.ts
@@ -1,7 +1,0 @@
-import { useCommonValuesContext } from '../CommonValuesProvider';
-
-export default function useTeleportedItemId(itemKey: string) {
-  const { componentId } = useCommonValuesContext();
-
-  return `${componentId}-${itemKey}`;
-}

--- a/packages/react-native-sortables/src/providers/utils/createProvider.tsx
+++ b/packages/react-native-sortables/src/providers/utils/createProvider.tsx
@@ -1,81 +1,39 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-/* eslint-disable no-redeclare */
 import {
   createContext,
   type PropsWithChildren,
-  type ReactNode,
   useContext,
   useMemo
 } from 'react';
 
 import { error, getContextProvider } from '../../utils';
 
-export default function createProvider<ProviderName extends string>(
-  name: ProviderName,
-  options: { withContext: false }
-): <ProviderProps extends PropsWithChildren<object>>(
-  factory: (props: ProviderProps) => { children: ReactNode } | void
-) => {
-  [P in ProviderName as `${P}Provider`]: React.FC<ProviderProps>;
-};
-
 export default function createProvider<
   ProviderName extends string,
   Guarded extends boolean = true
->(
-  name: ProviderName,
-  options?: { withContext?: true; guarded?: Guarded }
-): <
-  ProviderProps extends PropsWithChildren<object>,
-  ContextValue extends object
->(
-  factory: (props: ProviderProps) => {
-    value: ContextValue;
-    children?: ReactNode;
-  }
-) => {
-  [P in ProviderName as `${P}Context`]: React.Context<ContextValue>;
-} & {
-  [P in ProviderName as `${P}Provider`]: React.FC<ProviderProps>;
-} & {
-  [P in ProviderName as `use${P}Context`]: () => Guarded extends true
-    ? ContextValue
-    : ContextValue | null;
-};
-
-export default function createProvider<
-  ProviderName extends string,
-  Guarded extends boolean = true
->(name: ProviderName, options?: { withContext?: boolean; guarded?: Guarded }) {
+>(name: ProviderName, options?: { guarded?: Guarded }) {
   return function <
     ProviderProps extends PropsWithChildren<object>,
     ContextValue extends object
   >(
     factory: (props: ProviderProps) => {
       value?: ContextValue;
+      enabled?: boolean;
       children?: React.ReactNode;
-    } | void
-  ) {
-    const { guarded = true, withContext = true } = options ?? {};
-
-    if (!withContext) {
-      const Provider: React.FC<ProviderProps> = props => {
-        const { children = props.children } = factory(props) ?? {};
-        return <>{children}</>;
-      };
-
-      return { [`${name}Provider`]: Provider } as any;
     }
+  ) {
+    const { guarded = true } = options ?? {};
 
     const Context = createContext<ContextValue | null>(null);
     Context.displayName = name;
 
     const Provider: React.FC<ProviderProps> = props => {
-      const { children = props.children, value } = factory(props) as {
-        value?: ContextValue;
-        children?: React.ReactNode;
-      };
+      const {
+        children = props.children,
+        enabled = true,
+        value
+      } = factory(props);
 
       if (!value) {
         throw error(
@@ -83,8 +41,11 @@ export default function createProvider<
         );
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, react-hooks/exhaustive-deps
-      const memoValue = useMemo(() => value, [...Object.values(value)]);
+      const memoValue = useMemo(
+        () => (enabled ? value : null),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, react-hooks/exhaustive-deps
+        [enabled, ...Object.values(value)]
+      );
 
       const ContextProvider = getContextProvider(Context);
 
@@ -105,6 +66,14 @@ export default function createProvider<
       [`${name}Context`]: Context,
       [`${name}Provider`]: Provider,
       [`use${name}Context`]: useEnhancedContext
-    } as any;
+    } as {
+      [P in ProviderName as `${P}Context`]: React.Context<ContextValue>;
+    } & {
+      [P in ProviderName as `${P}Provider`]: React.FC<ProviderProps>;
+    } & {
+      [P in ProviderName as `use${P}Context`]: () => Guarded extends true
+        ? ContextValue
+        : ContextValue | null;
+    };
   };
 }

--- a/packages/react-native-sortables/src/types/state.ts
+++ b/packages/react-native-sortables/src/types/state.ts
@@ -10,26 +10,50 @@ export enum LayerState {
   FOCUSED = 2
 }
 
-/**
- * Represents the state of absolute positioning layout in sortable components.
- * @enum {number}
- */
 export enum AbsoluteLayoutState {
   /**
    * Initial state when the layout is relative. This occurs before sorting
    * is enabled for the first time and any measurements have been made.
    */
-  PENDING = 1,
+  PENDING,
 
   /**
    * Intermediate state when the layout can be changed to absolute, but
    * measurements haven't been completed yet.
    */
-  TRANSITION = 2,
+  TRANSITION,
 
   /**
    * Final state when the absolute layout can be applied, after all measurements
    * have been completed.
    */
-  COMPLETE = 3
+  COMPLETE
+}
+
+export enum ItemPortalState {
+  /**
+   * Initial state when there is no portal or the item is rendered
+   * in its original position (not teleported).
+   */
+  IDLE,
+
+  /**
+   * Intermediate state when item teleportation has been scheduled
+   * but not completed yet. Represents the transition from IDLE to
+   * TELEPORTED state.
+   */
+  TELEPORTING,
+
+  /**
+   * State when the item is fully rendered within the portal outlet
+   * at its destination position.
+   */
+  TELEPORTED,
+
+  /**
+   * Intermediate state when the item is being removed from the portal
+   * outlet but the removal is not complete yet. Represents the
+   * transition from TELEPORTED back to IDLE state.
+   */
+  EXITING
 }


### PR DESCRIPTION
## Description

This PR adds a possibility to easily enable/disable the active item portal provider via the `enabled` boolean prop on the `Sortable.PortalProvider` component. It also refactors the `DraggableView` component and some other helper components so that the smooth activation/deactivation of the portal is possible.

## Changes showcase

- **Before** - the entire components tree was unmounted and the new tree was mounted within or outside of the provider
- **After** - no unmounting/mounting happens, only a single re-render is needed

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/973074a7-1cb0-4a95-b82b-c7219c156cb4" /> | <video src="https://github.com/user-attachments/assets/38ff2dfa-75ec-445f-920d-f9eb9ebca19e" /> |