### PR TITLE
feat: Active item dropped callback, more props in drag start callback

### DIFF
--- a/example/app/src/examples/SortableFlex/features/CallbacksExample.tsx
+++ b/example/app/src/examples/SortableFlex/features/CallbacksExample.tsx
@@ -2,13 +2,15 @@
 /* eslint-disable no-console */
 import { useCallback, useMemo, useState } from 'react';
 import { useSharedValue } from 'react-native-reanimated';
-import Sortable, {
-  type DragEndCallback,
-  type DragMoveCallback,
-  type DragStartCallback,
-  type OrderChangeCallback,
-  type SortableFlexDragEndCallback
+import type {
+  ActiveItemDroppedCallback,
+  DragEndCallback,
+  DragMoveCallback,
+  DragStartCallback,
+  OrderChangeCallback,
+  SortableFlexDragEndCallback
 } from 'react-native-sortables';
+import Sortable from 'react-native-sortables';
 
 import type { SwitchOptions } from '@/components';
 import {
@@ -67,6 +69,13 @@ export default function CallbacksExample() {
     [text]
   );
 
+  const onActiveItemDroppedJS = useCallback<ActiveItemDroppedCallback>(
+    params => {
+      text.value = formatCallbackResult('onActiveItemDropped', params);
+    },
+    [text]
+  );
+
   /* Callbacks executed on the UI thread */
 
   const onDragStartUI = useCallback<DragStartCallback>(
@@ -101,12 +110,21 @@ export default function CallbacksExample() {
     [text]
   );
 
+  const onActiveItemDroppedUI = useCallback<ActiveItemDroppedCallback>(
+    params => {
+      'worklet';
+      text.value = formatCallbackResult('onActiveItemDropped', params);
+    },
+    [text]
+  );
+
   const options = useMemo(
     () => ({
       onDragStart: sw(onDragStartJS, onDragStartUI),
       onDragEnd: sw(onDragEndJS, onDragEndUI),
       onOrderChange: sw(onOrderChangeJS, onOrderChangeUI),
-      onDragMove: sw(onDragMoveJS, onDragMoveUI)
+      onDragMove: sw(onDragMoveJS, onDragMoveUI),
+      onActiveItemDropped: sw(onActiveItemDroppedJS, onActiveItemDroppedUI)
     }),
     [
       onDragEndJS,
@@ -116,7 +134,9 @@ export default function CallbacksExample() {
       onDragStartJS,
       onDragStartUI,
       onOrderChangeJS,
-      onOrderChangeUI
+      onOrderChangeUI,
+      onActiveItemDroppedJS,
+      onActiveItemDroppedUI
     ]
   );
 

--- a/example/app/src/examples/SortableGrid/features/CallbacksExample.tsx
+++ b/example/app/src/examples/SortableGrid/features/CallbacksExample.tsx
@@ -2,14 +2,16 @@
 /* eslint-disable no-console */
 import { useCallback, useMemo, useState } from 'react';
 import { useSharedValue } from 'react-native-reanimated';
-import Sortable, {
-  type DragEndCallback,
-  type DragMoveCallback,
-  type DragStartCallback,
-  type OrderChangeCallback,
-  type SortableGridDragEndCallback,
-  type SortableGridRenderItem
+import type {
+  ActiveItemDroppedCallback,
+  DragEndCallback,
+  DragMoveCallback,
+  DragStartCallback,
+  OrderChangeCallback,
+  SortableGridDragEndCallback,
+  SortableGridRenderItem
 } from 'react-native-sortables';
+import Sortable from 'react-native-sortables';
 
 import type { SwitchOptions } from '@/components';
 import {
@@ -68,6 +70,13 @@ export default function CallbacksExample() {
     [text]
   );
 
+  const onActiveItemDroppedJS = useCallback<ActiveItemDroppedCallback>(
+    params => {
+      text.value = formatCallbackResult('onActiveItemDropped', params);
+    },
+    [text]
+  );
+
   /* Callbacks executed on the UI thread */
 
   const onDragStartUI = useCallback<DragStartCallback>(
@@ -102,6 +111,14 @@ export default function CallbacksExample() {
     [text]
   );
 
+  const onActiveItemDroppedUI = useCallback<ActiveItemDroppedCallback>(
+    params => {
+      'worklet';
+      text.value = formatCallbackResult('onActiveItemDropped', params);
+    },
+    [text]
+  );
+
   const renderItem = useCallback<SortableGridRenderItem<(typeof DATA)[number]>>(
     ({ item }) => <GridCard>{item}</GridCard>,
     []
@@ -112,7 +129,8 @@ export default function CallbacksExample() {
       onDragStart: sw(onDragStartJS, onDragStartUI),
       onDragEnd: sw(onDragEndJS, onDragEndUI),
       onOrderChange: sw(onOrderChangeJS, onOrderChangeUI),
-      onDragMove: sw(onDragMoveJS, onDragMoveUI)
+      onDragMove: sw(onDragMoveJS, onDragMoveUI),
+      onActiveItemDropped: sw(onActiveItemDroppedJS, onActiveItemDroppedUI)
     }),
     [
       onDragEndJS,
@@ -122,7 +140,9 @@ export default function CallbacksExample() {
       onDragStartJS,
       onDragStartUI,
       onOrderChangeJS,
-      onOrderChangeUI
+      onOrderChangeUI,
+      onActiveItemDroppedJS,
+      onActiveItemDroppedUI
     ]
   );
 

--- a/packages/react-native-sortables/src/constants/props.ts
+++ b/packages/react-native-sortables/src/constants/props.ts
@@ -59,6 +59,7 @@ export const DEFAULT_SHARED_PROPS = {
   itemExiting: IS_WEB ? null : SortableItemExiting,
   itemsLayout: IS_WEB ? null : LinearTransition,
   itemsLayoutTransitionMode: 'all',
+  onActiveItemDropped: undefined,
   onDragMove: undefined,
   onDragStart: undefined,
   onOrderChange: undefined,

--- a/packages/react-native-sortables/src/index.ts
+++ b/packages/react-native-sortables/src/index.ts
@@ -12,6 +12,7 @@ import { PortalProvider } from './providers';
 export type { CustomHandleProps, SortableLayerProps } from './components';
 export * from './constants/layoutAnimations';
 export type {
+  ActiveItemDroppedCallback,
   DragEndCallback,
   DragMoveCallback,
   DragStartCallback,

--- a/packages/react-native-sortables/src/providers/SharedProvider.tsx
+++ b/packages/react-native-sortables/src/providers/SharedProvider.tsx
@@ -57,6 +57,7 @@ export default function SharedProvider({
   debug,
   hapticsEnabled,
   itemKeys,
+  onActiveItemDropped,
   onDragEnd,
   onDragMove,
   onDragStart,
@@ -103,6 +104,7 @@ export default function SharedProvider({
     <DragProvider
       hapticsEnabled={hapticsEnabled}
       overDrag={overDrag}
+      onActiveItemDropped={onActiveItemDropped}
       onDragEnd={onDragEnd}
       onDragMove={onDragMove}
       onDragStart={onDragStart}

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.ts
@@ -51,6 +51,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
   DragContextType
 >(({
   hapticsEnabled,
+  onActiveItemDropped,
   onDragEnd: stableOnDragEnd,
   onDragMove,
   onDragStart,
@@ -115,6 +116,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
   const stableOnDragStart = useStableCallbackValue(onDragStart);
   const stableOnDragMove = useStableCallbackValue(onDragMove);
   const stableOnOrderChange = useStableCallbackValue(onOrderChange);
+  const stableOnActiveItemDropped = useStableCallbackValue(onActiveItemDropped);
 
   // ACTIVE ITEM POSITION UPDATER
   useAnimatedReaction(
@@ -474,6 +476,9 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
         activeHandleMeasurements.value = null;
       }
 
+      const fromIndex = dragStartIndex.value;
+      const toIndex = keyToIndex.value[key]!;
+
       if (activeItemKey.value !== null) {
         prevActiveItemKey.value = activeItemKey.value;
         activeItemKey.value = null;
@@ -481,11 +486,11 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
         haptics.medium();
 
         stableOnDragEnd({
-          fromIndex: dragStartIndex.value,
+          fromIndex,
           indexToKey: indexToKey.value,
           key,
           keyToIndex: keyToIndex.value,
-          toIndex: keyToIndex.value[key]!
+          toIndex
         });
       }
 
@@ -502,6 +507,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
         prevActiveItemKey.value = null;
         activeItemDropped.value = true;
         updateLayer?.(LayerState.IDLE);
+        stableOnActiveItemDropped({ fromIndex, key, toIndex });
       }, dropAnimationDuration.value);
     },
     [
@@ -522,6 +528,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       inactiveAnimationProgress,
       indexToKey,
       keyToIndex,
+      stableOnActiveItemDropped,
       stableOnDragEnd,
       touchPosition,
       touchStartTouch,

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.ts
@@ -317,7 +317,9 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       haptics.medium();
       stableOnDragStart({
         fromIndex: dragStartIndex.value,
-        key
+        indexToKey: indexToKey.value,
+        key,
+        keyToIndex: keyToIndex.value
       });
     },
     [
@@ -334,6 +336,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       inactiveAnimationProgress,
       inactiveItemOpacity,
       inactiveItemScale,
+      indexToKey,
       itemDimensions,
       itemPositions,
       keyToIndex,

--- a/packages/react-native-sortables/src/types/props/shared.ts
+++ b/packages/react-native-sortables/src/types/props/shared.ts
@@ -131,6 +131,10 @@ export type DragStartParams = {
   key: string;
   /** Original index of the dragged item */
   fromIndex: number;
+  /** Array mapping indices to item keys */
+  indexToKey: Array<string>;
+  /** Object mapping item keys to their indices */
+  keyToIndex: Record<string, number>;
 };
 
 /** Parameters provided when an item is being dragged. */

--- a/packages/react-native-sortables/src/types/props/shared.ts
+++ b/packages/react-native-sortables/src/types/props/shared.ts
@@ -163,16 +163,26 @@ export type DragEndParams = {
 
 /** Parameters provided when items change their positions during dragging. */
 export type OrderChangeParams = {
-  /** Original index of the moved item */
+  /** Unique identifier of the moved item */
+  key: string;
+  /** Previous index of the moved item */
   fromIndex: number;
   /** New index of the moved item */
   toIndex: number;
-  /** Unique identifier of the moved item */
-  key: string;
   /** Array mapping indices to item keys */
   indexToKey: Array<string>;
   /** Object mapping item keys to their indices */
   keyToIndex: Record<string, number>;
+};
+
+/** Parameters provided when the active item is dropped */
+export type ActiveItemDroppedParams = {
+  /** Unique identifier of the dropped item */
+  key: string;
+  /** Original index of the dropped item */
+  fromIndex: number;
+  /** Final index where the item was dropped */
+  toIndex: number;
 };
 
 /**
@@ -199,6 +209,14 @@ export type DragEndCallback = (params: DragEndParams) => void;
  */
 export type OrderChangeCallback = (params: OrderChangeParams) => void;
 
+/**
+ * Callback function called when the active item is dropped
+ * @param params - Parameters for the active item dropped event
+ */
+export type ActiveItemDroppedCallback = (
+  params: ActiveItemDroppedParams
+) => void;
+
 export type SortableCallbacks = {
   /** Called when an item starts being dragged
    * @param params Parameters for the drag start event
@@ -222,6 +240,11 @@ export type SortableCallbacks = {
    * it's called frequently during dragging. Use `onDragEnd` instead.
    */
   onOrderChange?: OrderChangeCallback;
+
+  /** Called once when the active item is dropped.
+   * @param params Parameters for the active item dropped event
+   */
+  onActiveItemDropped?: ActiveItemDroppedCallback;
 };
 
 export type Overflow = 'hidden' | 'visible';


### PR DESCRIPTION
## Description

This PR adds more props to the `onDragStart` callback and implement the new `onActiveItemDropped` callback that is called when the active item drop animation finishes.
