### PR TITLE
fix: Stop passing excessive data to the item context

### DIFF
--- a/packages/react-native-sortables/src/providers/shared/ItemContextProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/ItemContextProvider.ts
@@ -17,7 +17,7 @@ const { ItemContextProvider, useItemContextContext: useItemContext } =
   createProvider('ItemContext', { guarded: true })<
     ItemContextProviderProps,
     ItemContextType
-  >(props => {
+  >(({ itemKey, activationAnimationProgress, gesture, isActive }) => {
     const {
       activationState,
       activeItemKey,
@@ -28,7 +28,10 @@ const { ItemContextProvider, useItemContextContext: useItemContext } =
 
     return {
       value: {
-        ...props,
+        itemKey,
+        activationAnimationProgress,
+        gesture,
+        isActive,
         activationState,
         activeItemKey,
         indexToKey,

--- a/packages/react-native-sortables/src/providers/shared/ItemContextProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/ItemContextProvider.ts
@@ -17,7 +17,7 @@ const { ItemContextProvider, useItemContextContext: useItemContext } =
   createProvider('ItemContext', { guarded: true })<
     ItemContextProviderProps,
     ItemContextType
-  >(({ itemKey, activationAnimationProgress, gesture, isActive }) => {
+  >(({ activationAnimationProgress, gesture, isActive, itemKey }) => {
     const {
       activationState,
       activeItemKey,
@@ -28,13 +28,13 @@ const { ItemContextProvider, useItemContextContext: useItemContext } =
 
     return {
       value: {
-        itemKey,
         activationAnimationProgress,
-        gesture,
-        isActive,
         activationState,
         activeItemKey,
+        gesture,
         indexToKey,
+        isActive,
+        itemKey,
         keyToIndex,
         prevActiveItemKey
       }


### PR DESCRIPTION
## Description

This PR fixes unnecessary re-renders when the item context is used within the sortable item context caused by the excessive data being passed to the context. I mistakenly put children in there, which usually change on each render.