### PR TITLE
fix: Invalid call to gesture manager when item is no longer available

### DIFF
--- a/packages/react-native-sortables/src/components/shared/DraggableView/TeleportedItemCell.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/TeleportedItemCell.tsx
@@ -31,7 +31,7 @@ export default function TeleportedItemCell({
   onMeasure,
   teleportedItemId
 }: TeleportedItemCellProps) {
-  const { notifyRendered } = usePortalContext()!;
+  const { notifyRendered } = usePortalContext() ?? {};
 
   const teleportedItemStyles = useTeleportedItemStyles(
     itemKey,
@@ -43,6 +43,10 @@ export default function TeleportedItemCell({
     isActive,
     activationAnimationProgress
   );
+
+  if (!notifyRendered) {
+    return null;
+  }
 
   return (
     <ItemCell


### PR DESCRIPTION
## Description

This PR removes invalid call to the gesture manager when the item gets removed before the gesture starts being handled.
