### PR TITLE
fix: Items not animated before `sortEnabled` is set to `true`

### DIFF
--- a/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
@@ -109,16 +109,15 @@ export default function SortableContainer({
   });
 
   const animatedMeasurementsContainerStyle = useAnimatedStyle(() => {
-    if (!usesAbsoluteLayout.value) {
+    const ctrl = controlledContainerDimensions.value;
+    const height = ctrl.height ? containerHeight.value : undefined;
+    const width = ctrl.width ? containerWidth.value : undefined;
+
+    if (!height && !width) {
       return EMPTY_OBJECT;
     }
 
-    const ctrl = controlledContainerDimensions.value;
-
-    return {
-      height: ctrl.height ? containerHeight.value : undefined,
-      width: ctrl.width ? containerWidth.value : undefined
-    };
+    return { height, width };
   });
 
   return (

--- a/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
@@ -22,7 +22,6 @@ import type {
   DropIndicatorSettings,
   Overflow
 } from '../../types';
-import { AbsoluteLayoutState } from '../../types';
 import AnimatedOnLayoutView from './AnimatedOnLayoutView';
 import DropIndicator from './DropIndicator';
 
@@ -48,14 +47,14 @@ export default function SortableContainer({
   style
 }: AnimatedHeightContainerProps) {
   const {
-    absoluteLayoutState,
     activeItemDropped,
     activeItemKey,
     containerHeight,
     containerRef,
     containerWidth,
     controlledContainerDimensions,
-    shouldAnimateLayout
+    shouldAnimateLayout,
+    usesAbsoluteLayout
   } = useCommonValuesContext();
   const { handleHelperContainerMeasurement, measurementsContainerRef } =
     useMeasurementsContext();
@@ -64,7 +63,7 @@ export default function SortableContainer({
   const animateLayout = dimensionsAnimationType === 'layout';
 
   const outerContainerStyle = useAnimatedStyle(() => {
-    if (absoluteLayoutState.value !== AbsoluteLayoutState.COMPLETE) {
+    if (!usesAbsoluteLayout.value) {
       return EMPTY_OBJECT;
     }
 
@@ -92,7 +91,7 @@ export default function SortableContainer({
   }, [dimensionsAnimationType]);
 
   const innerContainerStyle = useAnimatedStyle(() => {
-    if (absoluteLayoutState.value !== AbsoluteLayoutState.COMPLETE) {
+    if (!usesAbsoluteLayout.value) {
       return EMPTY_OBJECT;
     }
 
@@ -110,7 +109,7 @@ export default function SortableContainer({
   });
 
   const animatedMeasurementsContainerStyle = useAnimatedStyle(() => {
-    if (absoluteLayoutState.value === AbsoluteLayoutState.PENDING) {
+    if (!usesAbsoluteLayout.value) {
       return EMPTY_OBJECT;
     }
 

--- a/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
@@ -9,7 +9,6 @@ import {
 import { type DEFAULT_SORTABLE_FLEX_PROPS, IS_WEB } from '../../../constants';
 import { useDebugContext } from '../../../debug';
 import {
-  AbsoluteLayoutState,
   type FlexLayout,
   type FlexLayoutContextType,
   type RequiredBy,
@@ -56,7 +55,6 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
   width
 }) => {
   const {
-    absoluteLayoutState,
     controlledContainerDimensions,
     indexToKey,
     itemDimensions,
@@ -147,10 +145,6 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
                 paddings: paddings.value
               },
         (props, previousProps) => {
-          if (absoluteLayoutState.value === AbsoluteLayoutState.PENDING) {
-            return;
-          }
-
           onChange(
             props && calculateLayout(props),
             // On web, animate layout only if parent container is not resized
@@ -171,8 +165,7 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
       rowGap,
       itemDimensions,
       dimensionsLimits,
-      paddings,
-      absoluteLayoutState
+      paddings
     ]
   );
 

--- a/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
@@ -10,7 +10,6 @@ import { IS_WEB } from '../../../constants';
 import { useDebugContext } from '../../../debug';
 import { useAnimatableValue } from '../../../hooks';
 import {
-  AbsoluteLayoutState,
   type Animatable,
   type GridLayout,
   type GridLayoutContextType
@@ -44,7 +43,6 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
   rowHeight
 }) => {
   const {
-    absoluteLayoutState,
     indexToKey,
     itemDimensions,
     itemPositions,
@@ -128,10 +126,6 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
           numGroups
         }),
         (props, previousProps) => {
-          if (absoluteLayoutState.value === AbsoluteLayoutState.PENDING) {
-            return;
-          }
-
           onChange(
             calculateLayout(props),
             // On web, animate layout only if parent container is not resized
@@ -142,15 +136,7 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
           );
         }
       ),
-    [
-      mainGroupSize,
-      mainGap,
-      crossGap,
-      numGroups,
-      isVertical,
-      itemDimensions,
-      absoluteLayoutState
-    ]
+    [mainGroupSize, mainGap, crossGap, numGroups, isVertical, itemDimensions]
   );
 
   const useGridLayout = useCallback(

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
@@ -21,7 +21,6 @@ import type {
   Maybe,
   Vector
 } from '../../types';
-import { AbsoluteLayoutState } from '../../types';
 import { areArraysDifferent, getKeyToIndex } from '../../utils';
 import { createProvider } from '../utils';
 import { useActiveItemValuesContext } from './ActiveItemValuesProvider';
@@ -117,7 +116,7 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
     // OTHER
     const containerRef = useAnimatedRef<View>();
     const sortEnabled = useAnimatableValue(_sortEnabled);
-    const absoluteLayoutState = useSharedValue(AbsoluteLayoutState.PENDING);
+    const usesAbsoluteLayout = useSharedValue(false);
     const shouldAnimateLayout = useSharedValue(true);
     const animateLayoutOnReorderOnly = useDerivedValue(
       () => itemsLayoutTransitionMode === 'reorder',
@@ -138,7 +137,6 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
     return {
       value: {
         ...useActiveItemValuesContext(),
-        absoluteLayoutState,
         activationAnimationDuration,
         activeItemOpacity,
         activeItemScale,
@@ -168,7 +166,8 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
         shouldAnimateLayout,
         snapOffsetX,
         snapOffsetY,
-        sortEnabled
+        sortEnabled,
+        usesAbsoluteLayout
       }
     };
   });

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.ts
@@ -21,11 +21,7 @@ import type {
   SortableCallbacks,
   Vector
 } from '../../types';
-import {
-  AbsoluteLayoutState,
-  DragActivationState,
-  LayerState
-} from '../../types';
+import { DragActivationState, LayerState } from '../../types';
 import {
   clearAnimatedTimeout,
   getKeyToIndex,
@@ -60,7 +56,6 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
   overDrag
 }) => {
   const {
-    absoluteLayoutState,
     activationAnimationDuration,
     activationState,
     activeAnimationProgress,
@@ -86,7 +81,8 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
     snapOffsetX,
     snapOffsetY,
     sortEnabled,
-    touchPosition
+    touchPosition,
+    usesAbsoluteLayout
   } = useCommonValuesContext();
   const { measureContainer } = useMeasurementsContext();
   const { updateLayer } = useLayerContext() ?? {};
@@ -351,7 +347,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
         return;
       }
 
-      if (absoluteLayoutState.value !== AbsoluteLayoutState.COMPLETE) {
+      if (!usesAbsoluteLayout.value) {
         measureContainer();
       }
 
@@ -364,7 +360,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       // Start handling touch after a delay to prevent accidental activation
       // e.g. while scrolling the ScrollView
       activationTimeoutId.value = setAnimatedTimeout(() => {
-        if (absoluteLayoutState.value !== AbsoluteLayoutState.COMPLETE) {
+        if (!usesAbsoluteLayout.value) {
           return;
         }
 
@@ -386,7 +382,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       }, dragActivationDelay.value);
     },
     [
-      absoluteLayoutState,
+      usesAbsoluteLayout,
       activeItemKey,
       activationState,
       activationTimeoutId,

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
@@ -7,7 +7,7 @@ import {
   withTiming
 } from 'react-native-reanimated';
 
-import { AbsoluteLayoutState, type AnimatedStyleProp } from '../../../types';
+import { type AnimatedStyleProp } from '../../../types';
 import { useCommonValuesContext } from '../CommonValuesProvider';
 import useItemZIndex from './useItemZIndex';
 
@@ -30,14 +30,14 @@ export default function useItemLayoutStyles(
   activationAnimationProgress: SharedValue<number>
 ): AnimatedStyleProp {
   const {
-    absoluteLayoutState,
     activeItemDropped,
     activeItemKey,
     activeItemPosition,
     animateLayoutOnReorderOnly,
     dropAnimationDuration,
     itemPositions,
-    shouldAnimateLayout
+    shouldAnimateLayout,
+    usesAbsoluteLayout
   } = useCommonValuesContext();
 
   const zIndex = useItemZIndex(key, activationAnimationProgress);
@@ -94,7 +94,7 @@ export default function useItemLayoutStyles(
   );
 
   return useAnimatedStyle(() => {
-    if (absoluteLayoutState.value !== AbsoluteLayoutState.COMPLETE) {
+    if (!usesAbsoluteLayout.value) {
       return RELATIVE_STYLE;
     }
 

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -24,11 +24,7 @@ import type {
   ItemDragSettings,
   ReorderTriggerOrigin
 } from '../props/shared';
-import type {
-  AbsoluteLayoutState,
-  DragActivationState,
-  LayerState
-} from '../state';
+import type { DragActivationState, LayerState } from '../state';
 import type {
   AnimatedValues,
   AnyRecord,
@@ -94,7 +90,7 @@ export type CommonValuesContextType = ActiveItemValuesContextType &
     // OTHER
     containerRef: AnimatedRef<View>;
     sortEnabled: SharedValue<boolean>;
-    absoluteLayoutState: SharedValue<AbsoluteLayoutState>;
+    usesAbsoluteLayout: SharedValue<boolean>;
     shouldAnimateLayout: SharedValue<boolean>; // is set to false on web when the browser window is resized
     animateLayoutOnReorderOnly: SharedValue<boolean>;
     customHandle: boolean;

--- a/packages/react-native-sortables/src/types/state.ts
+++ b/packages/react-native-sortables/src/types/state.ts
@@ -10,26 +10,6 @@ export enum LayerState {
   FOCUSED = 2
 }
 
-export enum AbsoluteLayoutState {
-  /**
-   * Initial state when the layout is relative. This occurs before sorting
-   * is enabled for the first time and any measurements have been made.
-   */
-  PENDING,
-
-  /**
-   * Intermediate state when the layout can be changed to absolute, but
-   * measurements haven't been completed yet.
-   */
-  TRANSITION,
-
-  /**
-   * Final state when the absolute layout can be applied, after all measurements
-   * have been completed.
-   */
-  COMPLETE
-}
-
 export enum ItemPortalState {
   /**
    * Initial state when there is no portal or the item is rendered


### PR DESCRIPTION
## Description

This issue was caused by the optimization that delayed transition to absolute layout until `sortEnabled` is set to `true`. I remove this optimization as it shouldn't affect performance that much but added unnecessary complexity and introduced this issue.
