### PR TITLE
fix: Flex layout issues

### DIFF
--- a/example/app/src/examples/SortableFlex/features/FlexLayoutExample.tsx
+++ b/example/app/src/examples/SortableFlex/features/FlexLayoutExample.tsx
@@ -31,9 +31,9 @@ type FlexWrap = Required<SortableFlexStyle>['flexWrap'];
 
 const FLEX_DIRECTIONS: Array<FlexDirection> = [
   'row',
-  'column'
-  // 'row-reverse',
-  // 'column-reverse'
+  'column',
+  'row-reverse',
+  'column-reverse'
 ];
 
 const ALIGN_CONTENT_OPTIONS: Array<AlignContent> = [

--- a/packages/react-native-sortables/src/components/SortableFlex.tsx
+++ b/packages/react-native-sortables/src/components/SortableFlex.tsx
@@ -131,7 +131,12 @@ function SortableFlexInner({
           // positioning from interfering with our absolute layout
           alignContent: 'flex-start',
           alignItems: 'flex-start',
-          justifyContent: 'flex-start'
+          flexDirection: 'row',
+          justifyContent: 'flex-start',
+          paddingBottom: 0,
+          paddingLeft: 0,
+          paddingRight: 0,
+          paddingTop: 0
         }
       : {}
   );


### PR DESCRIPTION
## Description

I noticed that flex layout was broken for non default direction/alignment properties probably because I mistakenly removed style overrides for the absolute layout.

I also saw that paddings weren't applied properly on web so I set paddings to 0 in the absolute layout to make sure that it doesn't influence absolutely positioned flex container items.
