### PR TITLE
perf: Merge item decoration styles with position styles

### DIFF
--- a/packages/react-native-sortables/src/components/shared/DraggableView/DraggableView.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/DraggableView.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren, ReactNode } from 'react';
 import { Fragment, memo, useEffect, useState } from 'react';
-import { StyleSheet, type ViewStyle } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
 import {
   LayoutAnimationConfig,
@@ -12,9 +12,8 @@ import {
   CommonValuesContext,
   ItemContextProvider,
   useCommonValuesContext,
-  useItemDecorationStyles,
-  useItemLayoutStyles,
   useItemPanGesture,
+  useItemStyles,
   useMeasurementsContext,
   usePortalContext
 } from '../../../providers';
@@ -51,12 +50,7 @@ function DraggableView({
   const [isTeleported, setIsTeleported] = useState(false);
   const activationAnimationProgress = useSharedValue(0);
   const isActive = useDerivedValue(() => activeItemKey.value === key);
-  const layoutStyles = useItemLayoutStyles(key, activationAnimationProgress);
-  const decorationStyles = useItemDecorationStyles(
-    key,
-    isActive,
-    activationAnimationProgress
-  );
+  const itemStyles = useItemStyles(key, isActive, activationAnimationProgress);
   const gesture = useItemPanGesture(key, activationAnimationProgress);
 
   useEffect(() => {
@@ -89,12 +83,12 @@ function DraggableView({
     </ItemContextProvider>
   );
 
-  const renderItemCell = (styleOverride?: ViewStyle) => {
+  const renderItemCell = (hidden?: boolean) => {
     const innerComponent = (
       <ItemCell
         {...layoutAnimations}
-        cellStyle={[style, layoutStyles, styleOverride]}
-        decorationStyles={decorationStyles}
+        // TODO - check if this hiding approach works
+        cellStyle={[style, itemStyles, hidden && styles.hidden]}
         itemsOverridesStyle={itemsOverridesStyle}
         onMeasure={(width, height) =>
           handleItemMeasurement(key, { height, width })
@@ -145,7 +139,7 @@ function DraggableView({
     <Fragment>
       {/* We cannot unmount this item as its gesture detector must be still
       mounted to continue handling the pan gesture */}
-      {renderItemCell(isTeleported ? styles.hidden : undefined)}
+      {renderItemCell(isTeleported)}
       <ActiveItemPortal
         activationAnimationProgress={activationAnimationProgress}
         renderTeleportedItemCell={renderTeleportedItemCell}

--- a/packages/react-native-sortables/src/components/shared/DraggableView/DraggableView.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/DraggableView.tsx
@@ -1,6 +1,5 @@
 import type { PropsWithChildren, ReactNode } from 'react';
 import { Fragment, memo, useEffect, useState } from 'react';
-import { StyleSheet } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
 import {
   LayoutAnimationConfig,
@@ -73,6 +72,9 @@ function DraggableView({
     };
   }, [portalContext, teleportedItemId]);
 
+  const onMeasure = (width: number, height: number) =>
+    handleItemMeasurement(key, { height, width });
+
   const withItemContext = (component: ReactNode) => (
     <ItemContextProvider
       activationAnimationProgress={activationAnimationProgress}
@@ -83,16 +85,14 @@ function DraggableView({
     </ItemContextProvider>
   );
 
-  const renderItemCell = (hidden?: boolean) => {
+  const renderItemCell = (hidden = false) => {
     const innerComponent = (
       <ItemCell
         {...layoutAnimations}
-        // TODO - check if this hiding approach works
-        cellStyle={[style, itemStyles, hidden && styles.hidden]}
+        cellStyle={[style, itemStyles]}
+        hidden={hidden}
         itemsOverridesStyle={itemsOverridesStyle}
-        onMeasure={(width, height) =>
-          handleItemMeasurement(key, { height, width })
-        }>
+        onMeasure={onMeasure}>
         <LayoutAnimationConfig skipEntering={false} skipExiting={false}>
           {children}
         </LayoutAnimationConfig>
@@ -128,7 +128,8 @@ function DraggableView({
           baseCellStyle={style}
           isActive={isActive}
           itemKey={key}
-          itemsOverridesStyle={itemsOverridesStyle}>
+          itemsOverridesStyle={itemsOverridesStyle}
+          onMeasure={onMeasure}>
           {children}
         </TeleportedItemCell>
       )}
@@ -149,11 +150,5 @@ function DraggableView({
     </Fragment>
   );
 }
-
-const styles = StyleSheet.create({
-  hidden: {
-    opacity: 0
-  }
-});
 
 export default memo(DraggableView);

--- a/packages/react-native-sortables/src/components/shared/DraggableView/ItemCell.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/ItemCell.tsx
@@ -1,7 +1,11 @@
 import type { PropsWithChildren } from 'react';
-import type { LayoutChangeEvent, ViewStyle } from 'react-native';
+import {
+  type LayoutChangeEvent,
+  Platform,
+  StyleSheet,
+  type ViewStyle
+} from 'react-native';
 import type { AnimatedStyle } from 'react-native-reanimated';
-import Animated from 'react-native-reanimated';
 
 import type {
   AnimatedStyleProp,
@@ -11,7 +15,6 @@ import type {
 import AnimatedOnLayoutView from '../AnimatedOnLayoutView';
 
 export type ItemCellProps = PropsWithChildren<{
-  decorationStyles: AnimatedStyleProp;
   itemsOverridesStyle: AnimatedStyle<ViewStyle>;
   cellStyle: AnimatedStyleProp;
   onMeasure?: MeasureCallback;
@@ -22,7 +25,6 @@ export type ItemCellProps = PropsWithChildren<{
 export default function ItemCell({
   cellStyle,
   children,
-  decorationStyles,
   entering,
   exiting,
   itemsOverridesStyle,
@@ -39,14 +41,29 @@ export default function ItemCell({
     : undefined;
 
   return (
-    <Animated.View style={cellStyle}>
-      <AnimatedOnLayoutView
-        entering={entering}
-        exiting={exiting}
-        style={[itemsOverridesStyle, decorationStyles]}
-        onLayout={maybeOnLayout}>
-        {children}
-      </AnimatedOnLayoutView>
-    </Animated.View>
+    <AnimatedOnLayoutView
+      entering={entering}
+      exiting={exiting}
+      style={[styles.decoration, cellStyle, itemsOverridesStyle]}
+      onLayout={maybeOnLayout}>
+      {children}
+    </AnimatedOnLayoutView>
   );
 }
+
+const styles = StyleSheet.create({
+  decoration: Platform.select<ViewStyle>({
+    android: {
+      elevation: 5
+    },
+    default: {},
+    native: {
+      shadowOffset: {
+        height: 0,
+        width: 0
+      },
+      shadowOpacity: 1,
+      shadowRadius: 5
+    }
+  })
+});

--- a/packages/react-native-sortables/src/components/shared/DraggableView/TeleportedItemCell.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/TeleportedItemCell.tsx
@@ -4,7 +4,7 @@ import type { AnimatedStyle, SharedValue } from 'react-native-reanimated';
 import { LayoutAnimationConfig } from 'react-native-reanimated';
 
 import { useTeleportedItemStyles } from '../../../providers';
-import type { AnimatedStyleProp } from '../../../types';
+import type { AnimatedStyleProp, MeasureCallback } from '../../../types';
 import ItemCell from './ItemCell';
 
 type TeleportedItemCellProps = PropsWithChildren<{
@@ -13,6 +13,7 @@ type TeleportedItemCellProps = PropsWithChildren<{
   baseCellStyle: AnimatedStyleProp;
   isActive: SharedValue<boolean>;
   itemKey: string;
+  onMeasure: MeasureCallback;
 }>;
 
 export default function TeleportedItemCell({
@@ -21,7 +22,8 @@ export default function TeleportedItemCell({
   children,
   isActive,
   itemKey,
-  itemsOverridesStyle
+  itemsOverridesStyle,
+  onMeasure
 }: TeleportedItemCellProps) {
   const teleportedItemStyles = useTeleportedItemStyles(
     itemKey,
@@ -32,7 +34,8 @@ export default function TeleportedItemCell({
   return (
     <ItemCell
       cellStyle={[baseCellStyle, teleportedItemStyles]}
-      itemsOverridesStyle={itemsOverridesStyle}>
+      itemsOverridesStyle={itemsOverridesStyle}
+      onMeasure={onMeasure}>
       <LayoutAnimationConfig skipEntering>{children}</LayoutAnimationConfig>
     </ItemCell>
   );

--- a/packages/react-native-sortables/src/components/shared/DraggableView/TeleportedItemCell.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/TeleportedItemCell.tsx
@@ -3,10 +3,7 @@ import type { ViewStyle } from 'react-native';
 import type { AnimatedStyle, SharedValue } from 'react-native-reanimated';
 import { LayoutAnimationConfig } from 'react-native-reanimated';
 
-import {
-  useItemDecorationStyles,
-  useTeleportedItemStyles
-} from '../../../providers';
+import { useTeleportedItemStyles } from '../../../providers';
 import type { AnimatedStyleProp } from '../../../types';
 import ItemCell from './ItemCell';
 
@@ -31,16 +28,10 @@ export default function TeleportedItemCell({
     isActive,
     activationAnimationProgress
   );
-  const decorationStyles = useItemDecorationStyles(
-    itemKey,
-    isActive,
-    activationAnimationProgress
-  );
 
   return (
     <ItemCell
       cellStyle={[baseCellStyle, teleportedItemStyles]}
-      decorationStyles={decorationStyles}
       itemsOverridesStyle={itemsOverridesStyle}>
       <LayoutAnimationConfig skipEntering>{children}</LayoutAnimationConfig>
     </ItemCell>

--- a/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
@@ -174,7 +174,7 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
     const mainDimension = isVertical ? 'width' : 'height';
     if (currentStyleOverride?.[mainDimension] !== mainGroupSize.value) {
       itemsStyleOverride.value = {
-        [mainDimension]: mainGroupSize.value
+        [mainDimension]: mainGroupSize.value + mainGap.value
       };
     }
 

--- a/packages/react-native-sortables/src/providers/layout/grid/utils/layout.ts
+++ b/packages/react-native-sortables/src/providers/layout/grid/utils/layout.ts
@@ -54,7 +54,7 @@ export const calculateLayout = ({
     // Update offset of the next group
     crossAxisOffsets[crossIndex + 1] = Math.max(
       crossAxisOffsets[crossIndex + 1] ?? 0,
-      crossAxisOffset + crossItemSize + gaps.cross
+      crossAxisOffset + crossItemSize
     );
 
     // Update item position

--- a/packages/react-native-sortables/src/providers/shared/hooks/index.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/index.ts
@@ -1,6 +1,6 @@
 export { default as useDebugBoundingBox } from './useDebugBoundingBox';
-export { default as useItemDecorationStyles } from './useItemDecorationStyles';
-export { default as useItemLayoutStyles } from './useItemLayoutStyles';
+export { default as useItemDecorationStyles } from './useItemDecorationValues';
 export { default as useItemPanGesture } from './useItemPanGesture';
+export { default as useItemStyles } from './useItemStyles';
 export { default as useOrderUpdater } from './useOrderUpdater';
 export { default as useTeleportedItemStyles } from './useTeleportedItemStyles';

--- a/packages/react-native-sortables/src/providers/shared/hooks/index.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/index.ts
@@ -1,5 +1,4 @@
 export { default as useDebugBoundingBox } from './useDebugBoundingBox';
-export { default as useItemDecorationStyles } from './useItemDecorationValues';
 export { default as useItemPanGesture } from './useItemPanGesture';
 export { default as useItemStyles } from './useItemStyles';
 export { default as useOrderUpdater } from './useOrderUpdater';

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemDecorationValues.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemDecorationValues.ts
@@ -1,24 +1,19 @@
-import { useMemo } from 'react';
-import type { ViewStyle } from 'react-native';
-import { Platform, StyleSheet } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
 import {
   interpolate,
   interpolateColor,
-  useAnimatedStyle,
   useDerivedValue,
   withTiming
 } from 'react-native-reanimated';
 
 import { IS_WEB } from '../../../constants';
-import type { AnimatedStyleProp } from '../../../types';
 import { useCommonValuesContext } from '../CommonValuesProvider';
 
-export default function useItemDecorationStyles(
-  itemKey: string,
+export default function useItemDecorationValues(
+  key: string,
   isActive: SharedValue<boolean>,
   activationAnimationProgress: SharedValue<number>
-): AnimatedStyleProp {
+) {
   const {
     activationAnimationDuration,
     activeItemOpacity,
@@ -31,7 +26,7 @@ export default function useItemDecorationStyles(
   } = useCommonValuesContext();
 
   const adjustedInactiveProgress = useDerivedValue(() => {
-    if (isActive.value || prevActiveItemKey.value === itemKey) {
+    if (isActive.value || prevActiveItemKey.value === key) {
       return withTiming(0, { duration: activationAnimationDuration.value });
     }
 
@@ -42,7 +37,7 @@ export default function useItemDecorationStyles(
     );
   });
 
-  const animatedStyle = useAnimatedStyle(() => {
+  return useDerivedValue(() => {
     const progress = activationAnimationProgress.value;
     const zeroProgressOpacity = interpolate(
       adjustedInactiveProgress.value,
@@ -83,23 +78,4 @@ export default function useItemDecorationStyles(
       ]
     };
   });
-
-  return useMemo(() => [styles.decoration, animatedStyle], [animatedStyle]);
 }
-
-const styles = StyleSheet.create({
-  decoration: Platform.select<ViewStyle>({
-    android: {
-      elevation: 5
-    },
-    default: {},
-    native: {
-      shadowOffset: {
-        height: 0,
-        width: 0
-      },
-      shadowOpacity: 1,
-      shadowRadius: 5
-    }
-  })
-});

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayoutStyles.ts
@@ -1,16 +1,10 @@
 import type { ViewStyle } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
-import {
-  interpolate,
-  useAnimatedReaction,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming
-} from 'react-native-reanimated';
+import { useAnimatedStyle } from 'react-native-reanimated';
 
-import type { AnimatedStyleProp, Vector } from '../../../types';
-import { areVectorsDifferent } from '../../../utils';
+import type { AnimatedStyleProp } from '../../../types';
 import { useCommonValuesContext } from '../CommonValuesProvider';
+import useItemPosition from './useItemPosition';
 import useItemZIndex from './useItemZIndex';
 
 const RELATIVE_STYLE: ViewStyle = {
@@ -29,112 +23,25 @@ export default function useItemLayoutStyles(
   key: string,
   activationAnimationProgress: SharedValue<number>
 ): AnimatedStyleProp {
-  const {
-    activeItemDropped,
-    activeItemKey,
-    activeItemPosition,
-    animateLayoutOnReorderOnly,
-    itemPositions,
-    shouldAnimateLayout,
-    usesAbsoluteLayout
-  } = useCommonValuesContext();
+  const { usesAbsoluteLayout } = useCommonValuesContext();
 
   const zIndex = useItemZIndex(key, activationAnimationProgress);
-  const dropStartValues = useSharedValue<null | {
-    position: Vector;
-    progress: number;
-  }>(null);
-
-  const translateX = useSharedValue<null | number>(null);
-  const translateY = useSharedValue<null | number>(null);
-
-  // Inactive item updater
-  useAnimatedReaction(
-    () => ({
-      activationProgress: activationAnimationProgress.value,
-      isActive: activeItemKey.value === key,
-      itemPosition: itemPositions.value[key]
-    }),
-    ({ activationProgress, isActive, itemPosition }, prev) => {
-      if (isActive || !itemPosition) {
-        dropStartValues.value = null;
-        return;
-      }
-
-      if (
-        translateX.value === null ||
-        translateY.value === null ||
-        !shouldAnimateLayout.value ||
-        (animateLayoutOnReorderOnly.value &&
-          activationProgress === 0 &&
-          activeItemDropped.value)
-      ) {
-        // No animation case
-        translateX.value = itemPosition.x;
-        translateY.value = itemPosition.y;
-      } else if (activationProgress > 0) {
-        // Drop animation case
-        if (
-          !dropStartValues.value ||
-          (prev?.itemPosition &&
-            areVectorsDifferent(prev.itemPosition, itemPosition))
-        ) {
-          dropStartValues.value = {
-            position: {
-              x: translateX.value,
-              y: translateY.value
-            },
-            progress: activationProgress
-          };
-        }
-
-        const {
-          position: { x, y },
-          progress
-        } = dropStartValues.value;
-        const animate = (from: number, to: number) =>
-          interpolate(activationProgress, [progress, 0], [from, to]);
-
-        translateX.value = animate(x, itemPosition.x);
-        translateY.value = animate(y, itemPosition.y);
-      } else {
-        // Order change animation case
-        translateX.value = withTiming(itemPosition.x);
-        translateY.value = withTiming(itemPosition.y);
-      }
-    }
-  );
-
-  // Active item updater
-  useAnimatedReaction(
-    () => ({
-      isActive: activeItemKey.value === key,
-      position: activeItemPosition.value
-    }),
-    ({ isActive, position }) => {
-      if (!isActive || !position) {
-        return;
-      }
-
-      translateX.value = position.x;
-      translateY.value = position.y;
-    }
-  );
+  const position = useItemPosition(key, activationAnimationProgress);
 
   return useAnimatedStyle(() => {
     if (!usesAbsoluteLayout.value) {
       return RELATIVE_STYLE;
     }
 
-    if (translateX.value === null || translateY.value === null) {
+    if (!position.value) {
       return HIDDEN_STYLE;
     }
 
     return {
       position: 'absolute',
       transform: [
-        { translateX: translateX.value },
-        { translateY: translateY.value }
+        { translateX: position.value.x },
+        { translateY: position.value.y }
       ],
       zIndex: zIndex.value
     };

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemPosition.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemPosition.ts
@@ -13,6 +13,7 @@ import { useCommonValuesContext } from '../CommonValuesProvider';
 
 export default function useItemPosition(
   key: string,
+  isActive: SharedValue<boolean>,
   activationAnimationProgress: SharedValue<number>
 ): SharedValue<null | Vector> {
   const {
@@ -30,7 +31,7 @@ export default function useItemPosition(
   }>(null);
 
   positionRef.current ??= makeMutable(
-    activeItemKey.value === key
+    isActive.value
       ? activeItemPosition.value
       : (itemPositions.value[key] ?? null)
   );
@@ -41,11 +42,11 @@ export default function useItemPosition(
   useAnimatedReaction(
     () => ({
       activationProgress: activationAnimationProgress.value,
-      isActive: activeItemKey.value === key,
+      active: isActive.value,
       itemPosition: itemPositions.value[key]
     }),
-    ({ activationProgress, isActive, itemPosition }, prev) => {
-      if (!itemPosition || isActive) {
+    ({ activationProgress, active, itemPosition }, prev) => {
+      if (!itemPosition || active) {
         dropStartValues.value = null;
         return;
       }
@@ -64,7 +65,7 @@ export default function useItemPosition(
       }
       // Set dropStartValues only if the item was previously active or if is
       // already during the drop animation and the target position changed
-      else if (dropStartValues.value ? positionChanged : prev?.isActive) {
+      else if (dropStartValues.value ? positionChanged : prev?.active) {
         dropStartValues.value = {
           position: result.value,
           progress: activationProgress
@@ -104,11 +105,11 @@ export default function useItemPosition(
   // Active item updater
   useAnimatedReaction(
     () => ({
-      isActive: activeItemKey.value === key,
+      active: isActive.value,
       position: activeItemPosition.value
     }),
-    ({ isActive, position }) => {
-      if (isActive && position) {
+    ({ active, position }) => {
+      if (active && position) {
         result.value = position;
       }
     }

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemPosition.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemPosition.ts
@@ -1,0 +1,118 @@
+import { useRef } from 'react';
+import {
+  interpolate,
+  makeMutable,
+  type SharedValue,
+  useAnimatedReaction,
+  withTiming
+} from 'react-native-reanimated';
+
+import type { Vector } from '../../../types';
+import { areVectorsDifferent, useMutableValue } from '../../../utils';
+import { useCommonValuesContext } from '../CommonValuesProvider';
+
+export default function useItemPosition(
+  key: string,
+  activationAnimationProgress: SharedValue<number>
+): SharedValue<null | Vector> {
+  const {
+    activeItemKey,
+    activeItemPosition,
+    animateLayoutOnReorderOnly,
+    itemPositions,
+    shouldAnimateLayout
+  } = useCommonValuesContext();
+
+  const positionRef = useRef<SharedValue<null | Vector>>(null);
+  const dropStartValues = useMutableValue<null | {
+    position: Vector;
+    progress: number;
+  }>(null);
+
+  positionRef.current ??= makeMutable(
+    activeItemKey.value === key
+      ? activeItemPosition.value
+      : (itemPositions.value[key] ?? null)
+  );
+
+  const result = positionRef.current;
+
+  // Inactive item updater
+  useAnimatedReaction(
+    () => ({
+      activationProgress: activationAnimationProgress.value,
+      isActive: activeItemKey.value === key,
+      itemPosition: itemPositions.value[key]
+    }),
+    ({ activationProgress, isActive, itemPosition }, prev) => {
+      if (!itemPosition || isActive) {
+        dropStartValues.value = null;
+        return;
+      }
+
+      if (!result.value) {
+        result.value = itemPosition;
+        return;
+      }
+
+      const positionChanged =
+        prev?.itemPosition &&
+        areVectorsDifferent(prev.itemPosition, itemPosition);
+
+      if (activationProgress === 0) {
+        dropStartValues.value = null;
+      }
+      // Set dropStartValues only if the item was previously active or if is
+      // already during the drop animation and the target position changed
+      else if (dropStartValues.value ? positionChanged : prev?.isActive) {
+        dropStartValues.value = {
+          position: result.value,
+          progress: activationProgress
+        };
+      }
+
+      if (dropStartValues.value) {
+        const {
+          position: { x, y },
+          progress
+        } = dropStartValues.value;
+        const animate = (from: number, to: number) =>
+          interpolate(activationProgress, [progress, 0], [from, to]);
+
+        result.value = {
+          x: animate(x, itemPosition.x),
+          y: animate(y, itemPosition.y)
+        };
+        return;
+      }
+
+      if (!positionChanged) {
+        return;
+      }
+
+      if (
+        shouldAnimateLayout.value &&
+        (!animateLayoutOnReorderOnly.value || activeItemKey.value !== null)
+      ) {
+        result.value = withTiming(itemPosition);
+      } else {
+        result.value = itemPosition;
+      }
+    }
+  );
+
+  // Active item updater
+  useAnimatedReaction(
+    () => ({
+      isActive: activeItemKey.value === key,
+      position: activeItemPosition.value
+    }),
+    ({ isActive, position }) => {
+      if (isActive && position) {
+        result.value = position;
+      }
+    }
+  );
+
+  return result;
+}

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemStyles.ts
@@ -3,7 +3,9 @@ import type { SharedValue } from 'react-native-reanimated';
 import { useAnimatedStyle } from 'react-native-reanimated';
 
 import type { AnimatedStyleProp } from '../../../types';
+import { mergeStyles } from '../../../utils';
 import { useCommonValuesContext } from '../CommonValuesProvider';
+import useItemDecorationValues from './useItemDecorationValues';
 import useItemPosition from './useItemPosition';
 import useItemZIndex from './useItemZIndex';
 
@@ -19,31 +21,40 @@ const HIDDEN_STYLE: ViewStyle = {
   zIndex: -1
 };
 
-export default function useItemLayoutStyles(
+export default function useItemStyles(
   key: string,
+  isActive: SharedValue<boolean>,
   activationAnimationProgress: SharedValue<number>
 ): AnimatedStyleProp {
   const { usesAbsoluteLayout } = useCommonValuesContext();
 
   const zIndex = useItemZIndex(key, activationAnimationProgress);
-  const position = useItemPosition(key, activationAnimationProgress);
+  const position = useItemPosition(key, isActive, activationAnimationProgress);
+  const decoration = useItemDecorationValues(
+    key,
+    isActive,
+    activationAnimationProgress
+  );
 
   return useAnimatedStyle(() => {
     if (!usesAbsoluteLayout.value) {
-      return RELATIVE_STYLE;
+      return mergeStyles(RELATIVE_STYLE, decoration.value);
     }
 
     if (!position.value) {
       return HIDDEN_STYLE;
     }
 
-    return {
-      position: 'absolute',
-      transform: [
-        { translateX: position.value.x },
-        { translateY: position.value.y }
-      ],
-      zIndex: zIndex.value
-    };
+    return mergeStyles(
+      {
+        position: 'absolute',
+        transform: [
+          { translateX: position.value.x },
+          { translateY: position.value.y }
+        ],
+        zIndex: zIndex.value
+      },
+      decoration.value
+    );
   });
 }

--- a/packages/react-native-sortables/src/providers/shared/hooks/useTeleportedItemPosition.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useTeleportedItemPosition.ts
@@ -17,8 +17,7 @@ export default function useTeleportedItemPosition(
   activationAnimationProgress: SharedValue<number>
 ) {
   const { activeItemAbsolutePosition } = usePortalContext() ?? {};
-  const { activeItemKey, containerRef, itemPositions } =
-    useCommonValuesContext();
+  const { containerRef, itemPositions } = useCommonValuesContext();
 
   const dropStartValues = useMutableValue<null | {
     fromAbsolute: Vector;
@@ -29,7 +28,7 @@ export default function useTeleportedItemPosition(
   // Drop start values calculation reaction
   useAnimatedReaction(
     () => ({
-      active: activeItemKey.value === key
+      active: isActive.value
     }),
     ({ active }) => {
       if (active) {

--- a/packages/react-native-sortables/src/providers/shared/hooks/useTeleportedItemPosition.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useTeleportedItemPosition.ts
@@ -1,0 +1,101 @@
+import type { SharedValue } from 'react-native-reanimated';
+import {
+  interpolate,
+  measure,
+  useAnimatedReaction,
+  useDerivedValue
+} from 'react-native-reanimated';
+
+import type { Vector } from '../../../types';
+import { useMutableValue } from '../../../utils';
+import { useCommonValuesContext } from '../CommonValuesProvider';
+import { usePortalContext } from '../PortalProvider';
+
+export default function useTeleportedItemPosition(
+  key: string,
+  isActive: SharedValue<boolean>,
+  activationAnimationProgress: SharedValue<number>
+) {
+  const { activeItemAbsolutePosition } = usePortalContext() ?? {};
+  const { activeItemKey, containerRef, itemPositions } =
+    useCommonValuesContext();
+
+  const dropStartValues = useMutableValue<null | {
+    fromAbsolute: Vector;
+    progress: number;
+    toRelative: Vector;
+  }>(null);
+
+  // Drop start values calculation reaction
+  useAnimatedReaction(
+    () => ({
+      active: activeItemKey.value === key
+    }),
+    ({ active }) => {
+      if (active) {
+        dropStartValues.value = null;
+      } else if (
+        activeItemAbsolutePosition?.value &&
+        itemPositions.value[key]
+      ) {
+        dropStartValues.value = {
+          fromAbsolute: activeItemAbsolutePosition.value,
+          progress: activationAnimationProgress.value,
+          toRelative: itemPositions.value[key]
+        };
+      }
+    }
+  );
+
+  const absoluteItemPosition = useDerivedValue(() => {
+    if (isActive.value) {
+      return activeItemAbsolutePosition?.value ?? null;
+    }
+
+    if (dropStartValues.value) {
+      const measurements = measure(containerRef);
+      if (!measurements) {
+        return null;
+      }
+
+      const { fromAbsolute, progress, toRelative } = dropStartValues.value;
+
+      const animate = (source: number, target: number) =>
+        interpolate(
+          activationAnimationProgress.value,
+          [progress, 0],
+          [source, target]
+        );
+
+      return {
+        x: animate(fromAbsolute.x, measurements.pageX + toRelative.x),
+        y: animate(fromAbsolute.y, measurements.pageY + toRelative.y)
+      };
+    }
+
+    return null;
+  });
+
+  // Drop start values updater on target position change
+  useAnimatedReaction(
+    () => itemPositions.value[key],
+    position => {
+      if (
+        isActive.value ||
+        activationAnimationProgress.value === 0 ||
+        !position ||
+        !absoluteItemPosition.value
+      ) {
+        return;
+      }
+
+      dropStartValues.value = {
+        fromAbsolute: absoluteItemPosition.value,
+        progress: activationAnimationProgress.value,
+        toRelative: position
+      };
+    }
+  );
+
+  return absoluteItemPosition;
+}

--- a/packages/react-native-sortables/src/providers/shared/hooks/useTeleportedItemStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useTeleportedItemStyles.ts
@@ -2,7 +2,9 @@ import { type StyleProp, type ViewStyle } from 'react-native';
 import type { AnimatedStyle, SharedValue } from 'react-native-reanimated';
 import { useAnimatedStyle } from 'react-native-reanimated';
 
+import { mergeStyles } from '../../../utils';
 import { usePortalOutletContext } from '../PortalOutletProvider';
+import useItemDecorationValues from './useItemDecorationValues';
 import useItemZIndex from './useItemZIndex';
 import useTeleportedItemPosition from './useTeleportedItemPosition';
 
@@ -19,6 +21,11 @@ export default function useTeleportedItemStyles(
     isActive,
     activationAnimationProgress
   );
+  const decoration = useItemDecorationValues(
+    key,
+    isActive,
+    activationAnimationProgress
+  );
 
   return useAnimatedStyle(() => {
     if (!portalOutletMeasurements?.value || !position.value) {
@@ -29,14 +36,17 @@ export default function useTeleportedItemStyles(
     const { pageX: outletX, pageY: outletY } = portalOutletMeasurements.value;
     const { x: itemX, y: itemY } = position.value;
 
-    return {
-      display: 'flex',
-      position: 'absolute',
-      transform: [
-        { translateX: itemX - outletX },
-        { translateY: itemY - outletY }
-      ],
-      zIndex: zIndex.value
-    };
+    return mergeStyles(
+      {
+        display: 'flex',
+        position: 'absolute',
+        transform: [
+          { translateX: itemX - outletX },
+          { translateY: itemY - outletY }
+        ],
+        zIndex: zIndex.value
+      },
+      decoration.value
+    );
   });
 }

--- a/packages/react-native-sortables/src/providers/shared/hooks/useTeleportedItemStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useTeleportedItemStyles.ts
@@ -1,120 +1,37 @@
-import { useMemo } from 'react';
-import { type StyleProp, StyleSheet, type ViewStyle } from 'react-native';
+import { type StyleProp, type ViewStyle } from 'react-native';
 import type { AnimatedStyle, SharedValue } from 'react-native-reanimated';
-import {
-  interpolate,
-  measure,
-  useAnimatedReaction,
-  useAnimatedStyle,
-  useDerivedValue,
-  useSharedValue
-} from 'react-native-reanimated';
+import { useAnimatedStyle } from 'react-native-reanimated';
 
-import type { Vector } from '../../../types';
-import { useCommonValuesContext } from '../CommonValuesProvider';
 import { usePortalOutletContext } from '../PortalOutletProvider';
-import { usePortalContext } from '../PortalProvider';
 import useItemZIndex from './useItemZIndex';
+import useTeleportedItemPosition from './useTeleportedItemPosition';
 
 export default function useTeleportedItemStyles(
   key: string,
   isActive: SharedValue<boolean>,
   activationAnimationProgress: SharedValue<number>
 ): StyleProp<AnimatedStyle<ViewStyle>> {
-  const { activeItemAbsolutePosition } = usePortalContext() ?? {};
   const { portalOutletMeasurements } = usePortalOutletContext() ?? {};
-  const { containerRef, itemPositions } = useCommonValuesContext();
 
   const zIndex = useItemZIndex(key, activationAnimationProgress);
-
-  const dropStartValues = useSharedValue<null | {
-    fromAbsolute: Vector;
-    progress: number;
-    toRelative: Vector;
-  }>(null);
-
-  // Drop start values calculation reaction
-  useAnimatedReaction(
-    () => ({
-      active: isActive.value
-    }),
-    ({ active }) => {
-      if (active) {
-        dropStartValues.value = null;
-      } else if (
-        activeItemAbsolutePosition?.value &&
-        itemPositions.value[key]
-      ) {
-        dropStartValues.value = {
-          fromAbsolute: activeItemAbsolutePosition.value,
-          progress: activationAnimationProgress.value,
-          toRelative: itemPositions.value[key]
-        };
-      }
-    }
+  const position = useTeleportedItemPosition(
+    key,
+    isActive,
+    activationAnimationProgress
   );
 
-  const absoluteItemPosition = useDerivedValue(() => {
-    if (isActive.value) {
-      return activeItemAbsolutePosition?.value ?? null;
-    }
-
-    if (dropStartValues.value) {
-      const measurements = measure(containerRef);
-      if (!measurements) {
-        return null;
-      }
-
-      const { fromAbsolute, progress, toRelative } = dropStartValues.value;
-
-      const animate = (source: number, target: number) =>
-        interpolate(
-          activationAnimationProgress.value,
-          [progress, 0],
-          [source, target]
-        );
-
-      return {
-        x: animate(fromAbsolute.x, measurements.pageX + toRelative.x),
-        y: animate(fromAbsolute.y, measurements.pageY + toRelative.y)
-      };
-    }
-
-    return null;
-  });
-
-  // Drop start values updater on target position change
-  useAnimatedReaction(
-    () => itemPositions.value[key],
-    position => {
-      if (
-        isActive.value ||
-        activationAnimationProgress.value === 0 ||
-        !position ||
-        !absoluteItemPosition.value
-      ) {
-        return;
-      }
-
-      dropStartValues.value = {
-        fromAbsolute: absoluteItemPosition.value,
-        progress: activationAnimationProgress.value,
-        toRelative: position
-      };
-    }
-  );
-
-  const animatedStyle = useAnimatedStyle(() => {
-    if (!portalOutletMeasurements?.value || !absoluteItemPosition.value) {
+  return useAnimatedStyle(() => {
+    if (!portalOutletMeasurements?.value || !position.value) {
       // This should never happen
       return { display: 'none' };
     }
 
     const { pageX: outletX, pageY: outletY } = portalOutletMeasurements.value;
-    const { x: itemX, y: itemY } = absoluteItemPosition.value;
+    const { x: itemX, y: itemY } = position.value;
 
     return {
       display: 'flex',
+      position: 'absolute',
       transform: [
         { translateX: itemX - outletX },
         { translateY: itemY - outletY }
@@ -122,12 +39,4 @@ export default function useTeleportedItemStyles(
       zIndex: zIndex.value
     };
   });
-
-  return useMemo(() => [styles.container, animatedStyle], [animatedStyle]);
 }
-
-const styles = StyleSheet.create({
-  container: {
-    position: 'absolute'
-  }
-});

--- a/packages/react-native-sortables/src/utils/index.ts
+++ b/packages/react-native-sortables/src/utils/index.ts
@@ -11,3 +11,4 @@ export * from './order';
 export * from './props';
 export * from './react';
 export * from './reanimated';
+export * from './styles';

--- a/packages/react-native-sortables/src/utils/reanimated/index.ts
+++ b/packages/react-native-sortables/src/utils/reanimated/index.ts
@@ -1,2 +1,3 @@
 export * from './animatedTimeout';
 export { useAnimatedDebounce } from './useAnimatedDebounce';
+export { default as useMutableValue } from './useMutableValue';

--- a/packages/react-native-sortables/src/utils/reanimated/useMutableValue.ts
+++ b/packages/react-native-sortables/src/utils/reanimated/useMutableValue.ts
@@ -2,6 +2,5 @@ import { useState } from 'react';
 import { makeMutable } from 'react-native-reanimated';
 
 export default function useMutableValue<T>(initialValue: T) {
-  const [mutable] = useState(makeMutable(initialValue));
-  return mutable;
+  return useState(makeMutable(initialValue))[0];
 }

--- a/packages/react-native-sortables/src/utils/reanimated/useMutableValue.ts
+++ b/packages/react-native-sortables/src/utils/reanimated/useMutableValue.ts
@@ -1,0 +1,7 @@
+import { useState } from 'react';
+import { makeMutable } from 'react-native-reanimated';
+
+export default function useMutableValue<T>(initialValue: T) {
+  const [mutable] = useState(makeMutable(initialValue));
+  return mutable;
+}

--- a/packages/react-native-sortables/src/utils/styles.ts
+++ b/packages/react-native-sortables/src/utils/styles.ts
@@ -1,0 +1,20 @@
+import type { ViewStyle } from 'react-native';
+
+export const mergeStyles = (...styles: Array<ViewStyle>): ViewStyle => {
+  'worklet';
+  return styles.reduce((acc, style) => {
+    if (
+      style.transform &&
+      acc.transform &&
+      typeof style.transform === 'object'
+    ) {
+      return {
+        ...acc,
+        ...style,
+        transform: [...acc.transform, ...style.transform]
+      } as ViewStyle;
+    }
+
+    return { ...acc, ...style };
+  }, {} as ViewStyle);
+};


### PR DESCRIPTION
## Description

This PR improves `ItemCell` component implementation by merging decoration animated styles and layout styles (which results in twice less animated views with custom props, so less commits and clones of ShadowNodes to apply reanimated changes). It also cleans up code a bit by separating item position calculation from animated styles hooks.