### PR TITLE
perf: Replace useSharedValue with useMutableValue

### DIFF
--- a/packages/react-native-sortables/src/components/shared/DraggableView/ActiveItemPortal.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/ActiveItemPortal.tsx
@@ -2,11 +2,11 @@ import { type PropsWithChildren, type ReactNode, useEffect } from 'react';
 import {
   runOnJS,
   type SharedValue,
-  useAnimatedReaction,
-  useSharedValue
+  useAnimatedReaction
 } from 'react-native-reanimated';
 
 import { usePortalContext } from '../../../providers';
+import { useMutableValue } from '../../../utils';
 
 type ActiveItemPortalProps = PropsWithChildren<{
   teleportedItemId: string;
@@ -21,7 +21,7 @@ export default function ActiveItemPortal({
   teleportedItemId
 }: ActiveItemPortalProps) {
   const { teleport } = usePortalContext()!;
-  const teleportEnabled = useSharedValue(false);
+  const teleportEnabled = useMutableValue(false);
 
   useEffect(() => {
     if (teleportEnabled.value) {

--- a/packages/react-native-sortables/src/components/shared/DraggableView/DraggableView.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/DraggableView.tsx
@@ -3,8 +3,7 @@ import { Fragment, memo, useEffect, useState } from 'react';
 import { GestureDetector } from 'react-native-gesture-handler';
 import {
   LayoutAnimationConfig,
-  useDerivedValue,
-  useSharedValue
+  useDerivedValue
 } from 'react-native-reanimated';
 
 import {
@@ -17,7 +16,7 @@ import {
   usePortalContext
 } from '../../../providers';
 import type { AnimatedStyleProp, LayoutAnimation } from '../../../types';
-import { getContextProvider } from '../../../utils';
+import { getContextProvider, useMutableValue } from '../../../utils';
 import ActiveItemPortal from './ActiveItemPortal';
 import ItemCell from './ItemCell';
 import TeleportedItemCell from './TeleportedItemCell';
@@ -47,7 +46,7 @@ function DraggableView({
   const teleportedItemId = `${componentId}-${key}`;
 
   const [isTeleported, setIsTeleported] = useState(false);
-  const activationAnimationProgress = useSharedValue(0);
+  const activationAnimationProgress = useMutableValue(0);
   const isActive = useDerivedValue(() => activeItemKey.value === key);
   const itemStyles = useItemStyles(key, isActive, activationAnimationProgress);
   const gesture = useItemPanGesture(key, activationAnimationProgress);

--- a/packages/react-native-sortables/src/components/shared/DropIndicator.tsx
+++ b/packages/react-native-sortables/src/components/shared/DropIndicator.tsx
@@ -8,7 +8,6 @@ import Animated, {
   useAnimatedReaction,
   useAnimatedStyle,
   useDerivedValue,
-  useSharedValue,
   withTiming
 } from 'react-native-reanimated';
 
@@ -18,6 +17,7 @@ import type {
   DropIndicatorComponentProps,
   Vector
 } from '../../types';
+import { useMutableValue } from '../../utils';
 
 const DEFAULT_STYLE: ViewStyle = {
   opacity: 0
@@ -42,13 +42,13 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
   // Clone the array in order to prevent user from mutating the internal state
   const orderedItemKeys = useDerivedValue(() => [...indexToKey.value]);
 
-  const dropIndex = useSharedValue(0);
-  const dropPosition = useSharedValue<Vector>({ x: 0, y: 0 });
-  const prevUpdateItemKey = useSharedValue<null | string>(null);
-  const dimensions = useSharedValue<Dimensions | null>(null);
+  const dropIndex = useMutableValue(0);
+  const dropPosition = useMutableValue<Vector>({ x: 0, y: 0 });
+  const prevUpdateItemKey = useMutableValue<null | string>(null);
+  const dimensions = useMutableValue<Dimensions | null>(null);
 
-  const x = useSharedValue<null | number>(null);
-  const y = useSharedValue<null | number>(null);
+  const x = useMutableValue<null | number>(null);
+  const y = useMutableValue<null | number>(null);
 
   useAnimatedReaction(
     () => ({

--- a/packages/react-native-sortables/src/hooks/reanimated/useStableCallbackValue.ts
+++ b/packages/react-native-sortables/src/hooks/reanimated/useStableCallbackValue.ts
@@ -1,11 +1,8 @@
 import { useCallback, useEffect } from 'react';
-import {
-  isWorkletFunction,
-  runOnJS,
-  useSharedValue
-} from 'react-native-reanimated';
+import { isWorkletFunction, runOnJS } from 'react-native-reanimated';
 
 import type { AnyFunction } from '../../types';
+import { useMutableValue } from '../../utils';
 
 // We cannot store a function as a SharedValue because reanimated will treat
 // it as an animation and will try to execute the animation when assigned
@@ -39,7 +36,7 @@ const wrap = <C extends AnyFunction>(callback: C): WrappedCallback<C> => {
 export default function useStableCallbackValue<C extends AnyFunction>(
   callback?: C
 ) {
-  const stableCallback = useSharedValue<null | WrappedCallback<C>>(null);
+  const stableCallback = useMutableValue<null | WrappedCallback<C>>(null);
 
   useEffect(() => {
     if (callback) {

--- a/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
@@ -1,10 +1,6 @@
 import { type PropsWithChildren, useCallback } from 'react';
 import type { SharedValue } from 'react-native-reanimated';
-import {
-  useAnimatedReaction,
-  useDerivedValue,
-  useSharedValue
-} from 'react-native-reanimated';
+import { useAnimatedReaction, useDerivedValue } from 'react-native-reanimated';
 
 import { type DEFAULT_SORTABLE_FLEX_PROPS, IS_WEB } from '../../../constants';
 import { useDebugContext } from '../../../debug';
@@ -14,7 +10,7 @@ import {
   type RequiredBy,
   type SortableFlexStyle
 } from '../../../types';
-import { haveEqualPropValues } from '../../../utils';
+import { haveEqualPropValues, useMutableValue } from '../../../utils';
 import { useCommonValuesContext, useMeasurementsContext } from '../../shared';
 import { createProvider } from '../../utils';
 import { calculateLayout, updateLayoutDebugRects } from './utils';
@@ -66,7 +62,7 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
   const { applyControlledContainerDimensions } = useMeasurementsContext();
   const debugContext = useDebugContext();
 
-  const keyToGroup = useSharedValue<Record<string, number>>({});
+  const keyToGroup = useMutableValue<Record<string, number>>({});
 
   const columnGap = useDerivedValue(() => columnGap_ ?? gap);
   const rowGap = useDerivedValue(() => rowGap_ ?? gap);
@@ -109,7 +105,7 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
     };
   });
 
-  const appliedLayout = useSharedValue<FlexLayout | null>(null);
+  const appliedLayout = useMutableValue<FlexLayout | null>(null);
 
   // Because the number of groups can dynamically change after order change
   // and we can't detect that in the React runtime, we are creating debug

--- a/packages/react-native-sortables/src/providers/layout/flex/updates/insert/index.ts
+++ b/packages/react-native-sortables/src/providers/layout/flex/updates/insert/index.ts
@@ -1,9 +1,5 @@
 import type { SharedValue } from 'react-native-reanimated';
-import {
-  useAnimatedReaction,
-  useDerivedValue,
-  useSharedValue
-} from 'react-native-reanimated';
+import { useAnimatedReaction, useDerivedValue } from 'react-native-reanimated';
 
 import type {
   Coordinate,
@@ -15,7 +11,8 @@ import {
   error,
   gt as gt_,
   lt as lt_,
-  reorderInsert
+  reorderInsert,
+  useMutableValue
 } from '../../../../../utils';
 import {
   getAdditionalSwapOffset,
@@ -80,10 +77,12 @@ const useInsertStrategy: SortableFlexStrategyFactory = ({
     crossGap = rowGap;
   }
 
-  const swappedBeforeIndexes = useSharedValue<ItemGroupSwapResult | null>(null);
-  const swappedAfterIndexes = useSharedValue<ItemGroupSwapResult | null>(null);
-  const swappedBeforeLayout = useSharedValue<FlexLayout | null>(null);
-  const swappedAfterLayout = useSharedValue<FlexLayout | null>(null);
+  const swappedBeforeIndexes = useMutableValue<ItemGroupSwapResult | null>(
+    null
+  );
+  const swappedAfterIndexes = useMutableValue<ItemGroupSwapResult | null>(null);
+  const swappedBeforeLayout = useMutableValue<FlexLayout | null>(null);
+  const swappedAfterLayout = useMutableValue<FlexLayout | null>(null);
   const debugBox = useDebugBoundingBox();
 
   const activeGroupIndex = useDerivedValue(() => {

--- a/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
@@ -2,8 +2,7 @@ import { type PropsWithChildren, useCallback } from 'react';
 import {
   type SharedValue,
   useAnimatedReaction,
-  useDerivedValue,
-  useSharedValue
+  useDerivedValue
 } from 'react-native-reanimated';
 
 import { IS_WEB } from '../../../constants';
@@ -14,6 +13,7 @@ import {
   type GridLayout,
   type GridLayoutContextType
 } from '../../../types';
+import { useMutableValue } from '../../../utils';
 import { useCommonValuesContext, useMeasurementsContext } from '../../shared';
 import { createProvider } from '../../utils';
 import { calculateLayout } from './utils';
@@ -69,7 +69,7 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
    * width - in vertical orientation (default) (columns are groups)
    * height - in horizontal orientation (rows are groups)
    */
-  const mainGroupSize = useSharedValue<null | number>(rowHeight ?? null);
+  const mainGroupSize = useMutableValue<null | number>(rowHeight ?? null);
 
   // MAIN GROUP SIZE UPDATER
   useAnimatedReaction(

--- a/packages/react-native-sortables/src/providers/layout/grid/updates/insert.ts
+++ b/packages/react-native-sortables/src/providers/layout/grid/updates/insert.ts
@@ -1,7 +1,11 @@
-import { useAnimatedReaction, useSharedValue } from 'react-native-reanimated';
+import { useAnimatedReaction } from 'react-native-reanimated';
 
 import { EMPTY_ARRAY } from '../../../../constants';
-import { areArraysDifferent, reorderInsert } from '../../../../utils';
+import {
+  areArraysDifferent,
+  reorderInsert,
+  useMutableValue
+} from '../../../../utils';
 import {
   useCommonValuesContext,
   useCustomHandleContext
@@ -24,7 +28,7 @@ import { createGridStrategy } from './common';
 function useInactiveIndexToKey() {
   const { activeItemKey, indexToKey } = useCommonValuesContext();
   const { fixedItemKeys } = useCustomHandleContext() ?? {};
-  const result = useSharedValue<Array<string>>(EMPTY_ARRAY);
+  const result = useMutableValue<Array<string>>(EMPTY_ARRAY);
 
   useAnimatedReaction(
     () => ({

--- a/packages/react-native-sortables/src/providers/layout/grid/updates/swap.ts
+++ b/packages/react-native-sortables/src/providers/layout/grid/updates/swap.ts
@@ -1,7 +1,11 @@
-import { useAnimatedReaction, useSharedValue } from 'react-native-reanimated';
+import { useAnimatedReaction } from 'react-native-reanimated';
 
 import { EMPTY_ARRAY } from '../../../../constants';
-import { areArraysDifferent, reorderSwap } from '../../../../utils';
+import {
+  areArraysDifferent,
+  reorderSwap,
+  useMutableValue
+} from '../../../../utils';
 import { useCommonValuesContext } from '../../../shared';
 import { useGridLayoutContext } from '../GridLayoutProvider';
 import { getMainIndex } from '../utils';
@@ -26,7 +30,7 @@ import { createGridStrategy } from './common';
 function useInactiveIndexToKey() {
   const { activeItemKey, indexToKey, keyToIndex } = useCommonValuesContext();
   const { numGroups } = useGridLayoutContext();
-  const result = useSharedValue<Array<string>>(EMPTY_ARRAY);
+  const result = useMutableValue<Array<string>>(EMPTY_ARRAY);
 
   useAnimatedReaction(
     () => ({

--- a/packages/react-native-sortables/src/providers/shared/ActiveItemValuesProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/ActiveItemValuesProvider.ts
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import { useSharedValue } from 'react-native-reanimated';
 
 import type {
   ActiveItemValuesContextType,
@@ -7,6 +6,7 @@ import type {
   Vector
 } from '../../types';
 import { DragActivationState } from '../../types';
+import { useMutableValue } from '../../utils';
 import { createProvider } from '../utils';
 
 type ActiveItemValuesProviderProps = {
@@ -17,19 +17,19 @@ const { ActiveItemValuesProvider, useActiveItemValuesContext } = createProvider(
   'ActiveItemValues'
 )<ActiveItemValuesProviderProps, ActiveItemValuesContextType>(() => {
   // POSITIONS
-  const touchPosition = useSharedValue<null | Vector>(null);
-  const activeItemPosition = useSharedValue<null | Vector>(null);
+  const touchPosition = useMutableValue<null | Vector>(null);
+  const activeItemPosition = useMutableValue<null | Vector>(null);
 
   // DIMENSIONS
-  const activeItemDimensions = useSharedValue<Dimensions | null>(null);
+  const activeItemDimensions = useMutableValue<Dimensions | null>(null);
 
   // DRAG STATE
-  const activeItemKey = useSharedValue<null | string>(null);
-  const prevActiveItemKey = useSharedValue<null | string>(null);
-  const activationState = useSharedValue(DragActivationState.INACTIVE);
-  const activeAnimationProgress = useSharedValue(0);
-  const inactiveAnimationProgress = useSharedValue(0);
-  const activeItemDropped = useSharedValue(true);
+  const activeItemKey = useMutableValue<null | string>(null);
+  const prevActiveItemKey = useMutableValue<null | string>(null);
+  const activationState = useMutableValue(DragActivationState.INACTIVE);
+  const activeAnimationProgress = useMutableValue(0);
+  const inactiveAnimationProgress = useMutableValue(0);
+  const activeItemDropped = useMutableValue(true);
 
   return {
     value: {

--- a/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/hooks.ts
+++ b/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/hooks.ts
@@ -2,13 +2,13 @@ import type { AnimatedRef, SharedValue } from 'react-native-reanimated';
 import {
   measure,
   useAnimatedReaction,
-  useDerivedValue,
-  useSharedValue
+  useDerivedValue
 } from 'react-native-reanimated';
 
 import { useDebugContext } from '../../../debug';
 import { useAnimatableValue } from '../../../hooks';
 import type { Animatable } from '../../../types';
+import { useMutableValue } from '../../../utils';
 import { useCommonValuesContext } from '../CommonValuesProvider';
 import {
   handleMeasurementsHorizontal,
@@ -30,8 +30,8 @@ export function useTargetScrollOffset(
   const debugRects = debugContext?.useDebugRects(['start', 'end']);
   const debugLine = debugContext?.useDebugLine();
 
-  const targetScrollOffset = useSharedValue<null | number>(null);
-  const startContainerPagePosition = useSharedValue<null | number>(null);
+  const targetScrollOffset = useMutableValue<null | number>(null);
+  const startContainerPagePosition = useMutableValue<null | number>(null);
 
   const activeItemHeight = useDerivedValue(() => {
     const key = activeItemKey.value;

--- a/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/index.tsx
+++ b/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/index.tsx
@@ -5,13 +5,13 @@ import {
   useAnimatedReaction,
   useDerivedValue,
   useFrameCallback,
-  useScrollViewOffset,
-  useSharedValue
+  useScrollViewOffset
 } from 'react-native-reanimated';
 
 import { OFFSET_EPS } from '../../../constants';
 import { useAnimatableValue } from '../../../hooks';
 import type { AutoScrollContextType, AutoScrollSettings } from '../../../types';
+import { useMutableValue } from '../../../utils';
 import { createProvider } from '../../utils';
 import { useCommonValuesContext } from '../CommonValuesProvider';
 import { useTargetScrollOffset } from './hooks';
@@ -31,7 +31,7 @@ const { AutoScrollProvider, useAutoScrollContext } = createProvider(
 
   const scrollOffset = useScrollViewOffset(scrollableRef);
   const dragStartScrollOffset = useAnimatableValue<null | number>(null);
-  const prevScrollToOffset = useSharedValue<null | number>(null);
+  const prevScrollToOffset = useMutableValue<null | number>(null);
   const scrollOffsetDiff = useDerivedValue(() => {
     if (dragStartScrollOffset.value === null) {
       return null;
@@ -45,7 +45,7 @@ const { AutoScrollProvider, useAutoScrollContext } = createProvider(
   const enabled = useAnimatableValue(autoScrollEnabled);
   const speed = useAnimatableValue(autoScrollSpeed);
 
-  const isFrameCallbackActive = useSharedValue(false);
+  const isFrameCallbackActive = useMutableValue(false);
 
   const targetScrollOffset = useTargetScrollOffset(
     scrollableRef,

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
@@ -4,8 +4,7 @@ import type { SharedValue } from 'react-native-reanimated';
 import {
   useAnimatedRef,
   useAnimatedStyle,
-  useDerivedValue,
-  useSharedValue
+  useDerivedValue
 } from 'react-native-reanimated';
 
 import { useAnimatableValue } from '../../hooks';
@@ -21,7 +20,11 @@ import type {
   Maybe,
   Vector
 } from '../../types';
-import { areArraysDifferent, getKeyToIndex } from '../../utils';
+import {
+  areArraysDifferent,
+  getKeyToIndex,
+  useMutableValue
+} from '../../utils';
 import { createProvider } from '../utils';
 import { useActiveItemValuesContext } from './ActiveItemValuesProvider';
 
@@ -68,24 +71,24 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
     const prevKeysRef = useRef<Array<string>>([]);
 
     // ORDER
-    const indexToKey = useSharedValue<Array<string>>(itemKeys);
+    const indexToKey = useMutableValue<Array<string>>(itemKeys);
     const keyToIndex = useDerivedValue(() => getKeyToIndex(indexToKey.value));
 
     // POSITIONS
-    const itemPositions = useSharedValue<Record<string, Vector>>({});
+    const itemPositions = useMutableValue<Record<string, Vector>>({});
 
     // DIMENSIONS
     // measured dimensions via onLayout used to calculate containerWidth and containerHeight
     // (should be used for layout calculations and to determine if calculated
     // container dimensions have been applied)
-    const measuredContainerWidth = useSharedValue<null | number>(null);
-    const measuredContainerHeight = useSharedValue<null | number>(null);
+    const measuredContainerWidth = useMutableValue<null | number>(null);
+    const measuredContainerHeight = useMutableValue<null | number>(null);
     // calculated based on measuredContainerWidth and measuredContainerHeight and current layout
     // (containerWidth and containerHeight should be used in most cases)
-    const containerWidth = useSharedValue<null | number>(null);
-    const containerHeight = useSharedValue<null | number>(null);
-    const itemDimensions = useSharedValue<Record<string, Dimensions>>({});
-    const itemsStyleOverride = useSharedValue<Maybe<ViewStyle>>(
+    const containerWidth = useMutableValue<null | number>(null);
+    const containerHeight = useMutableValue<null | number>(null);
+    const itemDimensions = useMutableValue<Record<string, Dimensions>>({});
+    const itemsStyleOverride = useMutableValue<Maybe<ViewStyle>>(
       initialItemsStyleOverride
     );
 
@@ -116,8 +119,8 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
     // OTHER
     const containerRef = useAnimatedRef<View>();
     const sortEnabled = useAnimatableValue(_sortEnabled);
-    const usesAbsoluteLayout = useSharedValue(false);
-    const shouldAnimateLayout = useSharedValue(true);
+    const usesAbsoluteLayout = useMutableValue(false);
+    const shouldAnimateLayout = useMutableValue(true);
     const animateLayoutOnReorderOnly = useDerivedValue(
       () => itemsLayoutTransitionMode === 'reorder',
       [itemsLayoutTransitionMode]

--- a/packages/react-native-sortables/src/providers/shared/CustomHandleProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/CustomHandleProvider.ts
@@ -1,10 +1,10 @@
 import { type ReactNode, useCallback } from 'react';
 import type { View } from 'react-native';
 import type { AnimatedRef, MeasuredDimensions } from 'react-native-reanimated';
-import { measure, runOnUI, useSharedValue } from 'react-native-reanimated';
+import { measure, runOnUI } from 'react-native-reanimated';
 
 import type { CustomHandleContextType, Vector } from '../../types';
-import { useAnimatedDebounce } from '../../utils';
+import { useAnimatedDebounce, useMutableValue } from '../../utils';
 import { createProvider } from '../utils';
 import { useCommonValuesContext } from './CommonValuesProvider';
 
@@ -19,12 +19,12 @@ const { CustomHandleProvider, useCustomHandleContext } = createProvider(
   const { containerRef, itemPositions } = useCommonValuesContext();
   const debounce = useAnimatedDebounce();
 
-  const fixedItemKeys = useSharedValue<Record<string, boolean>>({});
-  const handleRefs = useSharedValue<Record<string, AnimatedRef<View>>>({});
-  const activeHandleMeasurements = useSharedValue<MeasuredDimensions | null>(
+  const fixedItemKeys = useMutableValue<Record<string, boolean>>({});
+  const handleRefs = useMutableValue<Record<string, AnimatedRef<View>>>({});
+  const activeHandleMeasurements = useMutableValue<MeasuredDimensions | null>(
     null
   );
-  const activeHandleOffset = useSharedValue<null | Vector>(null);
+  const activeHandleOffset = useMutableValue<null | Vector>(null);
 
   const registerHandle = useCallback(
     (key: string, handleRef: AnimatedRef<View>, fixed: boolean) => {

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.ts
@@ -9,7 +9,6 @@ import {
   interpolate,
   measure,
   useAnimatedReaction,
-  useSharedValue,
   withTiming
 } from 'react-native-reanimated';
 
@@ -26,7 +25,8 @@ import {
   clearAnimatedTimeout,
   getKeyToIndex,
   getOffsetDistance,
-  setAnimatedTimeout
+  setAnimatedTimeout,
+  useMutableValue
 } from '../../utils';
 import { createProvider } from '../utils';
 import { useAutoScrollContext } from './AutoScrollProvider';
@@ -101,14 +101,14 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
     overDrag === 'horizontal' || overDrag === 'both';
   const hasVerticalOverDrag = overDrag === 'vertical' || overDrag === 'both';
 
-  const touchStartTouch = useSharedValue<null | TouchData>(null);
-  const currentTouch = useSharedValue<null | TouchData>(null);
-  const dragStartItemTouchOffset = useSharedValue<null | Vector>(null);
-  const dragStartTouchPosition = useSharedValue<null | Vector>(null);
-  const dragStartIndex = useSharedValue(-1);
+  const touchStartTouch = useMutableValue<null | TouchData>(null);
+  const currentTouch = useMutableValue<null | TouchData>(null);
+  const dragStartItemTouchOffset = useMutableValue<null | Vector>(null);
+  const dragStartTouchPosition = useMutableValue<null | Vector>(null);
+  const dragStartIndex = useMutableValue(-1);
 
   // used for activation and deactivation (drop)
-  const activationTimeoutId = useSharedValue(-1);
+  const activationTimeoutId = useMutableValue(-1);
 
   // Create stable callbacks to avoid re-rendering when the callback
   // function is not memoized

--- a/packages/react-native-sortables/src/providers/shared/LayerProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/LayerProvider.tsx
@@ -1,11 +1,9 @@
 import { type PropsWithChildren, useCallback } from 'react';
 import { StyleSheet } from 'react-native';
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue
-} from 'react-native-reanimated';
+import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 
 import type { LayerContextType, LayerState } from '../../types';
+import { useMutableValue } from '../../utils';
 import { createProvider } from '../utils';
 
 type LayerProviderProps = PropsWithChildren<{
@@ -18,7 +16,7 @@ const { LayerProvider, useLayerContext } = createProvider('Layer', {
   const { updateLayer: updateParentLayer } = (useLayerContext() ??
     {}) as Partial<LayerContextType>;
 
-  const zIndex = useSharedValue(0);
+  const zIndex = useMutableValue(0);
 
   const updateLayer = useCallback(
     (state: LayerState) => {

--- a/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
@@ -4,14 +4,17 @@ import {
   measure,
   runOnUI,
   useAnimatedReaction,
-  useAnimatedRef,
-  useSharedValue
+  useAnimatedRef
 } from 'react-native-reanimated';
 
 import { OFFSET_EPS } from '../../constants';
 import { useUIStableCallback } from '../../hooks';
 import { type Dimensions, type MeasurementsContextType } from '../../types';
-import { areDimensionsDifferent, useAnimatedDebounce } from '../../utils';
+import {
+  areDimensionsDifferent,
+  useAnimatedDebounce,
+  useMutableValue
+} from '../../utils';
 import { createProvider } from '../utils';
 import { useCommonValuesContext } from './CommonValuesProvider';
 
@@ -35,8 +38,8 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
   } = useCommonValuesContext();
 
   const measurementsContainerRef = useAnimatedRef<View>();
-  const measuredItemsCount = useSharedValue(0);
-  const initialItemMeasurementsCompleted = useSharedValue(false);
+  const measuredItemsCount = useMutableValue(0);
+  const initialItemMeasurementsCompleted = useMutableValue(false);
   const debounce = useAnimatedDebounce();
 
   const handleItemMeasurement = useUIStableCallback(

--- a/packages/react-native-sortables/src/providers/shared/PortalOutletProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/PortalOutletProvider.tsx
@@ -1,14 +1,10 @@
 import type { ReactNode } from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { MeasuredDimensions } from 'react-native-reanimated';
-import {
-  measure,
-  runOnUI,
-  useAnimatedRef,
-  useSharedValue
-} from 'react-native-reanimated';
+import { measure, runOnUI, useAnimatedRef } from 'react-native-reanimated';
 
 import type { PortalOutletContextType } from '../../types';
+import { useMutableValue } from '../../utils';
 import { createProvider } from '../utils';
 
 const { PortalOutletProvider, usePortalOutletContext } = createProvider(
@@ -16,7 +12,7 @@ const { PortalOutletProvider, usePortalOutletContext } = createProvider(
   { guarded: false }
 )<{ children: ReactNode }, PortalOutletContextType>(({ children }) => {
   const portalOutletRef = useAnimatedRef<View>();
-  const portalOutletMeasurements = useSharedValue<MeasuredDimensions | null>(
+  const portalOutletMeasurements = useMutableValue<MeasuredDimensions | null>(
     null
   );
 

--- a/packages/react-native-sortables/src/providers/shared/PortalProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/PortalProvider.tsx
@@ -1,12 +1,12 @@
 import type { ReactNode } from 'react';
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
-import { useSharedValue } from 'react-native-reanimated';
 
 import type {
   PortalContextType,
   PortalSubscription,
   Vector
 } from '../../types';
+import { useMutableValue } from '../../utils';
 import { createProvider } from '../utils';
 import { PortalOutletProvider } from './PortalOutletProvider';
 
@@ -23,7 +23,7 @@ const { PortalProvider, usePortalContext } = createProvider('Portal', {
   >({});
   const subscribersRef = useRef<Record<string, Set<PortalSubscription>>>({});
 
-  const activeItemAbsolutePosition = useSharedValue<null | Vector>(null);
+  const activeItemAbsolutePosition = useMutableValue<null | Vector>(null);
 
   useEffect(() => {
     if (!enabled) {

--- a/packages/react-native-sortables/src/utils/reanimated/useAnimatedDebounce.ts
+++ b/packages/react-native-sortables/src/utils/reanimated/useAnimatedDebounce.ts
@@ -1,14 +1,14 @@
 import { useCallback, useEffect } from 'react';
-import { useSharedValue } from 'react-native-reanimated';
 
 import {
   type AnimatedTimeoutID,
   clearAnimatedTimeout,
   setAnimatedTimeout
 } from './animatedTimeout';
+import useMutableValue from './useMutableValue';
 
 export function useAnimatedDebounce() {
-  const updateTimeoutId = useSharedValue<AnimatedTimeoutID>(-1);
+  const updateTimeoutId = useMutableValue<AnimatedTimeoutID>(-1);
 
   useEffect(() => {
     return () => {

--- a/packages/react-native-sortables/src/utils/reanimated/useMutableValue.ts
+++ b/packages/react-native-sortables/src/utils/reanimated/useMutableValue.ts
@@ -2,5 +2,5 @@ import { useState } from 'react';
 import { makeMutable } from 'react-native-reanimated';
 
 export default function useMutableValue<T>(initialValue: T) {
-  return useState(makeMutable(initialValue))[0];
+  return useState(() => makeMutable(initialValue))[0];
 }


### PR DESCRIPTION
## Description

This PR replaces all `useSharedValue` usages with `useMutableValue`. `useSharedValue` is heavier because of the cleanup `useEffect` that cancels currently running animation if there is any:

```
export function useSharedValue<Value>(initialValue: Value): SharedValue<Value> {
  const [mutable] = useState(() => makeMutable(initialValue));
  useEffect(() => {
    return () => {
      cancelAnimation(mutable);
    };
  }, [mutable]);
  return mutable;
}
```

I don't need this behavior as I never use infinite animations and, in most cases, don't use animations at all, rather update value by myself. I only use animations for items reordering and the drop indicator, but since they are just short `withTiming` animations, the cleanup is not necessary. Even if the animation keeps running after the view was unmounted, it runs for a brief while, so there is no performance benefit in eager cleanup and it's better to reduce the number of unnecessary `useEffect` hooks.
