### PR TITLE
Fix DragProvider drag end index assignment

### DIFF
--- a/packages/react-native-sortables/src/providers/shared/DragProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.ts
@@ -457,6 +457,10 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       }
 
       clearAnimatedTimeout(activationTimeoutId.value);
+
+      const fromIndex = dragStartIndex.value;
+      const toIndex = keyToIndex.value[key]!;
+
       touchStartTouch.value = null;
       currentTouch.value = null;
       activationState.value = DragActivationState.INACTIVE;
@@ -488,9 +492,6 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       updateStartScrollOffset?.(null);
       updateLayer?.(LayerState.INTERMEDIATE);
       haptics.medium();
-
-      const fromIndex = dragStartIndex.value;
-      const toIndex = keyToIndex.value[key]!;
 
       stableOnDragEnd({
         fromIndex,


### PR DESCRIPTION
## Description

Moves the assignment of fromIndex and toIndex earlier in the drag end handler to fix incorrect fromIndex value.

Previously, fromIndex was always -1 when using the onDragEnd callback because the state was being reset too early. This change ensures that the correct indices are captured before any cleanup happens.
