### PR TITLE
fix: Allow disabling default layer provider

### DIFF
--- a/packages/react-native-sortables/src/constants/props.ts
+++ b/packages/react-native-sortables/src/constants/props.ts
@@ -32,6 +32,7 @@ export const DEFAULT_SHARED_PROPS = {
   autoScrollDirection: 'vertical',
   autoScrollEnabled: true,
   autoScrollSpeed: 1,
+  bringToFrontWhenActive: true,
   customHandle: false,
   debug: false,
   dimensionsAnimationType: 'none',

--- a/packages/react-native-sortables/src/providers/SharedProvider.tsx
+++ b/packages/react-native-sortables/src/providers/SharedProvider.tsx
@@ -42,6 +42,7 @@ type SharedProviderProps = PropsWithChildren<
       debug: boolean;
       controlledContainerDimensions: SharedValue<ControlledContainerDimensions>;
       itemsLayoutTransitionMode: ItemsLayoutTransitionMode;
+      bringToFrontWhenActive: boolean;
       initialCanMeasureItems?: boolean;
       dropIndicatorStyle?: ViewStyle;
     }
@@ -52,6 +53,7 @@ export default function SharedProvider({
   autoScrollDirection,
   autoScrollEnabled,
   autoScrollSpeed,
+  bringToFrontWhenActive,
   children,
   customHandle,
   debug,
@@ -78,7 +80,7 @@ export default function SharedProvider({
 
   const providers = [
     // Provider used for proper zIndex management
-    !inMultiZone && <LayerProvider />,
+    bringToFrontWhenActive && !inMultiZone && <LayerProvider />,
     // Provider used for layout debugging (can be used only in dev mode)
     __DEV__ && debug && <DebugProvider />,
     // Provider used for shared values between all providers below

--- a/packages/react-native-sortables/src/types/props/grid.ts
+++ b/packages/react-native-sortables/src/types/props/grid.ts
@@ -90,7 +90,6 @@ export type SortableGridProps<I> = Simplify<
        * it is strongly recommended to provide a custom keyExtractor implementation.
        */
       keyExtractor?: (item: I) => string;
-
       /** Number of columns in the grid.
        *
        * Used to create a vertical grid layout where items flow from top to bottom,
@@ -98,7 +97,6 @@ export type SortableGridProps<I> = Simplify<
        * @default 1
        */
       columns?: number;
-
       /** Number of rows in the grid.
        *
        * Used to create a horizontal grid layout where items flow from left to right,
@@ -107,7 +105,6 @@ export type SortableGridProps<I> = Simplify<
        * Requires rowHeight to be set.
        */
       rows?: number;
-
       /** Fixed height for each row in pixels in the horizontal grid.
        *
        * All rows of the horizontal grid have the same height.

--- a/packages/react-native-sortables/src/types/props/shared.ts
+++ b/packages/react-native-sortables/src/types/props/shared.ts
@@ -274,6 +274,10 @@ export type SharedProps = Simplify<
            * @note This only works in development builds and has no effect in production.
            */
           debug: boolean;
+          /** Whether the zIndex of the sortable container should be changed when
+           * drag starts
+           */
+          bringToFrontWhenActive: boolean;
         }
     >
 >;


### PR DESCRIPTION
## Description

This PR should fix the context menu issue reported in #417. The issue seems to be caused by the `zIndex` change of the sortable component when the item gets activated, which cancels the long press gesture from the context menu. I haven't found any better solution than this, which lets the user disable the `zIndex` change and just added a new prop to disable it.

Setting `bringToFrontWhenActive` to `false`, unfortunately results in rendering sortable items below its siblings rendered below (after it), which can be seen in the following example.

<details>
<summary>Source code</summary>

```tsx
import { useCallback } from 'react';
import { StyleSheet, Text, View } from 'react-native';
import type { SortableGridRenderItem } from 'react-native-sortables';
import Sortable from 'react-native-sortables';

import { ScrollScreen } from '@/components';
import { colors, radius, sizes, spacing, text } from '@/theme';

const DATA = Array.from({ length: 5 }, (_, index) => `Item ${index + 1}`);

export default function PlaygroundExample() {
  const renderItem = useCallback<SortableGridRenderItem<string>>(
    ({ item }) => (
      <View style={styles.card}>
        <Text style={styles.text}>{item}</Text>
      </View>
    ),
    []
  );

  return (
    <ScrollScreen contentContainerStyle={styles.container} includeNavBarHeight>
      <Sortable.Grid
        bringToFrontWhenActive={false}
        columnGap={10}
        columns={3}
        data={DATA}
        renderItem={renderItem}
        rowGap={10}
      />
      <Sortable.Grid
        columnGap={10}
        columns={3}
        data={DATA}
        renderItem={renderItem}
        rowGap={10}
      />
    </ScrollScreen>
  );
}

const styles = StyleSheet.create({
  card: {
    alignItems: 'center',
    backgroundColor: '#36877F',
    borderRadius: radius.md,
    height: sizes.xl,
    justifyContent: 'center'
  },
  container: {
    padding: spacing.md
  },
  text: {
    ...text.label2,
    color: colors.white
  }
});
```
</details>

| `bringToFrontWhenActive={true}` | `bringToFrontWhenActive={false}` |
|-|-|
| <video src="https://github.com/user-attachments/assets/64b54272-778e-4aba-9004-3e0b2b17f32a" /> | <video src="https://github.com/user-attachments/assets/b2a399f3-8432-4ae5-babe-b8f0e58f27d3" /> |
