### PR TITLE
feat: Separate controlled item dimensions from measured dimensions

### DIFF
--- a/example/app/src/examples/navigation/routes.ts
+++ b/example/app/src/examples/navigation/routes.ts
@@ -8,7 +8,7 @@ import type { Routes } from './types';
 
 const routes: Routes = {
   SortableGrid: {
-    // CardComponent: SortableGridCard,
+    CardComponent: SortableGridCard,
     name: 'Sortable Grid',
     flatten: true,
     routes: {
@@ -102,7 +102,7 @@ const routes: Routes = {
     }
   },
   SortableFlex: {
-    // CardComponent: SortableFlexCard,
+    CardComponent: SortableFlexCard,
     name: 'Sortable Flex',
     flatten: true,
     routes: {

--- a/example/app/src/examples/navigation/routes.ts
+++ b/example/app/src/examples/navigation/routes.ts
@@ -8,7 +8,7 @@ import type { Routes } from './types';
 
 const routes: Routes = {
   SortableGrid: {
-    CardComponent: SortableGridCard,
+    // CardComponent: SortableGridCard,
     name: 'Sortable Grid',
     flatten: true,
     routes: {
@@ -102,7 +102,7 @@ const routes: Routes = {
     }
   },
   SortableFlex: {
-    CardComponent: SortableFlexCard,
+    // CardComponent: SortableFlexCard,
     name: 'Sortable Flex',
     flatten: true,
     routes: {

--- a/packages/react-native-sortables/src/components/SortableFlex.tsx
+++ b/packages/react-native-sortables/src/components/SortableFlex.tsx
@@ -1,10 +1,6 @@
-import { type ReactElement } from 'react';
+import { type ReactElement, useMemo } from 'react';
 import { type StyleProp, StyleSheet, type ViewStyle } from 'react-native';
-import {
-  runOnUI,
-  useAnimatedStyle,
-  useDerivedValue
-} from 'react-native-reanimated';
+import { runOnUI, useAnimatedStyle } from 'react-native-reanimated';
 
 import {
   DEFAULT_SORTABLE_FLEX_PROPS,
@@ -24,6 +20,11 @@ import {
 import type { DropIndicatorSettings, SortableFlexProps } from '../types';
 import { getPropsWithDefaults, orderItems, validateChildren } from '../utils';
 import { DraggableView, SortableContainer } from './shared';
+
+const CONTROLLED_ITEM_DIMENSIONS = {
+  height: false,
+  width: false
+};
 
 function SortableFlex(props: SortableFlexProps) {
   const {
@@ -53,15 +54,17 @@ function SortableFlex(props: SortableFlexProps) {
   const itemKeys = childrenArray.map(([key]) => key);
 
   const { flexDirection, flexWrap } = styleProps;
-  const controlledContainerDimensions = useDerivedValue(() => {
+  const isColumn = flexDirection.startsWith('column');
+
+  const controlledContainerDimensions = useMemo(() => {
     if (flexWrap === 'nowrap') {
       return { height: height === undefined, width: width === undefined };
     }
     return {
       height: height === undefined,
-      width: flexDirection.startsWith('column') && width === undefined
+      width: isColumn && width === undefined
     };
-  }, [flexWrap, flexDirection, height, width]);
+  }, [flexWrap, isColumn, height, width]);
 
   const onDragEnd = useDragEndHandler(_onDragEnd, {
     order: params =>
@@ -74,6 +77,7 @@ function SortableFlex(props: SortableFlexProps) {
     <SharedProvider
       {...sharedProps}
       controlledContainerDimensions={controlledContainerDimensions}
+      controlledItemDimensions={CONTROLLED_ITEM_DIMENSIONS}
       debug={debug}
       itemKeys={itemKeys}
       onDragEnd={onDragEnd}>

--- a/packages/react-native-sortables/src/components/SortableGrid.tsx
+++ b/packages/react-native-sortables/src/components/SortableGrid.tsx
@@ -6,6 +6,7 @@ import { runOnUI, useAnimatedStyle } from 'react-native-reanimated';
 import { DEFAULT_SORTABLE_GRID_PROPS, IS_WEB } from '../constants';
 import { useDragEndHandler } from '../hooks';
 import { useAnimatableValue } from '../integrations/reanimated';
+import type { ItemDimensionsValidator } from '../providers';
 import {
   GRID_STRATEGIES,
   GridLayoutProvider,
@@ -21,6 +22,7 @@ import type {
   SortableGridRenderItem
 } from '../types';
 import {
+  areValuesDifferent,
   defaultKeyExtractor,
   error,
   getPropsWithDefaults,
@@ -103,6 +105,7 @@ function SortableGrid<I>(props: SortableGridProps<I>) {
       controlledItemDimensions={controlledItemDimensions}
       debug={debug}
       itemKeys={itemKeys}
+      validateItemDimensions={IS_WEB ? undefined : validateItemDimensions}
       onDragEnd={onDragEnd}>
       <GridLayoutProvider
         columnGap={columnGapValue}
@@ -140,6 +143,23 @@ function SortableGrid<I>(props: SortableGridProps<I>) {
     </SharedProvider>
   );
 }
+
+const validateItemDimensions: ItemDimensionsValidator = (
+  resolvedWidth,
+  resolvedHeight,
+  controlledDimensions,
+  measuredDimensions
+) => {
+  'worklet';
+  const isNewItem = resolvedWidth === undefined || resolvedHeight === undefined;
+  return (
+    !isNewItem ||
+    (controlledDimensions.width &&
+      !areValuesDifferent(resolvedWidth, measuredDimensions.width, 1)) ||
+    (controlledDimensions.height &&
+      !areValuesDifferent(resolvedHeight, measuredDimensions.height, 1))
+  );
+};
 
 type SortableGridInnerProps<I> = DropIndicatorSettings &
   Required<

--- a/packages/react-native-sortables/src/components/SortableGrid.tsx
+++ b/packages/react-native-sortables/src/components/SortableGrid.tsx
@@ -1,11 +1,7 @@
 import { useMemo } from 'react';
 import { StyleSheet } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
-import {
-  runOnUI,
-  useAnimatedStyle,
-  useDerivedValue
-} from 'react-native-reanimated';
+import { runOnUI, useAnimatedStyle } from 'react-native-reanimated';
 
 import { DEFAULT_SORTABLE_GRID_PROPS, IS_WEB } from '../constants';
 import { useDragEndHandler } from '../hooks';
@@ -79,10 +75,20 @@ function SortableGrid<I>(props: SortableGridProps<I>) {
   const columnGapValue = useAnimatableValue(columnGap);
   const rowGapValue = useAnimatableValue(rowGap);
 
-  const controlledContainerDimensions = useDerivedValue(() => ({
-    height: isVertical, // height is controlled for vertical grids
-    width: !isVertical // width is controlled for horizontal grids
-  }));
+  const controlledContainerDimensions = useMemo(
+    () => ({
+      height: isVertical, // height is controlled for vertical grids
+      width: !isVertical // width is controlled for horizontal grids
+    }),
+    [isVertical]
+  );
+  const controlledItemDimensions = useMemo(
+    () => ({
+      height: !isVertical, // height is controlled for horizontal grids
+      width: isVertical // width is controlled for vertical grids
+    }),
+    [isVertical]
+  );
 
   const itemKeys = useMemo(() => data.map(keyExtractor), [data, keyExtractor]);
 
@@ -94,6 +100,7 @@ function SortableGrid<I>(props: SortableGridProps<I>) {
     <SharedProvider
       {...sharedProps}
       controlledContainerDimensions={controlledContainerDimensions}
+      controlledItemDimensions={controlledItemDimensions}
       debug={debug}
       itemKeys={itemKeys}
       onDragEnd={onDragEnd}>

--- a/packages/react-native-sortables/src/components/shared/DraggableView/DraggableView.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/DraggableView.tsx
@@ -55,14 +55,14 @@ function DraggableView({
   const itemStyles = useItemStyles(key, isActive, activationAnimationProgress);
   const gesture = useItemPanGesture(key, activationAnimationProgress);
 
-  useEffect(
-    () =>
+  useEffect(() => {
+    return () => {
+      removeItemMeasurements(key);
       runOnUI(() => {
         handleDragEnd(key, activationAnimationProgress);
-        removeItemMeasurements(key);
-      }),
-    [activationAnimationProgress, handleDragEnd, key, removeItemMeasurements]
-  );
+      })();
+    };
+  }, [activationAnimationProgress, handleDragEnd, key, removeItemMeasurements]);
 
   useEffect(() => {
     if (!portalContext) {

--- a/packages/react-native-sortables/src/components/shared/DraggableView/DraggableView.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/DraggableView.tsx
@@ -136,8 +136,7 @@ function DraggableView({
           activationAnimationProgress={activationAnimationProgress}
           baseCellStyle={style}
           isActive={isActive}
-          itemKey={key}
-          onMeasure={onMeasure}>
+          itemKey={key}>
           {children}
         </TeleportedItemCell>
       )}

--- a/packages/react-native-sortables/src/components/shared/DraggableView/ItemCell.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/ItemCell.tsx
@@ -16,7 +16,7 @@ import AnimatedOnLayoutView from '../AnimatedOnLayoutView';
 
 export type ItemCellProps = PropsWithChildren<{
   cellStyle: AnimatedStyleProp;
-  onMeasure: MeasureCallback;
+  onMeasure?: MeasureCallback;
   hidden?: boolean;
   entering?: LayoutAnimation;
   exiting?: LayoutAnimation;
@@ -30,15 +30,15 @@ export default function ItemCell({
   hidden,
   onMeasure
 }: ItemCellProps) {
-  const onLayout = hidden
-    ? undefined
-    : ({
-        nativeEvent: {
-          layout: { height, width }
-        }
-      }: LayoutChangeEvent) => {
-        onMeasure(width, height);
-      };
+  const onLayout =
+    onMeasure &&
+    (({
+      nativeEvent: {
+        layout: { height, width }
+      }
+    }: LayoutChangeEvent) => {
+      onMeasure(width, height);
+    });
 
   return (
     <AnimatedOnLayoutView

--- a/packages/react-native-sortables/src/components/shared/DraggableView/TeleportedItemCell.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/TeleportedItemCell.tsx
@@ -4,7 +4,6 @@ import { LayoutAnimationConfig } from 'react-native-reanimated';
 
 import type { AnimatedStyleProp } from '../../../integrations/reanimated';
 import { useTeleportedItemStyles } from '../../../providers';
-import type { MeasureCallback } from '../../../types';
 import ItemCell from './ItemCell';
 
 type TeleportedItemCellProps = PropsWithChildren<{
@@ -12,7 +11,6 @@ type TeleportedItemCellProps = PropsWithChildren<{
   baseCellStyle: AnimatedStyleProp;
   isActive: SharedValue<boolean>;
   itemKey: string;
-  onMeasure: MeasureCallback;
 }>;
 
 export default function TeleportedItemCell({
@@ -20,8 +18,7 @@ export default function TeleportedItemCell({
   baseCellStyle,
   children,
   isActive,
-  itemKey,
-  onMeasure
+  itemKey
 }: TeleportedItemCellProps) {
   const teleportedItemStyles = useTeleportedItemStyles(
     itemKey,
@@ -30,9 +27,7 @@ export default function TeleportedItemCell({
   );
 
   return (
-    <ItemCell
-      cellStyle={[baseCellStyle, teleportedItemStyles]}
-      onMeasure={onMeasure}>
+    <ItemCell cellStyle={[baseCellStyle, teleportedItemStyles]}>
       <LayoutAnimationConfig skipEntering>{children}</LayoutAnimationConfig>
     </ItemCell>
   );

--- a/packages/react-native-sortables/src/components/shared/DropIndicator.tsx
+++ b/packages/react-native-sortables/src/components/shared/DropIndicator.tsx
@@ -12,12 +12,8 @@ import Animated, {
 } from 'react-native-reanimated';
 
 import { useMutableValue } from '../../integrations/reanimated';
-import { useCommonValuesContext } from '../../providers';
-import type {
-  Dimensions,
-  DropIndicatorComponentProps,
-  Vector
-} from '../../types';
+import { useCommonValuesContext, useItemDimensions } from '../../providers';
+import type { DropIndicatorComponentProps, Vector } from '../../types';
 
 const DEFAULT_STYLE: ViewStyle = {
   opacity: 0
@@ -34,7 +30,6 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
     activeItemDropped,
     activeItemKey,
     indexToKey,
-    itemDimensions,
     itemPositions,
     keyToIndex
   } = useCommonValuesContext();
@@ -45,7 +40,7 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
   const dropIndex = useMutableValue(0);
   const dropPosition = useMutableValue<Vector>({ x: 0, y: 0 });
   const prevUpdateItemKey = useMutableValue<null | string>(null);
-  const dimensions = useMutableValue<Dimensions | null>(null);
+  const dimensions = useItemDimensions(activeItemKey);
 
   const x = useMutableValue<null | number>(null);
   const y = useMutableValue<null | number>(null);
@@ -61,7 +56,6 @@ function DropIndicator({ DropIndicatorComponent, style }: DropIndicatorProps) {
       if (key !== null) {
         dropIndex.value = kToI[key] ?? 0;
         dropPosition.value = positions[key] ?? { x: 0, y: 0 };
-        dimensions.value = itemDimensions.value[key] ?? null;
 
         const update = (target: SharedValue<null | number>, value: number) => {
           if (target.value === null || prevUpdateItemKey.value === null) {

--- a/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
@@ -62,11 +62,9 @@ export default function SortableContainer({
         ? withTiming(value)
         : value;
 
-    const ctrl = controlledContainerDimensions.value;
-
     return {
       height: maybeAnimate(
-        ctrl.height ? containerHeight.value : null,
+        controlledContainerDimensions.height ? containerHeight.value : null,
         animateWorklet
       ),
       overflow:
@@ -74,20 +72,20 @@ export default function SortableContainer({
           ? 'visible'
           : overflow,
       width: maybeAnimate(
-        ctrl.width ? containerWidth.value : null,
+        controlledContainerDimensions.width ? containerWidth.value : null,
         animateWorklet
       )
     };
   }, [dimensionsAnimationType]);
 
-  const innerContainerStyle = useAnimatedStyle(() => {
-    const ctrl = controlledContainerDimensions.value;
-
-    return {
-      ...(ctrl.height && { minHeight: containerHeight.value }),
-      ...(ctrl.width && { minWidth: containerWidth.value })
-    };
-  });
+  const innerContainerStyle = useAnimatedStyle(() => ({
+    ...(controlledContainerDimensions.height && {
+      minHeight: containerHeight.value
+    }),
+    ...(controlledContainerDimensions.width && {
+      minWidth: containerWidth.value
+    })
+  }));
 
   return (
     <Animated.View

--- a/packages/react-native-sortables/src/providers/SharedProvider.tsx
+++ b/packages/react-native-sortables/src/providers/SharedProvider.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable react/jsx-key */
 import type { PropsWithChildren } from 'react';
 import type { ViewStyle } from 'react-native';
-import type { SharedValue } from 'react-native-reanimated';
 import { LayoutAnimationConfig } from 'react-native-reanimated';
 
 import { DebugProvider } from '../debug';
@@ -13,7 +12,7 @@ import type {
   ActiveItemDecorationSettings,
   ActiveItemSnapSettings,
   AutoScrollSettings,
-  ControlledContainerDimensions,
+  ControlledDimensions,
   ItemDragSettings,
   ItemsLayoutTransitionMode,
   SortableCallbacks
@@ -40,7 +39,8 @@ type SharedProviderProps = PropsWithChildren<
       hapticsEnabled: boolean;
       customHandle: boolean;
       debug: boolean;
-      controlledContainerDimensions: SharedValue<ControlledContainerDimensions>;
+      controlledContainerDimensions: ControlledDimensions;
+      controlledItemDimensions: ControlledDimensions;
       itemsLayoutTransitionMode: ItemsLayoutTransitionMode;
       bringToFrontWhenActive: boolean;
       dropIndicatorStyle?: ViewStyle;

--- a/packages/react-native-sortables/src/providers/SharedProvider.tsx
+++ b/packages/react-native-sortables/src/providers/SharedProvider.tsx
@@ -17,6 +17,7 @@ import type {
   ItemsLayoutTransitionMode,
   SortableCallbacks
 } from '../types';
+import type { ItemDimensionsValidator } from './shared';
 import {
   AutoScrollProvider,
   CommonValuesProvider,
@@ -44,6 +45,7 @@ type SharedProviderProps = PropsWithChildren<
       itemsLayoutTransitionMode: ItemsLayoutTransitionMode;
       bringToFrontWhenActive: boolean;
       dropIndicatorStyle?: ViewStyle;
+      validateItemDimensions?: ItemDimensionsValidator;
     }
 >;
 
@@ -67,6 +69,7 @@ export default function SharedProvider({
   overDrag,
   scrollableRef,
   sortEnabled,
+  validateItemDimensions,
   ...rest
 }: SharedProviderProps) {
   const inMultiZone = !!useMultiZoneContext();
@@ -90,7 +93,10 @@ export default function SharedProvider({
       {...rest}
     />,
     // Provider used for measurements of items and the container
-    <MeasurementsProvider itemsCount={itemKeys.length} />,
+    <MeasurementsProvider
+      itemsCount={itemKeys.length}
+      validateDimensions={validateItemDimensions}
+    />,
     // Provider used for auto-scrolling when dragging an item near the
     // edge of the container
     scrollableRef && (

--- a/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
@@ -236,37 +236,6 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
     }
   });
 
-  // useAnimatedReaction(
-  //   () => ({
-  //     containerH: containerHeight.value,
-  //     containerW: containerWidth.value,
-  //     itemMeasurementsCompleted: initialItemMeasurementsCompleted.value
-  //   }),
-  //   ({ containerH, containerW, itemMeasurementsCompleted }) => {
-  //     console.log(
-  //       usesAbsoluteLayout.value,
-  //       itemMeasurementsCompleted,
-  //       containerH,
-  //       containerW
-  //     );
-
-  //     if (
-  //       usesAbsoluteLayout.value ||
-  //       !itemMeasurementsCompleted ||
-  //       !containerH ||
-  //       !containerW
-  //     ) {
-  //       return;
-  //     }
-
-  //     // Add timeout for safety, to prevent too many updates in a short period of time
-  //     // (this may cause perf issues on low end devices, so the update is delayed for safety)
-  //     setAnimatedTimeout(() => {
-  //       usesAbsoluteLayout.value = true;
-  //     }, 100);
-  //   }
-  // );
-
   return {
     value: {
       appliedLayout,

--- a/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
@@ -56,8 +56,9 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
     containerWidth,
     controlledContainerDimensions,
     indexToKey,
-    itemDimensions,
+    itemHeights,
     itemPositions,
+    itemWidths,
     shouldAnimateLayout
   } = useCommonValuesContext();
   const { applyControlledContainerDimensions } = useMeasurementsContext();
@@ -84,13 +85,13 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
     let minW = Math.max(minWidth ?? 0, w ?? 0);
     let maxW = Math.min(maxWidth ?? Infinity, w ?? Infinity);
 
-    if (!controlledContainerDimensions.value.width) {
+    if (!controlledContainerDimensions.width) {
       if (!containerWidth.value) {
         return null;
       }
       minW = maxW = containerWidth.value;
     }
-    if (!controlledContainerDimensions.value.height) {
+    if (!controlledContainerDimensions.height) {
       if (!containerHeight.value) {
         return null;
       }
@@ -136,7 +137,8 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
                   row: rowGap.value
                 },
                 indexToKey: idxToKey.value,
-                itemDimensions: itemDimensions.value,
+                itemHeights: itemHeights.value,
+                itemWidths: itemWidths.value,
                 limits: dimensionsLimits.value,
                 paddings: paddings.value
               },
@@ -159,7 +161,8 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
       flexWrap,
       columnGap,
       rowGap,
-      itemDimensions,
+      itemHeights,
+      itemWidths,
       dimensionsLimits,
       paddings
     ]
@@ -181,7 +184,8 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
           row: rowGap.value
         },
         indexToKey: idxToKey,
-        itemDimensions: itemDimensions.value,
+        itemHeights: itemHeights.value,
+        itemWidths: itemWidths.value,
         limits: dimensionsLimits.value,
         paddings: paddings.value
       });
@@ -194,7 +198,8 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
       flexWrap,
       columnGap,
       rowGap,
-      itemDimensions,
+      itemHeights,
+      itemWidths,
       dimensionsLimits,
       paddings
     ]
@@ -225,7 +230,8 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
         layout,
         debugCrossAxisGapRects,
         debugMainAxisGapRects,
-        itemDimensions
+        itemWidths.value,
+        itemHeights.value
       );
     }
   });

--- a/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/flex/FlexLayoutProvider.tsx
@@ -236,6 +236,37 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
     }
   });
 
+  // useAnimatedReaction(
+  //   () => ({
+  //     containerH: containerHeight.value,
+  //     containerW: containerWidth.value,
+  //     itemMeasurementsCompleted: initialItemMeasurementsCompleted.value
+  //   }),
+  //   ({ containerH, containerW, itemMeasurementsCompleted }) => {
+  //     console.log(
+  //       usesAbsoluteLayout.value,
+  //       itemMeasurementsCompleted,
+  //       containerH,
+  //       containerW
+  //     );
+
+  //     if (
+  //       usesAbsoluteLayout.value ||
+  //       !itemMeasurementsCompleted ||
+  //       !containerH ||
+  //       !containerW
+  //     ) {
+  //       return;
+  //     }
+
+  //     // Add timeout for safety, to prevent too many updates in a short period of time
+  //     // (this may cause perf issues on low end devices, so the update is delayed for safety)
+  //     setAnimatedTimeout(() => {
+  //       usesAbsoluteLayout.value = true;
+  //     }, 100);
+  //   }
+  // );
+
   return {
     value: {
       appliedLayout,

--- a/packages/react-native-sortables/src/providers/layout/flex/updates/insert/index.ts
+++ b/packages/react-native-sortables/src/providers/layout/flex/updates/insert/index.ts
@@ -8,10 +8,14 @@ import type {
   FlexLayout,
   SortStrategyFactory
 } from '../../../../../types';
-import { gt as gt_, lt as lt_, reorderInsert } from '../../../../../utils';
+import {
+  gt as gt_,
+  lt as lt_,
+  reorderInsert,
+  resolveDimension
+} from '../../../../../utils';
 import {
   getAdditionalSwapOffset,
-  resolveDimension,
   useCommonValuesContext,
   useCustomHandleContext,
   useDebugBoundingBox

--- a/packages/react-native-sortables/src/providers/layout/flex/updates/insert/index.ts
+++ b/packages/react-native-sortables/src/providers/layout/flex/updates/insert/index.ts
@@ -11,6 +11,7 @@ import type {
 import { gt as gt_, lt as lt_, reorderInsert } from '../../../../../utils';
 import {
   getAdditionalSwapOffset,
+  resolveDimension,
   useCommonValuesContext,
   useCustomHandleContext,
   useDebugBoundingBox
@@ -24,7 +25,7 @@ import {
 } from './utils';
 
 const useInsertStrategy: SortStrategyFactory = () => {
-  const { activeItemKey, indexToKey, itemDimensions, keyToIndex } =
+  const { activeItemKey, indexToKey, itemHeights, itemWidths, keyToIndex } =
     useCommonValuesContext();
   const {
     appliedLayout,
@@ -37,7 +38,7 @@ const useInsertStrategy: SortStrategyFactory = () => {
   } = useFlexLayoutContext();
   const { fixedItemKeys } = useCustomHandleContext() ?? {};
 
-  const isColumn = flexDirection.startsWith('column');
+  const isRow = flexDirection.startsWith('row');
   const isReverse = flexDirection.endsWith('reverse');
 
   const gt = isReverse ? lt_ : gt_;
@@ -48,19 +49,22 @@ const useInsertStrategy: SortStrategyFactory = () => {
   let mainDimension: Dimension;
   let crossDimension: Dimension;
   let mainGap: SharedValue<number>;
+  let mainItemSizes: SharedValue<number | Record<string, number>>;
 
-  if (isColumn) {
-    mainCoordinate = 'y';
-    crossCoordinate = 'x';
-    mainDimension = 'height';
-    crossDimension = 'width';
-    mainGap = rowGap;
-  } else {
+  if (isRow) {
     mainCoordinate = 'x';
     crossCoordinate = 'y';
     mainDimension = 'width';
     crossDimension = 'height';
     mainGap = columnGap;
+    mainItemSizes = itemWidths;
+  } else {
+    mainCoordinate = 'y';
+    crossCoordinate = 'x';
+    mainDimension = 'height';
+    crossDimension = 'width';
+    mainGap = rowGap;
+    mainItemSizes = itemHeights;
   }
 
   const swappedBeforeIndexes = useMutableValue<ItemGroupSwapResult | null>(
@@ -89,11 +93,10 @@ const useInsertStrategy: SortStrategyFactory = () => {
             fixedKeys: fixedItemKeys?.value,
             groupSizeLimit: appliedLayout.value.groupSizeLimit,
             indexToKey: indexToKey.value,
-            itemDimensions: itemDimensions.value,
             itemGroups: appliedLayout.value.itemGroups,
             keyToIndex: keyToIndex.value,
-            mainDimension,
-            mainGap: mainGap.value
+            mainGap: mainGap.value,
+            mainItemSizes: isRow ? itemWidths.value : itemHeights.value
           }
         : null,
     props => {
@@ -133,9 +136,8 @@ const useInsertStrategy: SortStrategyFactory = () => {
       activeItemKey: activeKey,
       fixedKeys: fixedItemKeys?.value,
       groupSizeLimit: currentLayout.groupSizeLimit,
-      itemDimensions: itemDimensions.value,
-      mainDimension,
-      mainGap: mainGap.value
+      mainGap: mainGap.value,
+      mainItemSizes: isRow ? itemWidths.value : itemHeights.value
     };
 
     // CROSS AXIS BOUNDS
@@ -296,10 +298,12 @@ const useInsertStrategy: SortStrategyFactory = () => {
 
       const currentItemKey = currentGroup[itemIndexInGroup]!;
       const currentItemPosition = currentLayout.itemPositions[currentItemKey];
-      const currentItemDimensions = itemDimensions.value[currentItemKey];
-      if (!currentItemPosition || !currentItemDimensions) return;
+      const itemMainSize = resolveDimension(
+        mainItemSizes.value,
+        currentItemKey
+      );
+      if (!currentItemPosition || itemMainSize === undefined) return;
 
-      const itemMainSize = currentItemDimensions[mainDimension];
       swapItemAfterOffset =
         currentItemPosition[mainCoordinate] + (isReverse ? 0 : itemMainSize);
 
@@ -310,17 +314,18 @@ const useInsertStrategy: SortStrategyFactory = () => {
       }
 
       const nextItemPosition = currentLayout.itemPositions[nextItemKey];
-      const nextItemDimensions = itemDimensions.value[nextItemKey];
-      if (!nextItemPosition || !nextItemDimensions) break;
+      const nextItemMainSize = resolveDimension(
+        mainItemSizes.value,
+        nextItemKey
+      );
+      if (!nextItemPosition || nextItemMainSize === undefined) break;
 
       const currentItemMainAxisPosition = currentItemPosition[mainCoordinate];
       const nextItemMainAxisPosition = nextItemPosition[mainCoordinate];
 
       const isCurrentBeforeNext =
         currentItemMainAxisPosition < nextItemMainAxisPosition;
-      const sizeToAdd = isCurrentBeforeNext
-        ? nextItemDimensions[mainDimension]
-        : currentItemDimensions[mainDimension];
+      const sizeToAdd = isCurrentBeforeNext ? nextItemMainSize : itemMainSize;
 
       const averageOffset =
         (currentItemMainAxisPosition + nextItemMainAxisPosition + sizeToAdd) /
@@ -344,8 +349,7 @@ const useInsertStrategy: SortStrategyFactory = () => {
     if (groupBefore && itemIndexInGroup > 0) {
       const groupBeforeSize = getTotalGroupSize(
         groupBefore,
-        itemDimensions.value,
-        mainDimension,
+        mainItemSizes.value,
         mainGap.value
       );
       canBeFirst =
@@ -363,12 +367,15 @@ const useInsertStrategy: SortStrategyFactory = () => {
 
       const currentItemKey = currentGroup[itemIndexInGroup]!;
       const currentItemPosition = currentLayout.itemPositions[currentItemKey];
-      const currentItemDimensions = itemDimensions.value[currentItemKey];
-      if (!currentItemPosition || !currentItemDimensions) return;
+      const currentItemMainSize = resolveDimension(
+        mainItemSizes.value,
+        currentItemKey
+      );
+      if (!currentItemPosition || currentItemMainSize === undefined) return;
 
       swapItemBeforeOffset =
         currentItemPosition[mainCoordinate] +
-        (isReverse ? currentItemDimensions[mainDimension] : 0);
+        (isReverse ? currentItemMainSize : 0);
 
       const prevItemKey = currentGroup[itemIndexInGroup - 1];
       if (prevItemKey === undefined) {
@@ -377,8 +384,11 @@ const useInsertStrategy: SortStrategyFactory = () => {
       }
 
       const prevItemPosition = currentLayout.itemPositions[prevItemKey];
-      const prevItemDimensions = itemDimensions.value[prevItemKey];
-      if (!prevItemPosition || !prevItemDimensions) return;
+      const prevItemMainSize = resolveDimension(
+        mainItemSizes.value,
+        prevItemKey
+      );
+      if (!prevItemPosition || prevItemMainSize === undefined) return;
 
       const currentItemMainAxisPosition = currentItemPosition[mainCoordinate];
       const prevItemMainAxisPosition = prevItemPosition[mainCoordinate];
@@ -386,8 +396,8 @@ const useInsertStrategy: SortStrategyFactory = () => {
       const isPrevBeforeCurrent =
         prevItemMainAxisPosition < currentItemMainAxisPosition;
       const sizeToAdd = isPrevBeforeCurrent
-        ? currentItemDimensions[mainDimension]
-        : prevItemDimensions[mainDimension];
+        ? currentItemMainSize
+        : prevItemMainSize;
 
       const averageOffset =
         (prevItemMainAxisPosition + currentItemMainAxisPosition + sizeToAdd) /
@@ -417,24 +427,7 @@ const useInsertStrategy: SortStrategyFactory = () => {
         swapItemBeforeOffset = swapItemBeforeBound;
       }
 
-      if (isColumn) {
-        debugBox.top.update(
-          { x: swapGroupBeforeBound, y: swapItemBeforeBound },
-          { x: swapGroupAfterBound, y: swapItemBeforeOffset }
-        );
-        debugBox.bottom.update(
-          { x: swapGroupAfterBound, y: swapItemAfterOffset },
-          { x: swapGroupBeforeBound, y: swapItemAfterBound }
-        );
-        debugBox.right.update(
-          { x: swapGroupAfterOffset, y: swapItemBeforeBound },
-          { x: swapGroupAfterBound, y: swapItemAfterBound }
-        );
-        debugBox.left.update(
-          { x: swapGroupBeforeBound, y: swapItemBeforeBound },
-          { x: swapGroupBeforeOffset, y: swapItemAfterBound }
-        );
-      } else {
+      if (isRow) {
         debugBox.top.update(
           { x: swapItemBeforeBound, y: swapGroupBeforeBound },
           { x: swapItemAfterBound, y: swapGroupBeforeOffset }
@@ -450,6 +443,23 @@ const useInsertStrategy: SortStrategyFactory = () => {
         debugBox.left.update(
           { x: swapItemBeforeBound, y: swapGroupBeforeBound },
           { x: swapItemBeforeOffset, y: swapGroupAfterBound }
+        );
+      } else {
+        debugBox.top.update(
+          { x: swapGroupBeforeBound, y: swapItemBeforeBound },
+          { x: swapGroupAfterBound, y: swapItemBeforeOffset }
+        );
+        debugBox.bottom.update(
+          { x: swapGroupAfterBound, y: swapItemAfterOffset },
+          { x: swapGroupBeforeBound, y: swapItemAfterBound }
+        );
+        debugBox.right.update(
+          { x: swapGroupAfterOffset, y: swapItemBeforeBound },
+          { x: swapGroupAfterBound, y: swapItemAfterBound }
+        );
+        debugBox.left.update(
+          { x: swapGroupBeforeBound, y: swapItemBeforeBound },
+          { x: swapGroupBeforeOffset, y: swapItemAfterBound }
         );
       }
     }

--- a/packages/react-native-sortables/src/providers/layout/flex/updates/insert/utils.ts
+++ b/packages/react-native-sortables/src/providers/layout/flex/updates/insert/utils.ts
@@ -1,5 +1,4 @@
-import { reorderInsert } from '../../../../../utils';
-import { resolveDimension } from '../../../..';
+import { reorderInsert, resolveDimension } from '../../../../../utils';
 
 export type ItemGroupSwapProps = {
   activeItemKey: string;

--- a/packages/react-native-sortables/src/providers/layout/flex/updates/insert/utils.ts
+++ b/packages/react-native-sortables/src/providers/layout/flex/updates/insert/utils.ts
@@ -1,5 +1,5 @@
-import type { Dimension, Dimensions } from '../../../../../types';
 import { reorderInsert } from '../../../../../utils';
+import { resolveDimension } from '../../../..';
 
 export type ItemGroupSwapProps = {
   activeItemKey: string;
@@ -8,9 +8,8 @@ export type ItemGroupSwapProps = {
   groupSizeLimit: number;
   indexToKey: Array<string>;
   keyToIndex: Record<string, number>;
-  itemDimensions: Record<string, Dimensions>;
+  mainItemSizes: number | Record<string, number>;
   itemGroups: Array<Array<string>>;
-  mainDimension: Dimension;
   mainGap: number;
   fixedKeys: Record<string, boolean> | undefined;
 };
@@ -36,14 +35,13 @@ const getGroupItemIndex = (
 
 export const getTotalGroupSize = (
   group: Array<string>,
-  itemDimensions: Record<string, Dimensions>,
-  mainDimension: Dimension,
+  mainItemSizes: number | Record<string, number>,
   gap: number
 ) => {
   'worklet';
 
   const sizesSum = group.reduce(
-    (total, key) => total + (itemDimensions[key]?.[mainDimension] ?? 0),
+    (total, key) => total + (resolveDimension(mainItemSizes, key) ?? 0),
     0
   );
 
@@ -61,18 +59,17 @@ const getIndexesWhenSwappedToGroupBefore = ({
   fixedKeys,
   groupSizeLimit,
   indexToKey,
-  itemDimensions,
   itemGroups,
   keyToIndex,
-  mainDimension,
-  mainGap
+  mainGap,
+  mainItemSizes
 }: ItemGroupSwapProps): SwappedGroupIndexesResult => {
   'worklet';
   if (groupSizeLimit === Infinity) {
     return null;
   }
 
-  const activeMainSize = itemDimensions[activeItemKey]?.[mainDimension] ?? 0;
+  const activeMainSize = resolveDimension(mainItemSizes, activeItemKey) ?? 0;
 
   for (let groupIdx = currentGroupIndex; groupIdx > 0; groupIdx--) {
     const groupBefore = itemGroups[groupIdx - 1]!;
@@ -100,8 +97,7 @@ const getIndexesWhenSwappedToGroupBefore = ({
       // we have to check whether the active item won't wrap to this group
       const totalGroupBeforeBeforeSize = getTotalGroupSize(
         groupBeforeBefore,
-        itemDimensions,
-        mainDimension,
+        mainItemSizes,
         mainGap
       );
       const canBeFirstInGroupBefore =
@@ -112,7 +108,7 @@ const getIndexesWhenSwappedToGroupBefore = ({
           return null;
         }
         totalGroupSize +=
-          (itemDimensions[firstItemKey]?.[mainDimension] ?? 0) + mainGap;
+          (resolveDimension(mainItemSizes, firstItemKey) ?? 0) + mainGap;
         itemIndex++;
       }
     }
@@ -134,7 +130,7 @@ const getIndexesWhenSwappedToGroupBefore = ({
         };
       }
 
-      const itemMainSize = itemDimensions[itemKey]?.[mainDimension] ?? 0;
+      const itemMainSize = resolveDimension(mainItemSizes, itemKey) ?? 0;
       totalGroupSize += itemMainSize + mainGap;
     }
   }
@@ -148,11 +144,10 @@ const getIndexesWhenSwappedToGroupAfter = ({
   fixedKeys,
   groupSizeLimit,
   indexToKey,
-  itemDimensions,
   itemGroups,
   keyToIndex,
-  mainDimension,
-  mainGap
+  mainGap,
+  mainItemSizes
 }: ItemGroupSwapProps): SwappedGroupIndexesResult => {
   'worklet';
   const activeGroup = itemGroups[currentGroupIndex];
@@ -167,7 +162,7 @@ const getIndexesWhenSwappedToGroupAfter = ({
   }
 
   const getItemMainSize = (key: string) =>
-    itemDimensions[key]?.[mainDimension] ?? 0;
+    resolveDimension(mainItemSizes, key) ?? 0;
 
   // We need to remove the active item from the its group, fit all items
   // in the remaining space between the active item's group and the target group,

--- a/packages/react-native-sortables/src/providers/layout/flex/utils/debug.ts
+++ b/packages/react-native-sortables/src/providers/layout/flex/utils/debug.ts
@@ -1,12 +1,6 @@
-import type { SharedValue } from 'react-native-reanimated';
-
 import type { DebugRectUpdater } from '../../../../debug';
-import type {
-  Dimensions,
-  FlexDirection,
-  FlexLayout,
-  Vector
-} from '../../../../types';
+import type { FlexDirection, FlexLayout, Vector } from '../../../../types';
+import { resolveDimension } from '../../../shared';
 
 const DEBUG_COLORS = {
   backgroundColor: '#ffa500',
@@ -18,7 +12,8 @@ export const updateLayoutDebugRects = (
   layout: FlexLayout,
   debugCrossAxisGapRects: Array<DebugRectUpdater>,
   debugMainAxisGapRects: Array<DebugRectUpdater>,
-  itemDimensions: SharedValue<Record<string, Dimensions>>
+  itemWidths: number | Record<string, number>,
+  itemHeights: number | Record<string, number>
 ) => {
   'worklet';
   const isRow = flexDirection.startsWith('row');
@@ -49,6 +44,14 @@ export const updateLayoutDebugRects = (
     const group = layout.itemGroups[i];
     if (!group) break;
 
+    const set = (index: number, config: { from: Vector; to: Vector }) => {
+      debugMainAxisGapRects[index]?.set({
+        ...DEBUG_COLORS,
+        from: config.from,
+        to: config.to
+      });
+    };
+
     for (let j = 0; j < group.length; j++) {
       const key = group[j]!;
       const nextKey = layout.itemGroups[i]![j + 1];
@@ -59,40 +62,41 @@ export const updateLayoutDebugRects = (
 
       const position = layout.itemPositions[key]!;
       const nextPosition = layout.itemPositions[nextKey]!;
-      const dimensions = itemDimensions.value[key]!;
-      const nextDimensions = itemDimensions.value[nextKey]!;
-
-      // eslint-disable-next-line no-loop-func
-      const set = (config: { from: Vector; to: Vector }) => {
-        debugMainAxisGapRects[itemIndex]?.set({
-          ...DEBUG_COLORS,
-          from: config.from,
-          to: config.to
-        });
-      };
 
       if (isRow && isReverse) {
         // row-reverse
-        set({
-          from: { x: nextPosition.x + nextDimensions.width, y: offset },
+        set(itemIndex, {
+          from: {
+            x: nextPosition.x + resolveDimension(itemWidths, nextKey)!,
+            y: offset
+          },
           to: { x: position.x, y: currentEndOffset }
         });
       } else if (isRow) {
         // row
-        set({
-          from: { x: position.x + dimensions.width, y: offset },
+        set(itemIndex, {
+          from: {
+            x: position.x + resolveDimension(itemWidths, key)!,
+            y: offset
+          },
           to: { x: nextPosition.x, y: currentEndOffset }
         });
       } else if (isReverse) {
         // column-reverse
-        set({
-          from: { x: offset, y: nextPosition.y + nextDimensions.height },
+        set(itemIndex, {
+          from: {
+            x: offset,
+            y: nextPosition.y + resolveDimension(itemHeights, nextKey)!
+          },
           to: { x: currentEndOffset, y: position.y }
         });
       } else {
         // column
-        set({
-          from: { x: offset, y: position.y + dimensions.height },
+        set(itemIndex, {
+          from: {
+            x: offset,
+            y: position.y + resolveDimension(itemHeights, key)!
+          },
           to: { x: currentEndOffset, y: nextPosition.y }
         });
       }

--- a/packages/react-native-sortables/src/providers/layout/flex/utils/debug.ts
+++ b/packages/react-native-sortables/src/providers/layout/flex/utils/debug.ts
@@ -1,6 +1,6 @@
 import type { DebugRectUpdater } from '../../../../debug';
 import type { FlexDirection, FlexLayout, Vector } from '../../../../types';
-import { resolveDimension } from '../../../shared';
+import { resolveDimension } from '../../../../utils';
 
 const DEBUG_COLORS = {
   backgroundColor: '#ffa500',

--- a/packages/react-native-sortables/src/providers/layout/flex/utils/layout.ts
+++ b/packages/react-native-sortables/src/providers/layout/flex/utils/layout.ts
@@ -9,8 +9,7 @@ import type {
   JustifyContent,
   Vector
 } from '../../../../types';
-import { reverseArray, sum } from '../../../../utils';
-import { resolveDimension } from '../../../shared';
+import { resolveDimension, reverseArray, sum } from '../../../../utils';
 
 type AxisDirections = { cross: Direction; main: Direction };
 

--- a/packages/react-native-sortables/src/providers/layout/flex/utils/layout.ts
+++ b/packages/react-native-sortables/src/providers/layout/flex/utils/layout.ts
@@ -34,7 +34,7 @@ const createGroups = (
   for (const key of indexToKey) {
     const mainItemDimension = resolveDimension(mainItemSizes, key);
     const crossItemDimension = resolveDimension(crossItemSizes, key);
-    if (!mainItemDimension || !crossItemDimension) {
+    if (mainItemDimension === undefined || crossItemDimension === undefined) {
       return null;
     }
 

--- a/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/layout/grid/GridLayoutProvider.tsx
@@ -44,8 +44,9 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
   const {
     containerWidth,
     indexToKey,
-    itemDimensions,
+    itemHeights,
     itemPositions,
+    itemWidths,
     shouldAnimateLayout
   } = useCommonValuesContext();
   const { applyControlledContainerDimensions } = useMeasurementsContext();
@@ -90,6 +91,12 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
 
       mainGroupSize.value = value;
 
+      if (isVertical) {
+        itemWidths.value = value;
+      } else {
+        itemHeights.value = value;
+      }
+
       // DEBUG ONLY
       if (debugMainGapRects) {
         const gap = mainGap.value;
@@ -119,7 +126,8 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
           },
           indexToKey: idxToKey.value,
           isVertical,
-          itemDimensions: itemDimensions.value,
+          itemHeights: itemHeights.value,
+          itemWidths: itemWidths.value,
           mainGroupSize: mainGroupSize.value,
           numGroups
         }),
@@ -134,7 +142,15 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
           );
         }
       ),
-    [mainGroupSize, mainGap, crossGap, numGroups, isVertical, itemDimensions]
+    [
+      mainGroupSize,
+      mainGap,
+      crossGap,
+      numGroups,
+      isVertical,
+      itemHeights,
+      itemWidths
+    ]
   );
 
   const useGridLayout = useCallback(
@@ -147,12 +163,21 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
           },
           indexToKey: idxToKey.value,
           isVertical,
-          itemDimensions: itemDimensions.value,
+          itemHeights: itemHeights.value,
+          itemWidths: itemWidths.value,
           mainGroupSize: mainGroupSize.value,
           numGroups
         })
       ),
-    [mainGroupSize, mainGap, crossGap, numGroups, isVertical, itemDimensions]
+    [
+      mainGroupSize,
+      mainGap,
+      crossGap,
+      numGroups,
+      isVertical,
+      itemHeights,
+      itemWidths
+    ]
   );
 
   // GRID LAYOUT UPDATER
@@ -166,7 +191,7 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
     // Update item positions
     itemPositions.value = layout.itemPositions;
     // Update controlled container dimensions
-    applyControlledContainerDimensions(layout.calculatedDimensions);
+    applyControlledContainerDimensions(layout.controlledContainerDimensions);
 
     // DEBUG ONLY
     if (debugCrossGapRects) {

--- a/packages/react-native-sortables/src/providers/layout/grid/utils/layout.ts
+++ b/packages/react-native-sortables/src/providers/layout/grid/utils/layout.ts
@@ -1,4 +1,3 @@
-import { OFFSET_EPS } from '../../../../constants';
 import type {
   Coordinate,
   GridLayout,
@@ -27,33 +26,26 @@ export const calculateLayout = ({
 
   let mainCoordinate: Coordinate;
   let crossCoordinate: Coordinate;
-  let crossItemSizes, mainItemSizes;
+  let crossItemSizes;
 
   if (isVertical) {
     // grid with specified number of columns (vertical orientation)
     mainCoordinate = 'x';
     crossCoordinate = 'y';
-    mainItemSizes = itemWidths;
     crossItemSizes = itemHeights;
   } else {
     // grid with specified number of rows (horizontal orientation)
     mainCoordinate = 'y';
     crossCoordinate = 'x';
-    mainItemSizes = itemHeights;
     crossItemSizes = itemWidths;
   }
 
   for (const [itemIndex, itemKey] of indexToKey.entries()) {
     const crossItemSize = resolveDimension(crossItemSizes, itemKey);
-    const mainItemSize = resolveDimension(mainItemSizes, itemKey);
 
     // Return null if the item is not yet measured or the item main size
     // is different than the main group size (main size must be always the same)
-    if (
-      crossItemSize === undefined ||
-      mainItemSize === undefined ||
-      Math.abs(mainItemSize - mainGroupSize) > OFFSET_EPS
-    ) {
+    if (crossItemSize === undefined) {
       return null;
     }
 

--- a/packages/react-native-sortables/src/providers/layout/grid/utils/layout.ts
+++ b/packages/react-native-sortables/src/providers/layout/grid/utils/layout.ts
@@ -4,7 +4,7 @@ import type {
   GridLayoutProps,
   Vector
 } from '../../../../types';
-import { resolveDimension } from '../../../shared';
+import { resolveDimension } from '../../../../utils';
 import { getCrossIndex, getMainIndex } from './helpers';
 
 export const calculateLayout = ({

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
@@ -1,6 +1,5 @@
 import { type PropsWithChildren, useEffect, useMemo, useRef } from 'react';
 import type { View } from 'react-native';
-import type { SharedValue } from 'react-native-reanimated';
 import { useAnimatedRef, useDerivedValue } from 'react-native-reanimated';
 
 import type { Animatable } from '../../integrations/reanimated';
@@ -12,7 +11,7 @@ import type {
   ActiveItemDecorationSettings,
   ActiveItemSnapSettings,
   CommonValuesContextType,
-  ControlledContainerDimensions,
+  ControlledDimensions,
   Dimensions,
   ItemDragSettings,
   ItemsLayoutTransitionMode,
@@ -31,7 +30,8 @@ type CommonValuesProviderProps = PropsWithChildren<
       sortEnabled: Animatable<boolean>;
       customHandle: boolean;
       itemKeys: Array<string>;
-      controlledContainerDimensions: SharedValue<ControlledContainerDimensions>;
+      controlledContainerDimensions: ControlledDimensions;
+      controlledItemDimensions: ControlledDimensions;
       itemsLayoutTransitionMode: ItemsLayoutTransitionMode;
     }
 >;
@@ -46,6 +46,7 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
     activeItemScale: _activeItemScale,
     activeItemShadowOpacity: _activeItemShadowOpacity,
     controlledContainerDimensions,
+    controlledItemDimensions,
     customHandle,
     dragActivationDelay: _dragActivationDelay,
     dragActivationFailOffset: _dragActivationFailOffset,
@@ -74,7 +75,12 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
     // DIMENSIONS
     const containerWidth = useMutableValue<null | number>(null);
     const containerHeight = useMutableValue<null | number>(null);
-    const itemDimensions = useMutableValue<Record<string, Dimensions>>({});
+    const itemWidths = useMutableValue<number | Record<string, number>>(
+      controlledItemDimensions.width ? -1 : {}
+    );
+    const itemHeights = useMutableValue<number | Record<string, number>>(
+      controlledItemDimensions.height ? -1 : {}
+    );
     const activeItemDimensions = useMutableValue<Dimensions | null>(null);
 
     // DRAG STATE
@@ -144,6 +150,7 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
         containerRef,
         containerWidth,
         controlledContainerDimensions,
+        controlledItemDimensions,
         customHandle,
         dragActivationDelay,
         dragActivationFailOffset,
@@ -153,9 +160,10 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
         inactiveItemOpacity,
         inactiveItemScale,
         indexToKey,
-        itemDimensions,
+        itemHeights,
         itemPositions,
         itemsLayoutTransitionMode,
+        itemWidths,
         keyToIndex,
         prevActiveItemKey,
         shouldAnimateLayout,

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.ts
@@ -36,6 +36,7 @@ import { useLayerContext } from './LayerProvider';
 import { useMeasurementsContext } from './MeasurementsProvider';
 import { useMultiZoneContext } from './MultiZoneProvider';
 import { usePortalContext } from './PortalProvider';
+import { getItemDimensions } from './utils';
 
 type DragProviderProps = PropsWithChildren<
   Required<SortableCallbacks> & {
@@ -76,8 +77,9 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
     inactiveItemOpacity,
     inactiveItemScale,
     indexToKey,
-    itemDimensions,
+    itemHeights,
     itemPositions,
+    itemWidths,
     keyToIndex,
     prevActiveItemKey,
     snapOffsetX,
@@ -384,7 +386,11 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
         }
 
         const position = itemPositions.value[key];
-        const dimensions = itemDimensions.value[key];
+        const dimensions = getItemDimensions(
+          key,
+          itemWidths.value,
+          itemHeights.value
+        );
 
         if (!position || !dimensions) {
           return;
@@ -409,7 +415,8 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       dragActivationDelay,
       handleContainerMeasurement,
       handleDragStart,
-      itemDimensions,
+      itemHeights,
+      itemWidths,
       itemPositions,
       sortEnabled,
       touchStartTouch,

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.ts
@@ -27,7 +27,11 @@ import type {
   Vector
 } from '../../types';
 import { DragActivationState, LayerState } from '../../types';
-import { getKeyToIndex, getOffsetDistance } from '../../utils';
+import {
+  getItemDimensions,
+  getKeyToIndex,
+  getOffsetDistance
+} from '../../utils';
 import { createProvider } from '../utils';
 import { useAutoScrollContext } from './AutoScrollProvider';
 import { useCommonValuesContext } from './CommonValuesProvider';
@@ -36,7 +40,6 @@ import { useLayerContext } from './LayerProvider';
 import { useMeasurementsContext } from './MeasurementsProvider';
 import { useMultiZoneContext } from './MultiZoneProvider';
 import { usePortalContext } from './PortalProvider';
-import { getItemDimensions } from './utils';
 
 type DragProviderProps = PropsWithChildren<
   Required<SortableCallbacks> & {

--- a/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
@@ -12,11 +12,10 @@ import type {
   Dimensions,
   MeasurementsContextType
 } from '../../types';
-import { areValuesDifferent } from '../../utils';
+import { areValuesDifferent, resolveDimension } from '../../utils';
 import { createProvider } from '../utils';
 import { useCommonValuesContext } from './CommonValuesProvider';
 import { useMultiZoneContext } from './MultiZoneProvider';
-import { resolveDimension } from './utils';
 
 export type ItemDimensionsValidator = (
   resolvedWidth: number | undefined,

--- a/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
@@ -105,12 +105,11 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
         if (isNewItem) {
           measuredItemsCount.value += 1;
         }
-        if (!isWidthControlled) {
-          (itemWidths.value as Record<string, number>)[key] = dimensions.width;
+        if (typeof itemWidths.value === 'object') {
+          itemWidths.value[key] = dimensions.width;
         }
-        if (!isHeightControlled) {
-          (itemHeights.value as Record<string, number>)[key] =
-            dimensions.height;
+        if (typeof itemHeights.value === 'object') {
+          itemHeights.value[key] = dimensions.height;
         }
 
         if (activeItemKey.value === key) {
@@ -154,11 +153,11 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
       }
 
       runOnUI(() => {
-        if (!isWidthControlled) {
-          delete (itemWidths.value as Record<string, number>)[key];
+        if (typeof itemWidths.value === 'object') {
+          delete itemWidths.value[key];
         }
-        if (!isHeightControlled) {
-          delete (itemHeights.value as Record<string, number>)[key];
+        if (typeof itemHeights.value === 'object') {
+          delete itemHeights.value[key];
         }
         measuredItemsCount.value -= 1;
       })();

--- a/packages/react-native-sortables/src/providers/shared/hooks/index.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/index.ts
@@ -1,4 +1,5 @@
 export { default as useDebugBoundingBox } from './useDebugBoundingBox';
+export { default as useItemDimensions } from './useItemDimensions';
 export { default as useItemPanGesture } from './useItemPanGesture';
 export { default as useItemStyles } from './useItemStyles';
 export { default as useOrderUpdater } from './useOrderUpdater';

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemDimensions.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemDimensions.ts
@@ -1,0 +1,21 @@
+import type { SharedValue } from 'react-native-reanimated';
+import { isSharedValue, useDerivedValue } from 'react-native-reanimated';
+
+import type { Animatable } from '../../../integrations/reanimated';
+import type { Dimensions } from '../../../types';
+import { useCommonValuesContext } from '../CommonValuesProvider';
+import { getItemDimensions } from '../utils';
+
+export default function useItemDimensions(
+  key: Animatable<null | string>
+): SharedValue<Dimensions | null> {
+  const { itemHeights, itemWidths } = useCommonValuesContext();
+
+  return useDerivedValue(() => {
+    const keyValue = isSharedValue<null | string>(key) ? key.value : key;
+
+    return keyValue
+      ? getItemDimensions(keyValue, itemWidths.value, itemHeights.value)
+      : null;
+  });
+}

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemDimensions.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemDimensions.ts
@@ -3,8 +3,8 @@ import { isSharedValue, useDerivedValue } from 'react-native-reanimated';
 
 import type { Animatable } from '../../../integrations/reanimated';
 import type { Dimensions } from '../../../types';
+import { getItemDimensions } from '../../../utils';
 import { useCommonValuesContext } from '../CommonValuesProvider';
-import { getItemDimensions } from '../utils';
 
 export default function useItemDimensions(
   key: Animatable<null | string>

--- a/packages/react-native-sortables/src/providers/shared/hooks/useTeleportedItemStyles.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useTeleportedItemStyles.ts
@@ -3,10 +3,9 @@ import type { AnimatedStyle, SharedValue } from 'react-native-reanimated';
 import { useAnimatedStyle, useDerivedValue } from 'react-native-reanimated';
 
 import type { Dimensions } from '../../../types';
-import { mergeStyles } from '../../../utils';
+import { mergeStyles, resolveDimension } from '../../../utils';
 import { useCommonValuesContext } from '../CommonValuesProvider';
 import { usePortalContext } from '../PortalProvider';
-import { resolveDimension } from '../utils';
 import useItemDecorationValues from './useItemDecorationValues';
 import useItemZIndex from './useItemZIndex';
 import useTeleportedItemPosition from './useTeleportedItemPosition';

--- a/packages/react-native-sortables/src/providers/shared/index.ts
+++ b/packages/react-native-sortables/src/providers/shared/index.ts
@@ -14,6 +14,7 @@ export * from './hooks';
 export { ItemContextProvider, useItemContext } from './ItemContextProvider';
 export { LayerProvider } from './LayerProvider';
 export {
+  type ItemDimensionsValidator,
   MeasurementsProvider,
   useMeasurementsContext
 } from './MeasurementsProvider';

--- a/packages/react-native-sortables/src/providers/shared/utils.ts
+++ b/packages/react-native-sortables/src/providers/shared/utils.ts
@@ -1,32 +1,7 @@
 import { EXTRA_SWAP_OFFSET } from '../../constants';
 import type { Maybe } from '../../helperTypes';
-import type { Dimensions } from '../../types';
 
 export const getAdditionalSwapOffset = (size?: Maybe<number>) => {
   'worklet';
   return size ? Math.min(EXTRA_SWAP_OFFSET, size / 2) : EXTRA_SWAP_OFFSET;
-};
-
-export const resolveDimension = (
-  dimension: number | Record<string, number>,
-  key: string
-) => {
-  'worklet';
-  return typeof dimension === 'number' ? dimension : dimension[key];
-};
-
-export const getItemDimensions = (
-  key: string,
-  itemWidths: number | Record<string, number>,
-  itemHeights: number | Record<string, number>
-): Dimensions | null => {
-  'worklet';
-  const itemWidth = resolveDimension(itemWidths, key);
-  const itemHeight = resolveDimension(itemHeights, key);
-
-  if (itemWidth === undefined || itemHeight === undefined) {
-    return null;
-  }
-
-  return { height: itemHeight, width: itemWidth };
 };

--- a/packages/react-native-sortables/src/providers/shared/utils.ts
+++ b/packages/react-native-sortables/src/providers/shared/utils.ts
@@ -1,7 +1,32 @@
 import { EXTRA_SWAP_OFFSET } from '../../constants';
 import type { Maybe } from '../../helperTypes';
+import type { Dimensions } from '../../types';
 
 export const getAdditionalSwapOffset = (size?: Maybe<number>) => {
   'worklet';
   return size ? Math.min(EXTRA_SWAP_OFFSET, size / 2) : EXTRA_SWAP_OFFSET;
+};
+
+export const resolveDimension = (
+  dimension: number | Record<string, number>,
+  key: string
+) => {
+  'worklet';
+  return typeof dimension === 'number' ? dimension : dimension[key];
+};
+
+export const getItemDimensions = (
+  key: string,
+  itemWidths: number | Record<string, number>,
+  itemHeights: number | Record<string, number>
+): Dimensions | null => {
+  'worklet';
+  const itemWidth = resolveDimension(itemWidths, key);
+  const itemHeight = resolveDimension(itemHeights, key);
+
+  if (itemWidth === undefined || itemHeight === undefined) {
+    return null;
+  }
+
+  return { height: itemHeight, width: itemWidth };
 };

--- a/packages/react-native-sortables/src/types/layout/flex.ts
+++ b/packages/react-native-sortables/src/types/layout/flex.ts
@@ -23,7 +23,8 @@ export type FlexLayoutProps = {
     row: number;
     column: number;
   };
-  itemDimensions: Record<string, Dimensions>;
+  itemWidths: number | Record<string, number>;
+  itemHeights: number | Record<string, number>;
   indexToKey: Array<string>;
   flexDirection: FlexDirection;
   flexWrap: FlexWrap;

--- a/packages/react-native-sortables/src/types/layout/grid.ts
+++ b/packages/react-native-sortables/src/types/layout/grid.ts
@@ -6,14 +6,15 @@ export type GridLayoutProps = {
     main: number;
     cross: number;
   };
-  itemDimensions: Record<string, Dimensions>;
+  itemHeights: number | Record<string, number>;
+  itemWidths: number | Record<string, number>;
   indexToKey: Array<string>;
-  numGroups: number;
   isVertical: boolean;
+  numGroups: number;
 };
 
 export type GridLayout = {
   itemPositions: Record<string, Vector>;
   crossAxisOffsets: Array<number>;
-  calculatedDimensions: Partial<Dimensions>;
+  controlledContainerDimensions: Partial<Dimensions>;
 };

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -29,7 +29,7 @@ import type { DragActivationState, LayerState } from '../state';
 
 // COMMON VALUES
 
-export type ControlledContainerDimensions = { width: boolean; height: boolean };
+export type ControlledDimensions = { width: boolean; height: boolean };
 
 // COMMON VALUES
 
@@ -56,10 +56,12 @@ export type CommonValuesContextType =
       activeItemPosition: SharedValue<null | Vector>;
 
       // DIMENSIONS
-      controlledContainerDimensions: SharedValue<ControlledContainerDimensions>;
+      controlledContainerDimensions: ControlledDimensions;
+      controlledItemDimensions: ControlledDimensions;
       containerWidth: SharedValue<null | number>;
       containerHeight: SharedValue<null | number>;
-      itemDimensions: SharedValue<Record<string, Dimensions>>;
+      itemWidths: SharedValue<number | Record<string, number>>;
+      itemHeights: SharedValue<number | Record<string, number>>;
       activeItemDimensions: SharedValue<Dimensions | null>;
 
       // DRAG STATE

--- a/packages/react-native-sortables/src/utils/dimensions.ts
+++ b/packages/react-native-sortables/src/utils/dimensions.ts
@@ -1,0 +1,25 @@
+import type { Dimensions } from '../types';
+
+export const resolveDimension = (
+  dimension: number | Record<string, number>,
+  key: string
+) => {
+  'worklet';
+  return typeof dimension === 'number' ? dimension : dimension[key];
+};
+
+export const getItemDimensions = (
+  key: string,
+  itemWidths: number | Record<string, number>,
+  itemHeights: number | Record<string, number>
+): Dimensions | null => {
+  'worklet';
+  const itemWidth = resolveDimension(itemWidths, key);
+  const itemHeight = resolveDimension(itemHeights, key);
+
+  if (itemWidth === undefined || itemHeight === undefined) {
+    return null;
+  }
+
+  return { height: itemHeight, width: itemWidth };
+};

--- a/packages/react-native-sortables/src/utils/equality.ts
+++ b/packages/react-native-sortables/src/utils/equality.ts
@@ -1,5 +1,5 @@
 import type { AnyRecord, Maybe } from '../helperTypes';
-import type { Dimensions, Vector } from '../types';
+import type { Vector } from '../types';
 
 export function lt(a: number, b: number): boolean {
   'worklet';
@@ -23,19 +23,24 @@ export const areArraysDifferent = <T>(
   );
 };
 
-export const areDimensionsDifferent = (
-  dim1: Dimensions,
-  dim2: Dimensions,
+export const areValuesDifferent = (
+  dim1: number | undefined,
+  dim2: number | undefined,
   eps?: number
 ): boolean => {
   'worklet';
-  if (eps) {
-    return (
-      Math.abs(dim1.width - dim2.width) > eps ||
-      Math.abs(dim1.height - dim2.height) > eps
-    );
+  if (dim1 === undefined) {
+    return dim2 !== undefined;
   }
-  return dim1.width !== dim2.width || dim1.height !== dim2.height;
+  if (dim2 === undefined) {
+    return true;
+  }
+
+  if (eps) {
+    return Math.abs(dim1 - dim2) > eps;
+  }
+
+  return dim1 !== dim2;
 };
 
 export const areVectorsDifferent = (vec1: Vector, vec2: Vector): boolean => {

--- a/packages/react-native-sortables/src/utils/index.ts
+++ b/packages/react-native-sortables/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './arrays';
 export * from './children';
+export * from './dimensions';
 export * from './equality';
 export * from './keys';
 export * from './layout';


### PR DESCRIPTION
## Description

This PR separates controlled item dimensions from uncontrolled ones, updated when item sizes change. This change is especially useful on web, when the size of items (e.g. the width of grid columns) can change when the window is resized. In this case, we don't want to update measured dimensions for all items separately and instead it is better to use the already known column width.
