### PR TITLE
fix: Invalid flex container height on initial render

### DIFF
--- a/packages/react-native-sortables/src/components/shared/DraggableView/ItemCell.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/ItemCell.tsx
@@ -48,12 +48,7 @@ export default function ItemCell({
       <AnimatedOnLayoutView
         entering={entering}
         exiting={exiting}
-        style={[
-          styles.fill,
-          styles.decoration,
-          decorationStyle,
-          hidden && styles.hidden
-        ]}
+        style={[styles.decoration, decorationStyle, hidden && styles.hidden]}
         onLayout={hidden ? undefined : onLayout}>
         {children}
       </AnimatedOnLayoutView>
@@ -74,11 +69,11 @@ const styles = StyleSheet.create({
       },
       shadowOpacity: 1,
       shadowRadius: 5
+    },
+    web: {
+      flex: 1
     }
   }),
-  fill: {
-    flex: 1
-  },
   hidden: {
     left: -9999
   }

--- a/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
@@ -79,12 +79,14 @@ export default function SortableContainer({
   }, [dimensionsAnimationType]);
 
   const innerContainerStyle = useAnimatedStyle(() => ({
-    ...(controlledContainerDimensions.height && {
-      minHeight: containerHeight.value
-    }),
-    ...(controlledContainerDimensions.width && {
-      minWidth: containerWidth.value
-    })
+    ...(controlledContainerDimensions.height &&
+      containerHeight.value !== null && {
+        height: containerHeight.value
+      }),
+    ...(controlledContainerDimensions.width &&
+      containerWidth.value !== null && {
+        width: containerWidth.value
+      })
   }));
 
   return (


### PR DESCRIPTION
## Description

I was applying `minHeight: null` via the animated style which overridden the proper value of `minHeight` provided as a prop.
