### PR TITLE
fix: onActiveItemDropped not being fired when item is touched quickly

### DIFF
--- a/packages/react-native-sortables/src/providers/shared/DragProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.ts
@@ -536,7 +536,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
         toIndex
       });
 
-      activationTimeoutId.value = setAnimatedTimeout(() => {
+      setAnimatedTimeout(() => {
         prevActiveItemKey.value = null;
         activeItemDropped.value = true;
         updateLayer?.(LayerState.IDLE);


### PR DESCRIPTION
## Description

The `onActiveItemDropped` callback was not fired when the item was touched again quickly after being released. We don't need to cancel this timeout so I just removed the timeout handle to make it work.