### PR TITLE
chore: Simplify unions with excluded props

### DIFF
--- a/packages/react-native-sortables/src/helperTypes.ts
+++ b/packages/react-native-sortables/src/helperTypes.ts
@@ -38,3 +38,19 @@ export type DeepReadonly<T> = {
       ? DeepReadonly<T[K]>
       : Readonly<T[K]>;
 };
+
+type AllKeys<U> = U extends unknown ? keyof U : never;
+
+export type MutuallyExclusiveUnion<
+  T extends ReadonlyArray<unknown>,
+  Processed extends ReadonlyArray<unknown> = []
+> = T extends readonly [infer First, ...infer Rest]
+  ?
+      | (First & {
+          [K in Exclude<
+            AllKeys<[...Processed, ...Rest][number]>,
+            keyof First
+          >]?: never;
+        })
+      | MutuallyExclusiveUnion<Rest, readonly [...Processed, First]>
+  : never;

--- a/packages/react-native-sortables/src/types/debug.ts
+++ b/packages/react-native-sortables/src/types/debug.ts
@@ -1,7 +1,7 @@
 import type { ViewStyle } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
 
-import type { Maybe } from '../helperTypes';
+import type { Maybe, MutuallyExclusiveUnion } from '../helperTypes';
 import type { Vector } from './layout/shared';
 
 export enum DebugComponentType {
@@ -10,97 +10,79 @@ export enum DebugComponentType {
   RECT = 'rect'
 }
 
-export type DebugCrossProps = Pick<
-  DebugLineProps,
-  'color' | 'opacity' | 'style' | 'thickness' | 'visible'
-> & {
-  isAbsolute?: boolean;
-} & (
-    | {
-        x: Maybe<number>;
-        y: Maybe<number>;
-        position?: never;
-      }
-    | {
-        x?: never;
-        y?: never;
-        position: Maybe<Vector>;
-      }
-  );
+export type DebugCrossProps = MutuallyExclusiveUnion<
+  [
+    {
+      x: Maybe<number>;
+      y: Maybe<number>;
+    },
+    {
+      position: Maybe<Vector>;
+    }
+  ]
+> &
+  Pick<
+    DebugLineProps,
+    'color' | 'opacity' | 'style' | 'thickness' | 'visible'
+  > & {
+    isAbsolute?: boolean;
+  };
 
-export type DebugLineProps = {
+export type DebugLineProps = MutuallyExclusiveUnion<
+  [
+    {
+      from: Maybe<Vector>;
+      to: Maybe<Vector>;
+    },
+    {
+      x: Maybe<number>;
+    },
+    {
+      y: Maybe<number>;
+    }
+  ]
+> & {
   isAbsolute?: boolean;
   visible?: boolean;
   color?: ViewStyle['borderColor'];
   thickness?: number;
   style?: ViewStyle['borderStyle'];
   opacity?: number;
-} & (
-  | {
+};
+
+export type DebugRectProps = MutuallyExclusiveUnion<
+  [
+    {
       from: Maybe<Vector>;
       to: Maybe<Vector>;
-      x?: never;
-      y?: never;
-    }
-  | {
+    },
+    {
       x: Maybe<number>;
-      y?: never;
-      from?: never;
-      to?: never;
-    }
-  | {
-      x?: never;
       y: Maybe<number>;
-      from?: never;
-      to?: never;
+      width: Maybe<number>;
+      height: Maybe<number>;
+      positionOrigin?: `${'left' | 'right'} ${'bottom' | 'top'}`;
+    },
+    {
+      x: Maybe<number>;
+      width: Maybe<number>;
+      positionOrigin?: `${'left' | 'right'}`;
+    },
+    {
+      y: Maybe<number>;
+      height: Maybe<number>;
+      positionOrigin?: `${'bottom' | 'top'}`;
     }
-);
-
-export type DebugRectProps = Pick<
-  ViewStyle,
-  'backgroundColor' | 'borderColor' | 'borderStyle' | 'borderWidth'
-> & {
-  isAbsolute?: boolean;
-  backgroundOpacity?: number;
-  visible?: boolean;
-} & (
-    | {
-        from: Maybe<Vector>;
-        to: Maybe<Vector>;
-        x?: never;
-        y?: never;
-        width?: never;
-        height?: never;
-        positionOrigin?: never;
-      }
-    | {
-        x: Maybe<number>;
-        y: Maybe<number>;
-        from?: never;
-        to?: never;
-        width: Maybe<number>;
-        height: Maybe<number>;
-        positionOrigin?: `${'left' | 'right'} ${'bottom' | 'top'}`;
-      }
-    | {
-        x: Maybe<number>;
-        y?: never;
-        from?: never;
-        to?: never;
-        width: Maybe<number>;
-        height?: never;
-        positionOrigin?: `${'left' | 'right'}`;
-      }
-    | {
-        x?: never;
-        y: Maybe<number>;
-        from?: never;
-        to?: never;
-        width?: never;
-        height: Maybe<number>;
-        positionOrigin?: `${'bottom' | 'top'}`;
-      }
-  );
+  ]
+> &
+  Pick<
+    ViewStyle,
+    'backgroundColor' | 'borderColor' | 'borderStyle' | 'borderWidth'
+  > & {
+    isAbsolute?: boolean;
+    backgroundOpacity?: number;
+    visible?: boolean;
+  };
 
 export type WrappedProps<P> = { props: SharedValue<P> };
 

--- a/packages/react-native-sortables/src/types/props/grid.ts
+++ b/packages/react-native-sortables/src/types/props/grid.ts
@@ -1,6 +1,10 @@
 import type { ReactNode } from 'react';
 
-import type { DefaultProps, Simplify } from '../../helperTypes';
+import type {
+  DefaultProps,
+  MutuallyExclusiveUnion,
+  Simplify
+} from '../../helperTypes';
 import type { AnimatableProps } from '../../integrations/reanimated';
 import type { SortStrategyFactory } from '../providers';
 import type { DefaultSharedProps, DragEndParams, SharedProps } from './shared';
@@ -18,26 +22,25 @@ export type SortableGridDragEndCallback<I> = (
   params: SortableGridDragEndParams<I>
 ) => void;
 
-type SortableGridLayoutSettings = Partial<
-  AnimatableProps<{
-    /** Vertical spacing between grid items */
-    rowGap: number;
-    /** Horizontal spacing between grid items */
-    columnGap: number;
-  }>
+type SortableGridLayoutSettings = MutuallyExclusiveUnion<
+  [
+    {
+      columns?: number;
+    },
+    {
+      rows: number;
+      rowHeight: number;
+    }
+  ]
 > &
-  (
-    | {
-        columns?: number;
-        rows?: never;
-        rowHeight?: number;
-      }
-    | {
-        rows: number;
-        rowHeight: number;
-        columns?: number;
-      }
-  );
+  Partial<
+    AnimatableProps<{
+      /** Vertical spacing between grid items */
+      rowGap: number;
+      /** Horizontal spacing between grid items */
+      columnGap: number;
+    }>
+  >;
 
 /** Information passed to the renderItem function */
 export type SortableGridRenderItemInfo<I> = {


### PR DESCRIPTION
## Description

This PR adds a complex helper generic type to simplify creation of unions having the same props but some of props marked as `never`. It also makes horizontal grid types more strict and no longer allows mixing horizontal grid props with vertical grid props.

## Changes showcase

### Before

<img width="567" height="291" alt="image" src="https://github.com/user-attachments/assets/d9cbf01c-95d3-43dd-9a07-2fb544b9e743" />

### After

I know that the type error message could be better but this is the best what I can do

<img width="748" height="446" alt="image" src="https://github.com/user-attachments/assets/6110884e-0449-4070-8eff-1a1d5f123680" />
