### PR TITLE
fix: Incorrect drag start position, no item size animation when teleported

### DIFF
--- a/packages/react-native-sortables/src/integrations/reanimated/utils/animatedTimeout.ts
+++ b/packages/react-native-sortables/src/integrations/reanimated/utils/animatedTimeout.ts
@@ -18,7 +18,7 @@ function removeFromPendingTimeouts(id: AnimatedTimeoutID): void {
 
 export function setAnimatedTimeout<F extends AnyFunction>(
   callback: F,
-  delay: number
+  delay = 0
 ): AnimatedTimeoutID {
   let startTimestamp: number;
 

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.ts
@@ -329,7 +329,6 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
 
       inactiveAnimationProgress.value = hasInactiveAnimation ? animate() : 0;
       activeAnimationProgress.value = animate();
-      activationAnimationProgress.value = 0.01;
       activationAnimationProgress.value = animate();
 
       haptics.medium();


### PR DESCRIPTION
## Description

This PR fixes 2 issues related to collapsible items:
1. Incorrect position of the item when the drag starts
2. No dimensions layout transition of the active item when teleported (was rendered with the new dimensions right away)