### PR TITLE
fix: Invalid grid layout on mount

### DIFF
--- a/packages/react-native-sortables/src/components/SortableGrid.tsx
+++ b/packages/react-native-sortables/src/components/SortableGrid.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useLayoutEffect, useMemo, useRef } from 'react';
 import type { DimensionValue } from 'react-native';
 import { StyleSheet } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
@@ -7,7 +7,11 @@ import { runOnUI, useAnimatedStyle } from 'react-native-reanimated';
 import { DEFAULT_SORTABLE_GRID_PROPS, IS_WEB } from '../constants';
 import { useDragEndHandler } from '../hooks';
 import { useAnimatableValue } from '../integrations/reanimated';
-import { GridProvider, useMeasurementsContext } from '../providers';
+import {
+  GridProvider,
+  useGridLayoutContext,
+  useMeasurementsContext
+} from '../providers';
 import type {
   DropIndicatorSettings,
   SortableGridProps,
@@ -165,9 +169,10 @@ function SortableGridInner<I>({
 }: SortableGridInnerProps<I>) {
   const { handleContainerMeasurement, resetMeasurements } =
     useMeasurementsContext();
+  const { mainGroupSize } = useGridLayoutContext();
   const isFirstRenderRef = useRef(true);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (isFirstRenderRef.current) {
       isFirstRenderRef.current = false;
       return;
@@ -199,8 +204,9 @@ function SortableGridInner<I>({
               `calc((100% - ${columnGap.value * (groups - 1)}px) / ${groups})` as DimensionValue
           }
         : {
-            flexBasis: `${100 / groups}%`,
-            paddingHorizontal: columnGap.value / 2
+            flexBasis: mainGroupSize.value ? undefined : `${100 / groups}%`,
+            paddingHorizontal: columnGap.value / 2,
+            width: mainGroupSize.value
           }
       : { height: rowHeight }
   );

--- a/packages/react-native-sortables/src/components/SortableGrid.tsx
+++ b/packages/react-native-sortables/src/components/SortableGrid.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import type { DimensionValue } from 'react-native';
 import { StyleSheet } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
@@ -165,8 +165,15 @@ function SortableGridInner<I>({
 }: SortableGridInnerProps<I>) {
   const { handleContainerMeasurement, resetMeasurements } =
     useMeasurementsContext();
+  const isFirstRenderRef = useRef(true);
 
-  useEffect(resetMeasurements, [groups, resetMeasurements]);
+  useEffect(() => {
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false;
+      return;
+    }
+    resetMeasurements();
+  }, [groups, resetMeasurements]);
 
   const animatedInnerStyle = useAnimatedStyle(() =>
     isVertical

--- a/packages/react-native-sortables/src/providers/grid/GridLayoutProvider/GridLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/grid/GridLayoutProvider/GridLayoutProvider.tsx
@@ -4,6 +4,7 @@ import { useAnimatedReaction } from 'react-native-reanimated';
 
 import { IS_WEB } from '../../../constants';
 import { useDebugContext } from '../../../debug';
+import { useMutableValue } from '../../../integrations/reanimated';
 import type { GridLayoutContextType } from '../../../types';
 import {
   useAutoScrollContext,
@@ -60,6 +61,8 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
   const mainGap = isVertical ? columnGap : rowGap;
   const crossGap = isVertical ? rowGap : columnGap;
 
+  const mainGroupSize = useMutableValue<null | number>(null);
+
   // MAIN GROUP SIZE UPDATER
   useAnimatedReaction(
     () => {
@@ -83,6 +86,7 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
       } else {
         itemHeights.value = value;
       }
+      mainGroupSize.value = value;
 
       // DEBUG ONLY
       if (debugMainGapRects) {
@@ -168,6 +172,7 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
       crossGap,
       isVertical,
       mainGap,
+      mainGroupSize,
       numGroups
     }
   };

--- a/packages/react-native-sortables/src/providers/grid/GridLayoutProvider/updates/common.ts
+++ b/packages/react-native-sortables/src/providers/grid/GridLayoutProvider/updates/common.ts
@@ -29,7 +29,8 @@ export const createGridStrategy =
       itemHeights,
       itemWidths
     } = useCommonValuesContext();
-    const { crossGap, isVertical, mainGap, numGroups } = useGridLayoutContext();
+    const { crossGap, isVertical, mainGap, mainGroupSize, numGroups } =
+      useGridLayoutContext();
     const { additionalCrossOffset } = useAdditionalCrossOffsetContext() ?? {};
     const { fixedItemKeys } = useCustomHandleContext() ?? {};
 
@@ -75,14 +76,11 @@ export const createGridStrategy =
 
     return ({ activeIndex, dimensions, position }) => {
       'worklet';
-      const mainGroupSize = (isVertical ? itemWidths : itemHeights).value;
-
       if (
         !othersLayout.value ||
         crossContainerSize.value === null ||
         mainContainerSize.value === null ||
-        mainGroupSize === null ||
-        typeof mainGroupSize !== 'number'
+        mainGroupSize.value === null
       ) {
         return;
       }
@@ -170,7 +168,7 @@ export const createGridStrategy =
         if (mainBeforeBound !== Infinity) {
           mainIndex--;
         }
-        mainBeforeOffset = mainIndex * (mainGroupSize + mainGap.value);
+        mainBeforeOffset = mainIndex * (mainGroupSize.value + mainGap.value);
         mainBeforeBound = mainBeforeOffset - additionalOffset;
       } while (
         mainBeforeBound > 0 &&
@@ -186,7 +184,8 @@ export const createGridStrategy =
           mainIndex++;
         }
         mainAfterOffset =
-          mainIndex * (mainGroupSize + mainGap.value) + mainGroupSize;
+          mainIndex * (mainGroupSize.value + mainGap.value) +
+          mainGroupSize.value;
         mainAfterBound = mainAfterOffset + additionalOffset;
       } while (
         mainAfterBound < mainContainerSize.value &&

--- a/packages/react-native-sortables/src/types/providers/grid.ts
+++ b/packages/react-native-sortables/src/types/providers/grid.ts
@@ -8,5 +8,6 @@ export type GridLayoutContextType = {
   numGroups: number;
   mainGap: SharedValue<number>;
   crossGap: SharedValue<number>;
+  mainGroupSize: SharedValue<null | number>;
   isVertical: boolean;
 };


### PR DESCRIPTION
## Description

The `resetMeasurements` method was called in the `useEffect` on the first render, which cleared all item measurements before the layout was calculated. As a result, we got weird content stretch when the item started being dragged.