### PR TITLE
fix: Autoscroll exceeding bounds

### DIFF
--- a/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/utils.ts
+++ b/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/utils.ts
@@ -65,15 +65,7 @@ export const calculateRawProgressHorizontal: CalculateRawProgressFunction = (
   ...rest
 ) => calculateRawProgress(position, cX, cW, sX, sW, ...rest);
 
-type ClampDistanceFunction = (
-  distance: number,
-  contentContainerMeasurements: MeasuredDimensions,
-  scrollContainerMeasurements: MeasuredDimensions,
-  contentBounds: [number, number],
-  maxOverscroll: [number, number]
-) => number;
-
-const clampDistance = (
+export const clampDistance = (
   distance: number,
   containerOffset: number,
   scrollableSize: number,
@@ -102,17 +94,3 @@ const clampDistance = (
 
   return 0;
 };
-
-export const clampDistanceVertical: ClampDistanceFunction = (
-  distance,
-  { pageY: cY },
-  { height: sH, pageY: sY },
-  ...rest
-) => clampDistance(distance, sY - cY, sH, ...rest);
-
-export const clampDistanceHorizontal: ClampDistanceFunction = (
-  distance,
-  { pageX: cX },
-  { pageX: sX, width: sW },
-  ...rest
-) => clampDistance(distance, sX - cX, sW, ...rest);


### PR DESCRIPTION
## Description

This PR fixes the issue caused by the fact that `measure` sometimes returns slightly outdated values, thus the container scroll offset was invalid and we were scrolling beyond the bounds of the scrollable content size.

To fix the issue, I decided to check whether the new `contentOffset` is different from the old one before calling the `scrollBy` function in order not to queue too many scroll updates, which can sum up to the invalid distance outside of the scrollable content container size.