### PR TITLE
fix: Invalid builder bob config

### DIFF
--- a/packages/react-native-sortables/bob.config.cjs
+++ b/packages/react-native-sortables/bob.config.cjs
@@ -1,10 +1,7 @@
 module.exports = {
   source: 'src',
   output: 'dist',
-  exclude: [
-    '**/{__tests__,__fixtures__,__mocks__}/**',
-    '**/*.test.{js,jsx,ts,tsx}'
-  ],
+  exclude: '{**/{__tests__,__fixtures__,__mocks__}/**,**/*.test.{js,jsx,ts,tsx}}',
   targets: [
     ['module', { configFile: true }],
     ['typescript', { project: 'tsconfig.build.json' }]


### PR DESCRIPTION
## Description

It seems that the `react-native-builder-bob` no longer accepts an array of excludes after the upgrade and it must be passed a single string now.