### PR TITLE
fix: Prevent auto scroll from over scrolling content container

### DIFF
--- a/example/app/src/examples/SortableGrid/features/AutoScrollExample.tsx
+++ b/example/app/src/examples/SortableGrid/features/AutoScrollExample.tsx
@@ -18,7 +18,7 @@ import { useBottomNavBarHeight } from '@/providers';
 import { colors, spacing, style } from '@/theme';
 import { getItems } from '@/utils';
 
-const MANY_ITEMS = getItems(21);
+const MANY_ITEMS = getItems(30);
 const FEW_ITEMS = getItems(6);
 
 const LIST_ITEM_SECTIONS = ['List item 1', 'List item 2', 'List item 3'];
@@ -155,6 +155,7 @@ function ManyCards({ scrollableRef }: CardsSectionProps) {
       renderItem={({ item }) => <GridCard>{item}</GridCard>}
       rowGap={spacing.xs}
       scrollableRef={scrollableRef}
+      debug
     />
   );
 }
@@ -168,6 +169,7 @@ function FewCards({ scrollableRef }: CardsSectionProps) {
       renderItem={({ item }) => <GridCard>{item}</GridCard>}
       rowGap={spacing.xs}
       scrollableRef={scrollableRef}
+      debug
     />
   );
 }

--- a/example/app/src/examples/SortableGrid/features/AutoScrollExample.tsx
+++ b/example/app/src/examples/SortableGrid/features/AutoScrollExample.tsx
@@ -155,7 +155,6 @@ function ManyCards({ scrollableRef }: CardsSectionProps) {
       renderItem={({ item }) => <GridCard>{item}</GridCard>}
       rowGap={spacing.xs}
       scrollableRef={scrollableRef}
-      debug
     />
   );
 }
@@ -169,7 +168,6 @@ function FewCards({ scrollableRef }: CardsSectionProps) {
       renderItem={({ item }) => <GridCard>{item}</GridCard>}
       rowGap={spacing.xs}
       scrollableRef={scrollableRef}
-      debug
     />
   );
 }

--- a/packages/react-native-sortables/src/components/SortableFlex.tsx
+++ b/packages/react-native-sortables/src/components/SortableFlex.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo } from 'react';
 import type { ViewStyle } from 'react-native';
 import { StyleSheet } from 'react-native';
-import { useAnimatedStyle } from 'react-native-reanimated';
+import { runOnUI, useAnimatedStyle } from 'react-native-reanimated';
 
 import { DEFAULT_SORTABLE_FLEX_PROPS } from '../constants';
 import type { PropsWithDefaults } from '../hooks';
@@ -236,7 +236,7 @@ function SortableFlexComponent({
       {...rest}
       containerStyle={[baseContainerStyle, animatedContainerStyle]}
       itemStyle={styles.styleOverride}
-      onLayout={handleContainerMeasurement}
+      onLayout={runOnUI(handleContainerMeasurement)}
     />
   );
 }

--- a/packages/react-native-sortables/src/components/SortableFlex.tsx
+++ b/packages/react-native-sortables/src/components/SortableFlex.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo } from 'react';
 import type { ViewStyle } from 'react-native';
 import { StyleSheet } from 'react-native';
-import { runOnUI, useAnimatedStyle } from 'react-native-reanimated';
+import { useAnimatedStyle } from 'react-native-reanimated';
 
 import { DEFAULT_SORTABLE_FLEX_PROPS } from '../constants';
 import type { PropsWithDefaults } from '../hooks';
@@ -236,9 +236,7 @@ function SortableFlexComponent({
       {...rest}
       containerStyle={[baseContainerStyle, animatedContainerStyle]}
       itemStyle={styles.styleOverride}
-      onLayout={runOnUI((w, h) => {
-        handleContainerMeasurement(w, h);
-      })}
+      onLayout={handleContainerMeasurement}
     />
   );
 }

--- a/packages/react-native-sortables/src/components/SortableGrid.tsx
+++ b/packages/react-native-sortables/src/components/SortableGrid.tsx
@@ -2,7 +2,7 @@ import { useLayoutEffect, useMemo, useRef } from 'react';
 import type { DimensionValue } from 'react-native';
 import { StyleSheet } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
-import { useAnimatedStyle } from 'react-native-reanimated';
+import { runOnUI, useAnimatedStyle } from 'react-native-reanimated';
 
 import { DEFAULT_SORTABLE_GRID_PROPS, IS_WEB } from '../constants';
 import type { PropsWithDefaults } from '../hooks';
@@ -249,13 +249,12 @@ function SortableGridComponent<I>({
       {...rest}
       containerStyle={[styles.gridContainer, animatedInnerStyle]}
       itemStyle={itemStyle}
-      onLayout={(w, h) => {
-        'worklet';
+      onLayout={runOnUI((w, h) => {
         handleContainerMeasurement(
           w - (isVertical && !IS_WEB ? columnGap.value : 0),
           h
         );
-      }}
+      })}
     />
   );
 }

--- a/packages/react-native-sortables/src/components/SortableGrid.tsx
+++ b/packages/react-native-sortables/src/components/SortableGrid.tsx
@@ -2,7 +2,7 @@ import { useLayoutEffect, useMemo, useRef } from 'react';
 import type { DimensionValue } from 'react-native';
 import { StyleSheet } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
-import { runOnUI, useAnimatedStyle } from 'react-native-reanimated';
+import { useAnimatedStyle } from 'react-native-reanimated';
 
 import { DEFAULT_SORTABLE_GRID_PROPS, IS_WEB } from '../constants';
 import type { PropsWithDefaults } from '../hooks';
@@ -249,12 +249,13 @@ function SortableGridComponent<I>({
       {...rest}
       containerStyle={[styles.gridContainer, animatedInnerStyle]}
       itemStyle={itemStyle}
-      onLayout={runOnUI((w, h) => {
+      onLayout={(w, h) => {
+        'worklet';
         handleContainerMeasurement(
           w - (isVertical && !IS_WEB ? columnGap.value : 0),
           h
         );
-      })}
+      }}
     />
   );
 }

--- a/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
@@ -2,6 +2,7 @@ import { memo, useSyncExternalStore } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
 import Animated, {
   LinearTransition,
+  runOnUI,
   useAnimatedStyle,
   withTiming
 } from 'react-native-reanimated';
@@ -9,7 +10,11 @@ import Animated, {
 import { EMPTY_OBJECT, IS_WEB } from '../../constants';
 import { DebugOutlet } from '../../debug';
 import type { AnimatedStyleProp } from '../../integrations/reanimated';
-import { useCommonValuesContext, useItemsContext } from '../../providers';
+import {
+  useAutoScrollContext,
+  useCommonValuesContext,
+  useItemsContext
+} from '../../providers';
 import type {
   DimensionsAnimation,
   DropIndicatorSettings,
@@ -53,6 +58,7 @@ export default function SortableContainer({
     shouldAnimateLayout,
     usesAbsoluteLayout
   } = useCommonValuesContext();
+  const { onContainerLayout } = useAutoScrollContext() ?? {};
 
   const animateWorklet = dimensionsAnimationType === 'worklet';
   const animateLayout = dimensionsAnimationType === 'layout';
@@ -115,9 +121,12 @@ export default function SortableContainer({
       <AnimatedOnLayoutView
         ref={containerRef}
         style={[containerStyle, innerContainerStyle]}
-        onLayout={({ nativeEvent: { layout } }) => {
-          onLayout(layout.width, layout.height);
-        }}>
+        onLayout={({ nativeEvent: { layout } }) =>
+          runOnUI(() => {
+            onContainerLayout?.();
+            onLayout(layout.width, layout.height);
+          })()
+        }>
         <ItemsOutlet
           itemEntering={itemEntering}
           itemExiting={itemExiting}

--- a/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
@@ -2,7 +2,6 @@ import { memo, useSyncExternalStore } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
 import Animated, {
   LinearTransition,
-  runOnUI,
   useAnimatedStyle,
   withTiming
 } from 'react-native-reanimated';
@@ -10,11 +9,7 @@ import Animated, {
 import { EMPTY_OBJECT, IS_WEB } from '../../constants';
 import { DebugOutlet } from '../../debug';
 import type { AnimatedStyleProp } from '../../integrations/reanimated';
-import {
-  useAutoScrollContext,
-  useCommonValuesContext,
-  useItemsContext
-} from '../../providers';
+import { useCommonValuesContext, useItemsContext } from '../../providers';
 import type {
   DimensionsAnimation,
   DropIndicatorSettings,
@@ -58,7 +53,6 @@ export default function SortableContainer({
     shouldAnimateLayout,
     usesAbsoluteLayout
   } = useCommonValuesContext();
-  const { onContainerLayout } = useAutoScrollContext() ?? {};
 
   const animateWorklet = dimensionsAnimationType === 'worklet';
   const animateLayout = dimensionsAnimationType === 'layout';
@@ -122,10 +116,7 @@ export default function SortableContainer({
         ref={containerRef}
         style={[containerStyle, innerContainerStyle]}
         onLayout={({ nativeEvent: { layout } }) =>
-          runOnUI(() => {
-            onContainerLayout?.();
-            onLayout(layout.width, layout.height);
-          })()
+          onLayout(layout.width, layout.height)
         }>
         <ItemsOutlet
           itemEntering={itemEntering}

--- a/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/AutoScrollProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/AutoScrollProvider.tsx
@@ -220,7 +220,7 @@ function AutoScrollUpdater({
           ctx.targetScrollOffset + distance,
           ctx.sortableOffset + bounds[0] - maxOverscroll[0]
         );
-      }
+      } else return;
 
       if (Math.abs(newScrollOffset - ctx.targetScrollOffset) < 1) {
         return;
@@ -269,6 +269,7 @@ function AutoScrollUpdater({
 
       const distance = velocity * (cappedElapsedTime / 1000);
 
+      console.log('frameCallbackFunction', distance, ctx.progress);
       scrollBy(distance, animateScrollTo);
     },
     [

--- a/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/useDebugHelpers.ts
+++ b/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/useDebugHelpers.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import type { MeasuredDimensions, SharedValue } from 'react-native-reanimated';
+import type { SharedValue } from 'react-native-reanimated';
 
 import { useDebugContext } from '../../../debug';
 
@@ -37,10 +37,8 @@ export default function useDebugHelpers(
   }, [debugRects]);
 
   const updateDebugRects = useCallback(
-    (containerPos: number, scrollableMeasurements: MeasuredDimensions) => {
+    (containerPos: number, scrollableSize: number) => {
       'worklet';
-      const { height: sH, width: sW } = scrollableMeasurements;
-
       const startTriggerProps = isVertical
         ? {
             height: startActivationOffset,
@@ -55,12 +53,12 @@ export default function useDebugHelpers(
         ? {
             height: endActivationOffset,
             positionOrigin: 'bottom' as const,
-            y: -containerPos + sH
+            y: -containerPos + scrollableSize
           }
         : {
             positionOrigin: 'right' as const,
             width: endActivationOffset,
-            x: -containerPos + sW
+            x: -containerPos + scrollableSize
           };
 
       debugRects?.start.set({ ...TRIGGER_COLORS, ...startTriggerProps });

--- a/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/useDebugHelpers.ts
+++ b/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/useDebugHelpers.ts
@@ -15,7 +15,7 @@ const OVERSCROLL_COLORS = {
 
 export default function useDebugHelpers(
   isVertical: boolean,
-  [startOffset, endOffset]: [number, number],
+  [startActivationOffset, endActivationOffset]: [number, number],
   contentBounds: SharedValue<[number, number] | null>,
   [maxStartOverscroll, maxEndOverscroll]: [number, number]
 ) {
@@ -37,39 +37,30 @@ export default function useDebugHelpers(
   }, [debugRects]);
 
   const updateDebugRects = useCallback(
-    (
-      contentContainerMeasurements: MeasuredDimensions,
-      scrollContainerMeasurements: MeasuredDimensions
-    ) => {
+    (containerPos: number, scrollableMeasurements: MeasuredDimensions) => {
       'worklet';
-      const { pageX: cX, pageY: cY } = contentContainerMeasurements;
-      const {
-        height: sH,
-        pageX: sX,
-        pageY: sY,
-        width: sW
-      } = scrollContainerMeasurements;
+      const { height: sH, width: sW } = scrollableMeasurements;
 
       const startTriggerProps = isVertical
         ? {
-            height: startOffset,
-            y: sY - cY
+            height: startActivationOffset,
+            y: -containerPos
           }
         : {
-            width: startOffset,
-            x: sX - cX
+            width: startActivationOffset,
+            x: -containerPos
           };
 
       const endTriggerProps = isVertical
         ? {
-            height: endOffset,
+            height: endActivationOffset,
             positionOrigin: 'bottom' as const,
-            y: sY - cY + sH
+            y: -containerPos + sH
           }
         : {
             positionOrigin: 'right' as const,
-            width: endOffset,
-            x: sX - cX + sW
+            width: endActivationOffset,
+            x: -containerPos + sW
           };
 
       debugRects?.start.set({ ...TRIGGER_COLORS, ...startTriggerProps });
@@ -114,11 +105,11 @@ export default function useDebugHelpers(
     [
       debugRects,
       isVertical,
-      startOffset,
-      endOffset,
       contentBounds,
       maxStartOverscroll,
-      maxEndOverscroll
+      maxEndOverscroll,
+      startActivationOffset,
+      endActivationOffset
     ]
   );
 

--- a/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/utils.ts
+++ b/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/utils.ts
@@ -64,33 +64,3 @@ export const calculateRawProgressHorizontal: CalculateRawProgressFunction = (
   { pageX: sX, width: sW },
   ...rest
 ) => calculateRawProgress(position, cX, cW, sX, sW, ...rest);
-
-export const clampDistance = (
-  distance: number,
-  containerOffset: number,
-  scrollableSize: number,
-  [startOffset, endOffset]: [number, number],
-  [maxStartOverscroll, maxEndOverscroll]: [number, number]
-) => {
-  if (distance < 0) {
-    // Scrolling up
-    return Math.min(
-      0,
-      Math.max(containerOffset + distance, startOffset - maxStartOverscroll) -
-        containerOffset
-    );
-  }
-
-  if (distance > 0) {
-    // Scrolling down
-    return Math.max(
-      0,
-      Math.min(
-        containerOffset + distance,
-        endOffset - scrollableSize + maxEndOverscroll
-      ) - containerOffset
-    );
-  }
-
-  return 0;
-};

--- a/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/utils.ts
+++ b/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/utils.ts
@@ -5,7 +5,6 @@ import { Extrapolation, interpolate } from 'react-native-reanimated';
 export const calculateRawProgress = (
   position: number,
   containerPos: number,
-  scrollablePos: number,
   scrollableSize: number,
   activationOffset: [number, number],
   contentBounds: [number, number],
@@ -20,8 +19,8 @@ export const calculateRawProgress = (
     Extrapolation.CLAMP
   );
 
-  const contentEndPos = containerPos + contentBounds[1];
-  const endDistance = scrollablePos + scrollableSize - contentEndPos;
+  const contentSize = contentBounds[1] - contentBounds[0];
+  const endDistance = scrollableSize - contentSize - startDistance;
   const endBoundProgress = interpolate(
     endDistance,
     [-activationOffset[1], maxOverscroll[1]],
@@ -29,12 +28,10 @@ export const calculateRawProgress = (
     Extrapolation.CLAMP
   );
 
-  const startBound = scrollablePos - containerPos;
+  const startBound = -containerPos;
   const startThreshold = startBound + activationOffset[0];
   const endBound = startBound + scrollableSize;
   const endThreshold = endBound - activationOffset[1];
-
-  console.log(position, [startBound, startThreshold, endThreshold, endBound]);
 
   return interpolate(
     position,

--- a/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/utils.ts
+++ b/packages/react-native-sortables/src/providers/shared/AutoScrollProvider/utils.ts
@@ -1,66 +1,45 @@
 'worklet';
-import type {
-  ExtrapolationType,
-  MeasuredDimensions
-} from 'react-native-reanimated';
+import type { ExtrapolationType } from 'react-native-reanimated';
 import { Extrapolation, interpolate } from 'react-native-reanimated';
 
-type CalculateRawProgressFunction = (
+export const calculateRawProgress = (
   position: number,
-  contentContainerMeasurements: MeasuredDimensions,
-  scrollContainerMeasurements: MeasuredDimensions,
-  activationOffset: [number, number],
-  maxOverscroll: [number, number],
-  extrapolation: ExtrapolationType
-) => number;
-
-const calculateRawProgress = (
-  position: number,
-  contentPos: number,
-  contentSize: number,
+  containerPos: number,
   scrollablePos: number,
   scrollableSize: number,
-  [startOffset, endOffset]: [number, number],
-  [maxStartOverscroll, maxEndOverscroll]: [number, number],
+  activationOffset: [number, number],
+  contentBounds: [number, number],
+  maxOverscroll: [number, number],
   extrapolation: ExtrapolationType
 ) => {
-  const startBound = scrollablePos - contentPos;
-  const startThreshold = startBound + startOffset;
-  const endBound = startBound + scrollableSize;
-  const endThreshold = endBound - endOffset;
-
-  const startBoundProgress = -interpolate(
-    startBound,
-    [-maxStartOverscroll, startOffset],
-    [0, 1],
-    Extrapolation.CLAMP
-  );
-
-  const endBoundProgress = interpolate(
-    endBound,
-    [contentSize - endOffset, contentSize + maxEndOverscroll],
+  const startDistance = containerPos + contentBounds[0];
+  const startBoundProgress = interpolate(
+    startDistance,
+    [-activationOffset[0], maxOverscroll[0]],
     [1, 0],
     Extrapolation.CLAMP
   );
 
+  const contentEndPos = containerPos + contentBounds[1];
+  const endDistance = scrollablePos + scrollableSize - contentEndPos;
+  const endBoundProgress = interpolate(
+    endDistance,
+    [-activationOffset[1], maxOverscroll[1]],
+    [1, 0],
+    Extrapolation.CLAMP
+  );
+
+  const startBound = scrollablePos - containerPos;
+  const startThreshold = startBound + activationOffset[0];
+  const endBound = startBound + scrollableSize;
+  const endThreshold = endBound - activationOffset[1];
+
+  console.log(position, [startBound, startThreshold, endThreshold, endBound]);
+
   return interpolate(
     position,
     [startBound, startThreshold, endThreshold, endBound],
-    [startBoundProgress, 0, 0, endBoundProgress],
+    [-startBoundProgress, 0, 0, endBoundProgress],
     extrapolation
   );
 };
-
-export const calculateRawProgressVertical: CalculateRawProgressFunction = (
-  position,
-  { height: cH, pageY: cY },
-  { height: sH, pageY: sY },
-  ...rest
-) => calculateRawProgress(position, cY, cH, sY, sH, ...rest);
-
-export const calculateRawProgressHorizontal: CalculateRawProgressFunction = (
-  position,
-  { pageX: cX, width: cW },
-  { pageX: sX, width: sW },
-  ...rest
-) => calculateRawProgress(position, cX, cW, sX, sW, ...rest);

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.ts
@@ -108,7 +108,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
     usesAbsoluteLayout
   } = useCommonValuesContext();
   const { updateLayer } = useLayerContext() ?? {};
-  const { scrollOffsetDiff } = useAutoScrollContext() ?? {};
+  const { isVerticalScroll, scrollOffsetDiff } = useAutoScrollContext() ?? {};
   const {
     activeHandleMeasurements,
     activeHandleOffset,
@@ -141,10 +141,10 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       enableSnap: enableActiveItemSnap.value,
       itemTouchOffset: context.value.dragStartItemTouchOffset,
       key: activeItemKey.value,
-      offsetDiff: scrollOffsetDiff?.value,
       offsetX: snapOffsetX.value,
       offsetY: snapOffsetY.value,
       progress: activeAnimationProgress.value,
+      scrollDiff: scrollOffsetDiff?.value,
       snapItemDimensions:
         activeHandleMeasurements?.value ?? activeItemDimensions.value,
       snapItemOffset: activeHandleOffset?.value,
@@ -159,10 +159,10 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       enableSnap,
       itemTouchOffset,
       key,
-      offsetDiff,
       offsetX,
       offsetY,
       progress,
+      scrollDiff,
       snapItemDimensions,
       snapItemOffset,
       startTouch,
@@ -188,15 +188,17 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       // Touch position
 
       const newTouchPosition = {
-        x:
-          startTouchPosition.x +
-          (touch.absoluteX - startTouch.absoluteX) +
-          (offsetDiff?.x ?? 0),
-        y:
-          startTouchPosition.y +
-          (touch.absoluteY - startTouch.absoluteY) +
-          (offsetDiff?.y ?? 0)
+        x: startTouchPosition.x + (touch.absoluteX - startTouch.absoluteX),
+        y: startTouchPosition.y + (touch.absoluteY - startTouch.absoluteY)
       };
+
+      if (scrollDiff) {
+        if (isVerticalScroll) {
+          newTouchPosition.y += scrollDiff;
+        } else {
+          newTouchPosition.x += scrollDiff;
+        }
+      }
 
       if (
         !touchPosition.value ||

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -116,7 +116,6 @@ export type AutoScrollContextType = {
   scrollOffsetDiff: SharedValue<number>;
   isVerticalScroll: boolean;
   contentBounds: SharedValue<[Vector, Vector] | null>;
-  onContainerLayout: () => void;
   scrollBy: (distance: number, animated: boolean) => void;
 };
 

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -116,6 +116,7 @@ export type AutoScrollContextType = {
   scrollOffsetDiff: SharedValue<number>;
   isVerticalScroll: boolean;
   contentBounds: SharedValue<[Vector, Vector] | null>;
+  onContainerLayout: () => void;
   scrollBy: (distance: number, animated: boolean) => void;
 };
 

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -113,7 +113,8 @@ export type MeasurementsContextType = {
 
 export type AutoScrollContextType = {
   scrollableRef: AnimatedRef<ScrollView>;
-  scrollOffsetDiff: SharedValue<null | Partial<Vector>>;
+  scrollOffsetDiff: SharedValue<number>;
+  isVerticalScroll: boolean;
   contentBounds: SharedValue<[Vector, Vector] | null>;
   scrollBy: (distance: number, animated: boolean) => void;
 };


### PR DESCRIPTION
## Description

This PR is an another fix to the issue that I attempted to fix in the #473 PR. It seems that the issue still occurred as the `measure` function and the `scrollOffset` value received from the `useScrollOffset` weren't updated in sync.
