### PR TITLE
chore: Limit example apps workflow to trigger just on main

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -8,13 +8,6 @@ on:
       - 'example/**'
       - 'packages/react-native-sortables/**'
       - '.github/workflows/build-examples.yml'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'example/**'
-      - 'packages/react-native-sortables/**'
-      - '.github/workflows/build-examples.yml'
   workflow_dispatch: # Allow manual triggering
 
 env:


### PR DESCRIPTION
## Description

This PR limits the example apps build check workflow trigger to just the `main` branch and removes the PR trigger.
