### PR TITLE
ci: Fix concurrency group in react native example app build

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -62,7 +62,7 @@ jobs:
     name: 📱 Build ${{ matrix.app }} (${{ matrix.platform }})
     runs-on: macos-15
     concurrency:
-      group: build-react-native-${{ github.ref }}
+      group: build-react-native-${{ matrix.app }}-${{ matrix.platform }}-${{ github.ref }}
       cancel-in-progress: true
     strategy:
       matrix:


### PR DESCRIPTION
## Description

There was an issue with the group name which immediately cancelled example app builds