### PR TITLE
fix: Active item getting stuck on iOS 26

### DIFF
--- a/packages/react-native-sortables/src/providers/shared/DragProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.ts
@@ -508,9 +508,6 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       const ctx = context.value;
       clearAnimatedTimeout(ctx.activationTimeoutId);
 
-      const fromIndex = ctx.dragStartIndex;
-      const toIndex = keyToIndex.value[key]!;
-
       ctx.touchStartTouch = null;
       currentTouch.value = null;
       activationState.value = DragActivationState.INACTIVE;
@@ -527,6 +524,9 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       if (multiZoneActiveItemDimensions) {
         multiZoneActiveItemDimensions.value = null;
       }
+
+      const fromIndex = ctx.dragStartIndex;
+      const toIndex = keyToIndex.value[key]!;
 
       prevActiveItemKey.value = activeItemKey.value;
       ctx.dragStartItemTouchOffset = null;

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemPanGesture.ts
@@ -27,13 +27,12 @@ export default function useItemPanGesture(
           handleTouchesMove(e, manager.fail);
         })
         .onTouchesCancelled((_, manager) => {
+          handleDragEnd(key, activationAnimationProgress);
           manager.fail();
         })
         .onTouchesUp((_, manager) => {
-          manager.end();
-        })
-        .onFinalize(() => {
           handleDragEnd(key, activationAnimationProgress);
+          manager.end();
         }),
     [
       handleDragEnd,


### PR DESCRIPTION
## Description

For some reason the `onFinalize` method is no longer called on the gesture detector when the manual gesture manager's `end` method is called. I moved the `handleDragEnd` call to the `onTouchesUp` and `onTouchesCancelled` methods to call it directly without relying on the `onFinalize` callback.