### PR TITLE
fix: Invalid item position after release in reduced motion

### DIFF
--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayout.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayout.ts
@@ -174,6 +174,7 @@ export default function useItemLayout(
       progress: activationAnimationProgress.value
     }),
     ({ active, itemPosition, progress }, prev) => {
+      console.log('???', key, active, itemPosition, progress);
       if (!itemPosition || active) {
         interpolationStartValues.value = null;
         return;
@@ -189,7 +190,10 @@ export default function useItemLayout(
         areVectorsDifferent(prev.itemPosition, itemPosition, 1);
 
       if (progress === 0) {
-        if (interpolationStartValues.value) {
+        // interpolationStartValues value is not set when the reduced motion
+        // is enabled as the progress value changes immediately from 1 to 0
+        // and the second if branch below is never entered
+        if (interpolationStartValues.value || prev?.active) {
           interpolationStartValues.value = null;
           position.value = itemPosition;
           return;


### PR DESCRIPTION
## Description

This PR fixes the active iteem getting stuck after being released issue when the reduced motion is enabled.

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/c7ea289b-787e-462c-91e0-8e1fe4640f41" /> | <video src="https://github.com/user-attachments/assets/960487e6-9c2a-4057-8643-510f4f97fffb" /> |
