### PR TITLE
fix: Webpack bundling issue caused by TurboModule import

### DIFF
--- a/packages/react-native-sortables/src/integrations/haptics/adapters/index.native.ts
+++ b/packages/react-native-sortables/src/integrations/haptics/adapters/index.native.ts
@@ -1,0 +1,1 @@
+export { default as ReactNativeHapticFeedback } from './react-native-haptic-feedback';

--- a/packages/react-native-sortables/src/integrations/haptics/adapters/index.ts
+++ b/packages/react-native-sortables/src/integrations/haptics/adapters/index.ts
@@ -1,1 +1,7 @@
-export { default as ReactNativeHapticFeedback } from './react-native-haptic-feedback';
+import type { HapticOptions } from 'react-native-haptic-feedback';
+
+export const ReactNativeHapticFeedback = {
+  load: () => (_type: string, _options?: HapticOptions) => {
+    // noop
+  }
+};


### PR DESCRIPTION
## Description

This PR should fix the bundling issue by adding the `.native.ts` extension to the file that should be bundled only for the native platforms.