### PR TITLE
fix: Support react-native-gesture-handler 3.x types

### DIFF
--- a/packages/react-native-sortables/src/components/shared/DraggableView/ActiveItemPortal.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/ActiveItemPortal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
-import type { ManualGesture } from 'react-native-gesture-handler';
+import type { GestureType } from 'react-native-gesture-handler';
 import { runOnJS, useAnimatedReaction } from 'react-native-reanimated';
 
 import { useStableCallback } from '../../../hooks';
@@ -22,7 +22,9 @@ type ActiveItemPortalProps = Pick<
   'activationAnimationProgress' | 'baseStyle' | 'isActive' | 'itemKey'
 > & {
   commonValuesContext: CommonValuesContextType;
-  gesture: ManualGesture;
+  // gesture-handler 3.x dropped the `ManualGesture` type; `GestureType` works on
+  // both 2.x and 3.x (and matches `ItemContextType.gesture`)
+  gesture: GestureType;
   onTeleport: (isTeleported: boolean) => void;
 };
 

--- a/packages/react-native-sortables/src/components/shared/DraggableView/ActiveItemPortal.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/ActiveItemPortal.tsx
@@ -22,8 +22,6 @@ type ActiveItemPortalProps = Pick<
   'activationAnimationProgress' | 'baseStyle' | 'isActive' | 'itemKey'
 > & {
   commonValuesContext: CommonValuesContextType;
-  // gesture-handler 3.x dropped the `ManualGesture` type; `GestureType` works on
-  // both 2.x and 3.x (and matches `ItemContextType.gesture`)
   gesture: GestureType;
   onTeleport: (isTeleported: boolean) => void;
 };


### PR DESCRIPTION
`ActiveItemPortal`'s `gesture` prop used the `ManualGesture` type, which `react-native-gesture-handler` 3.x no longer exports (it became `LegacyManualGesture`).

Switched it to `GestureType`, which is exported by both 2.x and 3.x and matches the type already used by `ItemContextType.gesture` (where this prop is forwarded). This keeps the library's types resolvable on gesture-handler 2.x **and** 3.x under the existing `>=2.0.0` peer range.

Type-only change — no runtime behavior change.