### PR TITLE
docs: Fix custom handle drag dismissed on web

### DIFF
--- a/packages/docs/src/examples/CustomHandle.tsx
+++ b/packages/docs/src/examples/CustomHandle.tsx
@@ -12,9 +12,6 @@ export default function CustomHandleExample() {
         {/* Wraps the handle component */}
         {/* highlight-next-line */}
         <Sortable.Handle>
-          {/* Disable pointer events so touches reach the drag gesture */}
-          {/* instead of being captured by the handle icon */}
-          {/* highlight-next-line */}
           <View pointerEvents='none' style={styles.handle}>
             <Text style={styles.handleText}>::</Text>
           </View>

--- a/packages/docs/src/examples/CustomHandle.tsx
+++ b/packages/docs/src/examples/CustomHandle.tsx
@@ -12,7 +12,10 @@ export default function CustomHandleExample() {
         {/* Wraps the handle component */}
         {/* highlight-next-line */}
         <Sortable.Handle>
-          <View style={styles.handle}>
+          {/* Disable pointer events so touches reach the drag gesture */}
+          {/* instead of being captured by the handle icon */}
+          {/* highlight-next-line */}
+          <View pointerEvents='none' style={styles.handle}>
             <Text style={styles.handleText}>::</Text>
           </View>
           {/* highlight-next-line */}


### PR DESCRIPTION
On web, a touch on the `::` handle icon was sometimes hijacked by the browser's default `touch-action`, which cancelled the drag before it started. Setting `pointerEvents="none"` on the handle content routes touches to the gesture detector (`touch-action: none`) instead. Purely behavioural — the handle looks the same.
