### PR TITLE
docs: Improve drop indicator and touchable example colors

### DIFF
--- a/packages/docs/src/examples/DropIndicatorCustomStyle.tsx
+++ b/packages/docs/src/examples/DropIndicatorCustomStyle.tsx
@@ -42,10 +42,11 @@ const styles = StyleSheet.create({
     padding: 10
   },
   dropIndicator: {
-    backgroundColor: 'var(--ifm-color-primary-lightest)',
+    backgroundColor: 'transparent',
     borderColor: 'var(--ifm-color-primary)',
+    borderRadius: 10,
     borderStyle: 'solid',
-    borderWidth: 5
+    borderWidth: 4
   },
   text: {
     color: 'white',

--- a/packages/docs/src/examples/DropIndicatorDefault.tsx
+++ b/packages/docs/src/examples/DropIndicatorDefault.tsx
@@ -20,7 +20,6 @@ export default function DropIndicatorDefaultExample() {
         columnGap={10}
         columns={3}
         data={DATA}
-        dropIndicatorStyle={styles.dropIndicator}
         renderItem={renderItem}
         rowGap={10}
         // highlight-next-line
@@ -40,14 +39,6 @@ const styles = StyleSheet.create({
   },
   container: {
     padding: 10
-  },
-  dropIndicator: {
-    backgroundColor: 'var(--ifm-color-emphasis-200)',
-    borderColor: 'var(--ifm-color-emphasis-600)',
-    borderRadius: 10,
-    borderStyle: 'dashed',
-    borderWidth: 2,
-    flex: 1
   },
   text: {
     color: 'white',

--- a/packages/docs/src/examples/DropIndicatorDefault.tsx
+++ b/packages/docs/src/examples/DropIndicatorDefault.tsx
@@ -20,6 +20,7 @@ export default function DropIndicatorDefaultExample() {
         columnGap={10}
         columns={3}
         data={DATA}
+        dropIndicatorStyle={styles.dropIndicator}
         renderItem={renderItem}
         rowGap={10}
         // highlight-next-line
@@ -39,6 +40,14 @@ const styles = StyleSheet.create({
   },
   container: {
     padding: 10
+  },
+  dropIndicator: {
+    backgroundColor: 'var(--ifm-color-emphasis-200)',
+    borderColor: 'var(--ifm-color-emphasis-600)',
+    borderRadius: 10,
+    borderStyle: 'dashed',
+    borderWidth: 2,
+    flex: 1
   },
   text: {
     color: 'white',

--- a/packages/docs/src/examples/Touchable.tsx
+++ b/packages/docs/src/examples/Touchable.tsx
@@ -35,6 +35,7 @@ export default function TouchableExample() {
         data={data}
         renderItem={renderItem}
         rowGap={10}
+        onDragEnd={({ data: newData }) => setData(newData)}
       />
       {data.length === 0 && (
         <View style={styles.emptyContainer}>
@@ -59,7 +60,7 @@ const styles = StyleSheet.create({
     padding: 10
   },
   deleteButton: {
-    backgroundColor: 'var(--ifm-color-primary-light)',
+    backgroundColor: 'rgba(255, 255, 255, 0.3)',
     borderRadius: 10,
     padding: 8
   },


### PR DESCRIPTION
## Summary

Two small Grid example colour fixes (visible on the docs site):

- **Drop indicator (custom-style example)** — `--ifm-color-primary-lightest` was too bright in dark mode; now a transparent fill with a `--ifm-color-primary` border.
- **Touchable** — the delete button blended into the card (`--ifm-color-primary-light`); now translucent white, with reordering persisted via `onDragEnd`.

Verified in light and dark mode.