### PR TITLE
docs: Add Sortable Flex examples

### DIFF
--- a/packages/docs/docs/flex/examples.mdx
+++ b/packages/docs/docs/flex/examples.mdx
@@ -1,9 +1,0 @@
----
-sidebar_position: 3
----
-
-# Examples
-
-Because the **Sortable Flex** component has similar features to the **Sortable Grid** component, the examples would be very similar.
-
-Refer to the [Grid Examples](/grid/examples) section for more information.

--- a/packages/docs/docs/flex/examples/_category_.json
+++ b/packages/docs/docs/flex/examples/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Examples",
+  "position": 3,
+  "link": {
+    "type": "generated-index",
+    "title": "Flex Examples",
+    "slug": "/flex/examples"
+  }
+}

--- a/packages/docs/docs/flex/examples/active-item-portal.mdx
+++ b/packages/docs/docs/flex/examples/active-item-portal.mdx
@@ -1,0 +1,23 @@
+---
+sidebar_position: 8
+description: ''
+---
+
+# Active Item Portal
+
+## Description
+
+This example demonstrates how to use the active item portal to render the active item on top of other components.
+
+In this case, the `PortalProvider` is used to render the active item outside of the `ScrollView` content bounds. This is the only way to render only the active item without cropping it whilst keeping the rest of the flex container within the `ScrollView` content bounds.
+
+## Example
+
+import InteractiveExample from '@site/src/components/InteractiveExample';
+import FlexActiveItemPortalExample from '@site/src/examples/FlexActiveItemPortal';
+import FlexActiveItemPortalCode from '!!raw-loader!@site/src/examples/FlexActiveItemPortal';
+
+<InteractiveExample
+  component={FlexActiveItemPortalExample}
+  code={FlexActiveItemPortalCode}
+/>

--- a/packages/docs/docs/flex/examples/active-item-portal.mdx
+++ b/packages/docs/docs/flex/examples/active-item-portal.mdx
@@ -20,4 +20,5 @@ import FlexActiveItemPortalCode from '!!raw-loader!@site/src/examples/FlexActive
 <InteractiveExample
   component={FlexActiveItemPortalExample}
   code={FlexActiveItemPortalCode}
+  metastring='{33,53}'
 />

--- a/packages/docs/docs/flex/examples/auto-scroll.mdx
+++ b/packages/docs/docs/flex/examples/auto-scroll.mdx
@@ -1,0 +1,21 @@
+---
+sidebar_position: 1
+description: ''
+---
+
+# Auto Scroll
+
+## Description
+
+This example demonstrates how to use the **auto scroll** feature of the **Sortable Flex** component. Pass a `scrollableRef` pointing to the scrollable container and it will scroll automatically while you drag an item near its edges.
+
+## Example
+
+import InteractiveExample from '@site/src/components/InteractiveExample';
+import FlexAutoScrollExample from '@site/src/examples/FlexAutoScroll';
+import FlexAutoScrollCode from '!!raw-loader!@site/src/examples/FlexAutoScroll';
+
+<InteractiveExample
+  component={FlexAutoScrollExample}
+  code={FlexAutoScrollCode}
+/>

--- a/packages/docs/docs/flex/examples/custom-handle.mdx
+++ b/packages/docs/docs/flex/examples/custom-handle.mdx
@@ -1,0 +1,21 @@
+---
+sidebar_position: 6
+description: ''
+---
+
+# Custom Handle
+
+## Description
+
+The **Custom Handle** example demonstrates how to use a custom item drag handle in the **Sortable Flex** component.
+
+## Example
+
+import InteractiveExample from '@site/src/components/InteractiveExample';
+import FlexCustomHandleExample from '@site/src/examples/FlexCustomHandle';
+import FlexCustomHandleCode from '!!raw-loader!@site/src/examples/FlexCustomHandle';
+
+<InteractiveExample
+  component={FlexCustomHandleExample}
+  code={FlexCustomHandleCode}
+/>

--- a/packages/docs/docs/flex/examples/custom-shadow.mdx
+++ b/packages/docs/docs/flex/examples/custom-shadow.mdx
@@ -1,0 +1,23 @@
+---
+sidebar_position: 9
+description: ''
+---
+
+# Custom Shadow
+
+## Description
+
+This example demonstrates how to create a **custom shadow** for the active item during drag. By disabling the default shadow with `activeItemShadowOpacity={0}` and using the [useItemContext](/hooks/useItemContext) hook, you can animate the `box-shadow` property of the item based on the activation animation progress.
+
+This is particularly useful when you want to add shadows on **Android**, where shadows are not supported by default and must be implemented by the user.
+
+## Example
+
+import InteractiveExample from '@site/src/components/InteractiveExample';
+import FlexCustomShadowExample from '@site/src/examples/FlexCustomShadow';
+import FlexCustomShadowCode from '!!raw-loader!@site/src/examples/FlexCustomShadow';
+
+<InteractiveExample
+  component={FlexCustomShadowExample}
+  code={FlexCustomShadowCode}
+/>

--- a/packages/docs/docs/flex/examples/different-item-sizes.mdx
+++ b/packages/docs/docs/flex/examples/different-item-sizes.mdx
@@ -1,0 +1,21 @@
+---
+sidebar_position: 4
+description: ''
+---
+
+# Different Item Sizes
+
+## Description
+
+This example shows that the **Sortable Flex** component can handle **items of different sizes** without any issues. Items flow and wrap naturally based on their content.
+
+## Example
+
+import InteractiveExample from '@site/src/components/InteractiveExample';
+import FlexDifferentSizesExample from '@site/src/examples/FlexDifferentSizes';
+import FlexDifferentSizesCode from '!!raw-loader!@site/src/examples/FlexDifferentSizes';
+
+<InteractiveExample
+  component={FlexDifferentSizesExample}
+  code={FlexDifferentSizesCode}
+/>

--- a/packages/docs/docs/flex/examples/drop-indicator.mdx
+++ b/packages/docs/docs/flex/examples/drop-indicator.mdx
@@ -1,0 +1,41 @@
+---
+sidebar_position: 2
+description: ''
+---
+
+# Drop Indicator
+
+## Description
+
+The drop indicator is a **visual indicator** that shows the **position where the item will be dropped** when the user releases the item.
+
+## Default
+
+import InteractiveExample from '@site/src/components/InteractiveExample';
+import FlexDropIndicatorDefaultExample from '@site/src/examples/FlexDropIndicatorDefault';
+import FlexDropIndicatorDefaultCode from '!!raw-loader!@site/src/examples/FlexDropIndicatorDefault';
+
+<InteractiveExample
+  component={FlexDropIndicatorDefaultExample}
+  code={FlexDropIndicatorDefaultCode}
+/>
+
+## Custom Style
+
+import FlexDropIndicatorCustomStyleExample from '@site/src/examples/FlexDropIndicatorCustomStyle';
+import FlexDropIndicatorCustomStyleCode from '!!raw-loader!@site/src/examples/FlexDropIndicatorCustomStyle';
+
+<InteractiveExample
+  component={FlexDropIndicatorCustomStyleExample}
+  code={FlexDropIndicatorCustomStyleCode}
+/>
+
+## Custom Component
+
+import FlexDropIndicatorCustomComponentExample from '@site/src/examples/FlexDropIndicatorCustomComponent';
+import FlexDropIndicatorCustomComponentCode from '!!raw-loader!@site/src/examples/FlexDropIndicatorCustomComponent';
+
+<InteractiveExample
+  component={FlexDropIndicatorCustomComponentExample}
+  code={FlexDropIndicatorCustomComponentCode}
+/>

--- a/packages/docs/docs/flex/examples/fixed-items.mdx
+++ b/packages/docs/docs/flex/examples/fixed-items.mdx
@@ -1,0 +1,23 @@
+---
+sidebar_position: 7
+description: ''
+---
+
+# Fixed Items
+
+## Description
+
+The fixed items example demonstrates how to create a **Sortable Flex** with items which have a **fixed position**.
+
+In the example below, the **first**, the **last** and an **item in the middle** are fixed (grayed out) and stay in the same ordinal position.
+
+## Example
+
+import InteractiveExample from '@site/src/components/InteractiveExample';
+import FlexFixedItemsExample from '@site/src/examples/FlexFixedItems';
+import FlexFixedItemsCode from '!!raw-loader!@site/src/examples/FlexFixedItems';
+
+<InteractiveExample
+  component={FlexFixedItemsExample}
+  code={FlexFixedItemsCode}
+/>

--- a/packages/docs/docs/flex/examples/item-snap.mdx
+++ b/packages/docs/docs/flex/examples/item-snap.mdx
@@ -1,0 +1,18 @@
+---
+sidebar_position: 3
+description: ''
+---
+
+# Item snap
+
+## Description
+
+The item snap is a **transformation of the item** that happens when the user **presses the item** (before the drag starts). It **transforms** the item **in relation to the touch position**.
+
+## Example
+
+import InteractiveExample from '@site/src/components/InteractiveExample';
+import FlexItemSnapExample from '@site/src/examples/FlexItemSnap';
+import FlexItemSnapCode from '!!raw-loader!@site/src/examples/FlexItemSnap';
+
+<InteractiveExample component={FlexItemSnapExample} code={FlexItemSnapCode} />

--- a/packages/docs/docs/flex/examples/touchable.mdx
+++ b/packages/docs/docs/flex/examples/touchable.mdx
@@ -1,0 +1,20 @@
+---
+sidebar_position: 5
+description: ''
+---
+
+# Touchable
+
+## Description
+
+This example shows why the [Sortable.Touchable](/helper-components/touchable) component is useful when you need to **properly detect press events** on **components nested inside** the sortable component item (more precisely, nested within the part of the item that detects the drag gesture - this might be the entire item or just a part of it if the custom handle, like [Sortable.Handle](/helper-components/handle), is used).
+
+In this **Sortable Flex** example, each item has a delete button that removes it only when **pressed, not when the item is dragged**.
+
+## Example
+
+import InteractiveExample from '@site/src/components/InteractiveExample';
+import FlexTouchableExample from '@site/src/examples/FlexTouchable';
+import FlexTouchableCode from '!!raw-loader!@site/src/examples/FlexTouchable';
+
+<InteractiveExample component={FlexTouchableExample} code={FlexTouchableCode} />

--- a/packages/docs/src/examples/CustomHandle.tsx
+++ b/packages/docs/src/examples/CustomHandle.tsx
@@ -28,6 +28,7 @@ export default function CustomHandleExample() {
         activeItemScale={1.05}
         columns={1}
         data={DATA}
+        dragActivationDelay={0}
         overDrag='vertical'
         renderItem={renderItem}
         rowGap={10}

--- a/packages/docs/src/examples/FlexActiveItemPortal.tsx
+++ b/packages/docs/src/examples/FlexActiveItemPortal.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import Animated, { useAnimatedRef } from 'react-native-reanimated';
+import Sortable from 'react-native-sortables';
+
+const DATA = [
+  'Poland',
+  'Germany',
+  'France',
+  'Italy',
+  'Spain',
+  'Portugal',
+  'Greece',
+  'Great Britain',
+  'United States',
+  'Canada',
+  'Australia',
+  'New Zealand',
+  'Brazil',
+  'Argentina',
+  'Mexico',
+  'Japan',
+  'China',
+  'India'
+];
+
+export default function FlexActiveItemPortalExample() {
+  const [portalEnabled, setPortalEnabled] = useState(false);
+  const scrollableRef = useAnimatedRef<Animated.ScrollView>();
+
+  return (
+    <View style={styles.container}>
+      <Sortable.PortalProvider enabled={portalEnabled}>
+        <View style={styles.flexContainer}>
+          <Animated.ScrollView
+            contentContainerStyle={styles.contentContainer}
+            ref={scrollableRef}>
+            <Sortable.Flex gap={10} scrollableRef={scrollableRef}>
+              {DATA.map(item => (
+                <View key={item} style={styles.cell}>
+                  <Text numberOfLines={1} style={styles.text}>
+                    {item}
+                  </Text>
+                </View>
+              ))}
+            </Sortable.Flex>
+          </Animated.ScrollView>
+        </View>
+        <Pressable onPress={() => setPortalEnabled(prev => !prev)}>
+          <Text
+            style={
+              styles.buttonText
+            }>{`${portalEnabled ? 'Disable' : 'Enable'} Portal`}</Text>
+        </Pressable>
+      </Sortable.PortalProvider>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  buttonText: {
+    color: 'var(--ifm-color-primary)',
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginTop: 15
+  },
+  cell: {
+    alignItems: 'center',
+    backgroundColor: 'var(--ifm-color-primary)',
+    borderRadius: 9999,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12
+  },
+  container: {
+    alignItems: 'center',
+    backgroundColor: 'var(--ifm-color-emphasis-100)',
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20
+  },
+  contentContainer: {
+    padding: 10
+  },
+  flexContainer: {
+    backgroundColor: 'var(--ifm-background-surface-color)',
+    borderRadius: 10,
+    height: 400,
+    overflow: 'hidden',
+    width: '100%'
+  },
+  text: {
+    color: 'white',
+    fontWeight: 'bold'
+  }
+});

--- a/packages/docs/src/examples/FlexAutoScroll.tsx
+++ b/packages/docs/src/examples/FlexAutoScroll.tsx
@@ -1,0 +1,82 @@
+import { StyleSheet, Text, View } from 'react-native';
+import Animated, { useAnimatedRef } from 'react-native-reanimated';
+import Sortable from 'react-native-sortables';
+
+const DATA = [
+  'Poland',
+  'Germany',
+  'France',
+  'Italy',
+  'Spain',
+  'Portugal',
+  'Greece',
+  'Great Britain',
+  'United States',
+  'Canada',
+  'Australia',
+  'New Zealand',
+  'Brazil',
+  'Argentina',
+  'Mexico',
+  'Japan',
+  'China',
+  'India',
+  'Norway',
+  'Sweden',
+  'Finland',
+  'Denmark',
+  'Ireland',
+  'Belgium',
+  'Austria',
+  'Switzerland',
+  'Croatia',
+  'Serbia',
+  'Turkey',
+  'Egypt'
+];
+
+export default function FlexAutoScrollExample() {
+  const scrollableRef = useAnimatedRef<Animated.ScrollView>();
+
+  return (
+    <Animated.ScrollView
+      contentContainerStyle={styles.contentContainer}
+      ref={scrollableRef}
+      style={styles.scrollView}>
+      <Sortable.Flex
+        gap={10}
+        // highlight-next-line
+        scrollableRef={scrollableRef} // required for auto scroll
+      >
+        {DATA.map(item => (
+          <View key={item} style={styles.cell}>
+            <Text numberOfLines={1} style={styles.text}>
+              {item}
+            </Text>
+          </View>
+        ))}
+      </Sortable.Flex>
+    </Animated.ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  cell: {
+    alignItems: 'center',
+    backgroundColor: 'var(--ifm-color-primary)',
+    borderRadius: 9999,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12
+  },
+  contentContainer: {
+    padding: 10
+  },
+  scrollView: {
+    height: 400 // Limit height to enable scrolling in demo
+  },
+  text: {
+    color: 'white',
+    fontWeight: 'bold'
+  }
+});

--- a/packages/docs/src/examples/FlexCustomHandle.tsx
+++ b/packages/docs/src/examples/FlexCustomHandle.tsx
@@ -1,0 +1,72 @@
+import { StyleSheet, Text, View } from 'react-native';
+import Sortable from 'react-native-sortables';
+
+const DATA = [
+  'Poland',
+  'Germany',
+  'France',
+  'Italy',
+  'Spain',
+  'Portugal',
+  'Greece',
+  'Canada'
+];
+
+export default function FlexCustomHandleExample() {
+  return (
+    <View style={styles.container}>
+      <Sortable.Flex
+        gap={10}
+        // highlight-next-line
+        customHandle // must be set to use a custom handle
+      >
+        {DATA.map(item => (
+          <View key={item} style={styles.card}>
+            <Text numberOfLines={1} style={styles.text}>
+              {item}
+            </Text>
+            {/* Wraps the handle component */}
+            {/* highlight-next-line */}
+            <Sortable.Handle>
+              <View pointerEvents='none' style={styles.handle}>
+                <Text style={styles.handleText}>⋮⋮</Text>
+              </View>
+              {/* highlight-next-line */}
+            </Sortable.Handle>
+          </View>
+        ))}
+      </Sortable.Flex>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    alignItems: 'center',
+    backgroundColor: 'var(--ifm-color-primary)',
+    borderRadius: 9999,
+    flexDirection: 'row',
+    gap: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 12
+  },
+  container: {
+    padding: 10
+  },
+  handle: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.2)',
+    borderRadius: 5,
+    height: 24,
+    justifyContent: 'center',
+    width: 22
+  },
+  handleText: {
+    color: 'white',
+    fontWeight: 'bold'
+  },
+  text: {
+    color: 'white',
+    fontWeight: 'bold'
+  }
+});

--- a/packages/docs/src/examples/FlexCustomHandle.tsx
+++ b/packages/docs/src/examples/FlexCustomHandle.tsx
@@ -16,6 +16,7 @@ export default function FlexCustomHandleExample() {
   return (
     <View style={styles.container}>
       <Sortable.Flex
+        dragActivationDelay={0}
         gap={10}
         // highlight-next-line
         customHandle // must be set to use a custom handle

--- a/packages/docs/src/examples/FlexCustomShadow.tsx
+++ b/packages/docs/src/examples/FlexCustomShadow.tsx
@@ -1,0 +1,79 @@
+import { memo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  interpolateColor,
+  useAnimatedStyle
+} from 'react-native-reanimated';
+import Sortable, { useItemContext } from 'react-native-sortables';
+
+const DATA = [
+  'Poland',
+  'Germany',
+  'France',
+  'Italy',
+  'Spain',
+  'Portugal',
+  'Greece',
+  'Great Britain',
+  'United States',
+  'Canada',
+  'Australia',
+  'New Zealand'
+];
+
+export default function FlexCustomShadowExample() {
+  return (
+    <View style={styles.container}>
+      <Sortable.Flex
+        // Disable default shadow as we will apply our
+        // box-shadow in the item component
+        activeItemShadowOpacity={0}
+        gap={10}>
+        {DATA.map(item => (
+          <FlexItem item={item} key={item} />
+        ))}
+      </Sortable.Flex>
+    </View>
+  );
+}
+
+const FlexItem = memo(function FlexItem({ item }: { item: string }) {
+  const { activationAnimationProgress } = useItemContext();
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const color = interpolateColor(
+      activationAnimationProgress.value,
+      [0, 1],
+      ['transparent', '#1a433f']
+    );
+    return {
+      boxShadow: `0 5px 10px ${color}`
+    };
+  });
+
+  return (
+    <Animated.View style={[styles.cell, animatedStyle]}>
+      <Text numberOfLines={1} style={styles.text}>
+        {item}
+      </Text>
+    </Animated.View>
+  );
+});
+
+const styles = StyleSheet.create({
+  cell: {
+    alignItems: 'center',
+    backgroundColor: 'var(--ifm-color-primary)',
+    borderRadius: 9999,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12
+  },
+  container: {
+    padding: 16
+  },
+  text: {
+    color: 'white',
+    fontWeight: 'bold'
+  }
+});

--- a/packages/docs/src/examples/FlexDifferentSizes.tsx
+++ b/packages/docs/src/examples/FlexDifferentSizes.tsx
@@ -1,0 +1,51 @@
+import { StyleSheet, Text, View } from 'react-native';
+import Sortable from 'react-native-sortables';
+
+const DATA = [
+  { label: 'Poland', size: 14 },
+  { label: 'Germany', size: 22 },
+  { label: 'France', size: 16 },
+  { label: 'Italy', size: 28 },
+  { label: 'Spain', size: 14 },
+  { label: 'Portugal', size: 20 },
+  { label: 'Greece', size: 18 },
+  { label: 'Great Britain', size: 14 },
+  { label: 'United States', size: 24 },
+  { label: 'Canada', size: 16 },
+  { label: 'Australia', size: 20 },
+  { label: 'New Zealand', size: 14 }
+];
+
+export default function FlexDifferentSizesExample() {
+  return (
+    <View style={styles.container}>
+      <Sortable.Flex alignItems='center' gap={10}>
+        {DATA.map(({ label, size }) => (
+          <View key={label} style={styles.cell}>
+            <Text numberOfLines={1} style={[styles.text, { fontSize: size }]}>
+              {label}
+            </Text>
+          </View>
+        ))}
+      </Sortable.Flex>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  cell: {
+    alignItems: 'center',
+    backgroundColor: 'var(--ifm-color-primary)',
+    borderRadius: 9999,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12
+  },
+  container: {
+    padding: 10
+  },
+  text: {
+    color: 'white',
+    fontWeight: 'bold'
+  }
+});

--- a/packages/docs/src/examples/FlexDropIndicatorCustomComponent.tsx
+++ b/packages/docs/src/examples/FlexDropIndicatorCustomComponent.tsx
@@ -1,0 +1,123 @@
+import { StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  interpolateColor,
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  withSequence,
+  withSpring,
+  withTiming
+} from 'react-native-reanimated';
+import type { DropIndicatorComponentProps } from 'react-native-sortables';
+import Sortable from 'react-native-sortables';
+
+const DATA = [
+  'Poland',
+  'Germany',
+  'France',
+  'Italy',
+  'Spain',
+  'Portugal',
+  'Greece',
+  'Great Britain',
+  'United States',
+  'Canada',
+  'Australia',
+  'New Zealand'
+];
+
+function DropIndicator({
+  activeAnimationProgress,
+  activeItemKey,
+  dropIndex,
+  orderedItemKeys,
+  style
+}: DropIndicatorComponentProps) {
+  const itemsCount = useDerivedValue(() => orderedItemKeys.value.length);
+  const indexes = useDerivedValue(() =>
+    Array.from({ length: itemsCount.value }, (_, i) => i)
+  );
+  const colors = useDerivedValue(() =>
+    Array.from({ length: itemsCount.value }, (_, i) => {
+      const hue = (360 / itemsCount.value) * i;
+      return `hsl(${hue}, 100%, 50%)`;
+    })
+  );
+
+  const scale = useSharedValue(0);
+  const colorIndex = useSharedValue(0);
+  const showIndicator = useDerivedValue(
+    () => activeAnimationProgress.value > 0.2 && activeItemKey.value !== null
+  );
+
+  useAnimatedReaction(
+    () => ({
+      count: itemsCount.value,
+      index: dropIndex.value,
+      show: showIndicator.value
+    }),
+    ({ count, index, show }, prev) => {
+      if (show !== prev?.show) {
+        scale.value = withSpring(+show);
+      } else if (show && index !== prev?.index) {
+        colorIndex.value = withTiming(index % count);
+        scale.value = withSequence(
+          withTiming(0.75, { duration: 100 }),
+          withSpring(1)
+        );
+      }
+    }
+  );
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    backgroundColor: interpolateColor(
+      colorIndex.value,
+      indexes.value,
+      colors.value
+    ),
+    transform: [{ scale: scale.value }]
+  }));
+
+  return (
+    <Animated.View style={[style, styles.customIndicator, animatedStyle]} />
+  );
+}
+
+export default function FlexDropIndicatorCustomComponentExample() {
+  return (
+    <View style={styles.container}>
+      <Sortable.Flex
+        DropIndicatorComponent={DropIndicator}
+        gap={10}
+        showDropIndicator>
+        {DATA.map(item => (
+          <View key={item} style={styles.cell}>
+            <Text numberOfLines={1} style={styles.text}>
+              {item}
+            </Text>
+          </View>
+        ))}
+      </Sortable.Flex>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  cell: {
+    alignItems: 'center',
+    backgroundColor: 'var(--ifm-color-primary)',
+    borderRadius: 9999,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12
+  },
+  container: {
+    padding: 10
+  },
+  customIndicator: { borderRadius: 9999, borderStyle: 'solid' },
+  text: {
+    color: 'white',
+    fontWeight: 'bold'
+  }
+});

--- a/packages/docs/src/examples/FlexDropIndicatorCustomStyle.tsx
+++ b/packages/docs/src/examples/FlexDropIndicatorCustomStyle.tsx
@@ -1,0 +1,61 @@
+import { StyleSheet, Text, View } from 'react-native';
+import Sortable from 'react-native-sortables';
+
+const DATA = [
+  'Poland',
+  'Germany',
+  'France',
+  'Italy',
+  'Spain',
+  'Portugal',
+  'Greece',
+  'Great Britain',
+  'United States',
+  'Canada',
+  'Australia',
+  'New Zealand'
+];
+
+export default function FlexDropIndicatorCustomStyleExample() {
+  return (
+    <View style={styles.container}>
+      <Sortable.Flex
+        dropIndicatorStyle={styles.dropIndicator} // Custom style
+        gap={10}
+        showDropIndicator>
+        {DATA.map(item => (
+          <View key={item} style={styles.cell}>
+            <Text numberOfLines={1} style={styles.text}>
+              {item}
+            </Text>
+          </View>
+        ))}
+      </Sortable.Flex>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  cell: {
+    alignItems: 'center',
+    backgroundColor: 'var(--ifm-color-primary)',
+    borderRadius: 9999,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12
+  },
+  container: {
+    padding: 10
+  },
+  dropIndicator: {
+    backgroundColor: 'transparent',
+    borderColor: 'var(--ifm-color-primary)',
+    borderRadius: 9999,
+    borderStyle: 'solid',
+    borderWidth: 4
+  },
+  text: {
+    color: 'white',
+    fontWeight: 'bold'
+  }
+});

--- a/packages/docs/src/examples/FlexDropIndicatorDefault.tsx
+++ b/packages/docs/src/examples/FlexDropIndicatorDefault.tsx
@@ -1,0 +1,63 @@
+import { StyleSheet, Text, View } from 'react-native';
+import Sortable from 'react-native-sortables';
+
+const DATA = [
+  'Poland',
+  'Germany',
+  'France',
+  'Italy',
+  'Spain',
+  'Portugal',
+  'Greece',
+  'Great Britain',
+  'United States',
+  'Canada',
+  'Australia',
+  'New Zealand'
+];
+
+export default function FlexDropIndicatorDefaultExample() {
+  return (
+    <View style={styles.container}>
+      <Sortable.Flex
+        dropIndicatorStyle={styles.dropIndicator}
+        gap={10}
+        // highlight-next-line
+        showDropIndicator>
+        {DATA.map(item => (
+          <View key={item} style={styles.cell}>
+            <Text numberOfLines={1} style={styles.text}>
+              {item}
+            </Text>
+          </View>
+        ))}
+      </Sortable.Flex>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  cell: {
+    alignItems: 'center',
+    backgroundColor: 'var(--ifm-color-primary)',
+    borderRadius: 9999,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12
+  },
+  container: {
+    padding: 10
+  },
+  dropIndicator: {
+    backgroundColor: 'var(--ifm-color-emphasis-200)',
+    borderColor: 'var(--ifm-color-emphasis-600)',
+    borderRadius: 9999,
+    borderStyle: 'dashed',
+    borderWidth: 2,
+    flex: 1
+  },
+  text: {
+    color: 'white',
+    fontWeight: 'bold'
+  }
+});

--- a/packages/docs/src/examples/FlexDropIndicatorDefault.tsx
+++ b/packages/docs/src/examples/FlexDropIndicatorDefault.tsx
@@ -20,7 +20,6 @@ export default function FlexDropIndicatorDefaultExample() {
   return (
     <View style={styles.container}>
       <Sortable.Flex
-        dropIndicatorStyle={styles.dropIndicator}
         gap={10}
         // highlight-next-line
         showDropIndicator>
@@ -47,14 +46,6 @@ const styles = StyleSheet.create({
   },
   container: {
     padding: 10
-  },
-  dropIndicator: {
-    backgroundColor: 'var(--ifm-color-emphasis-200)',
-    borderColor: 'var(--ifm-color-emphasis-600)',
-    borderRadius: 9999,
-    borderStyle: 'dashed',
-    borderWidth: 2,
-    flex: 1
   },
   text: {
     color: 'white',

--- a/packages/docs/src/examples/FlexFixedItems.tsx
+++ b/packages/docs/src/examples/FlexFixedItems.tsx
@@ -1,0 +1,68 @@
+import { useCallback } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Sortable from 'react-native-sortables';
+
+const DATA = [
+  'Poland',
+  'Germany',
+  'France',
+  'Italy',
+  'Spain',
+  'Portugal',
+  'Greece',
+  'Great Britain',
+  'United States',
+  'Canada',
+  'Australia',
+  'New Zealand'
+];
+const FIXED_ITEMS = new Set([DATA[0], DATA[7], DATA[11]]);
+
+export default function FlexFixedItemsExample() {
+  const renderItem = useCallback((item: string) => {
+    const isFixed = FIXED_ITEMS.has(item);
+
+    return (
+      <Sortable.Handle key={item} mode={isFixed ? 'fixed-order' : 'draggable'}>
+        <View
+          style={[
+            styles.card,
+            {
+              backgroundColor: isFixed
+                ? 'var(--ifm-color-emphasis-400)'
+                : 'var(--ifm-color-primary)'
+            }
+          ]}>
+          <Text numberOfLines={1} style={styles.text}>
+            {item}
+          </Text>
+        </View>
+      </Sortable.Handle>
+    );
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Sortable.Flex gap={10} customHandle>
+        {DATA.map(renderItem)}
+      </Sortable.Flex>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    alignItems: 'center',
+    borderRadius: 9999,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12
+  },
+  container: {
+    padding: 10
+  },
+  text: {
+    color: 'white',
+    fontWeight: 'bold'
+  }
+});

--- a/packages/docs/src/examples/FlexItemSnap.tsx
+++ b/packages/docs/src/examples/FlexItemSnap.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { StyleSheet, Switch, Text, View } from 'react-native';
+import Sortable from 'react-native-sortables';
+
+const DATA = [
+  'Poland',
+  'Germany',
+  'France',
+  'Italy',
+  'Spain',
+  'Portugal',
+  'Greece',
+  'Canada'
+];
+
+export default function FlexItemSnapExample() {
+  const [snapEnabled, setSnapEnabled] = useState(true);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.controls}>
+        <Text style={styles.label}>Enable Snap</Text>
+        <Switch
+          thumbColor='#f4f3f4'
+          value={snapEnabled}
+          trackColor={{
+            false: 'var(--ifm-color-emphasis-400)',
+            true: 'var(--ifm-color-primary)'
+          }}
+          onValueChange={setSnapEnabled}
+        />
+      </View>
+      <Sortable.Flex
+        enableActiveItemSnap={snapEnabled}
+        gap={10}
+        snapOffsetX='50%'
+        snapOffsetY='50%'>
+        {DATA.map(item => (
+          <View key={item} style={styles.cell}>
+            <Text numberOfLines={1} style={styles.text}>
+              {item}
+            </Text>
+          </View>
+        ))}
+      </Sortable.Flex>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  cell: {
+    alignItems: 'center',
+    backgroundColor: 'var(--ifm-color-primary)',
+    borderRadius: 9999,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12
+  },
+  container: {
+    flex: 1,
+    padding: 10
+  },
+  controls: {
+    alignItems: 'center',
+    backgroundColor: 'var(--ifm-color-emphasis-100)',
+    borderRadius: 8,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 20,
+    padding: 10
+  },
+  label: {
+    color: 'var(--ifm-color-content)',
+    fontSize: 16,
+    fontWeight: '600'
+  },
+  text: {
+    color: 'white',
+    fontWeight: 'bold'
+  }
+});

--- a/packages/docs/src/examples/FlexTouchable.tsx
+++ b/packages/docs/src/examples/FlexTouchable.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Sortable from 'react-native-sortables';
+
+const INITIAL_DATA = [
+  'Poland',
+  'Germany',
+  'France',
+  'Italy',
+  'Spain',
+  'Portugal',
+  'Greece',
+  'Canada'
+];
+
+export default function FlexTouchableExample() {
+  const [data, setData] = useState(INITIAL_DATA);
+
+  return (
+    <View style={styles.container}>
+      <Sortable.Flex
+        gap={10}
+        // highlight-next-line
+        onDragEnd={({ order }) => setData(order(data))}>
+        {data.map(item => (
+          <View key={item} style={styles.card}>
+            <Text numberOfLines={1} style={styles.text}>
+              {item}
+            </Text>
+            {/* highlight-next-line */}
+            <Sortable.Touchable
+              style={styles.deleteButton}
+              // highlight-next-line
+              onTap={() => setData(prev => prev.filter(i => i !== item))}>
+              <Text style={styles.text}>✕</Text>
+              {/* highlight-next-line */}
+            </Sortable.Touchable>
+          </View>
+        ))}
+      </Sortable.Flex>
+      {data.length === 0 && (
+        <View style={styles.emptyContainer}>
+          <Text style={styles.emptyText}>All items deleted!</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    alignItems: 'center',
+    backgroundColor: 'var(--ifm-color-primary)',
+    borderRadius: 9999,
+    flexDirection: 'row',
+    gap: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 12
+  },
+  container: {
+    flex: 1,
+    padding: 10
+  },
+  deleteButton: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(255, 255, 255, 0.3)',
+    borderRadius: 9999,
+    height: 22,
+    justifyContent: 'center',
+    width: 22
+  },
+  emptyContainer: {
+    alignItems: 'center',
+    padding: 20
+  },
+  emptyText: {
+    color: 'var(--ifm-color-emphasis-600)',
+    fontSize: 16,
+    fontStyle: 'italic'
+  },
+  text: {
+    color: 'white',
+    fontWeight: 'bold'
+  }
+});


### PR DESCRIPTION
## Summary

Adds a **Flex examples** section to the docs, mirroring the existing Grid examples. Previously `flex/examples.mdx` just pointed users to the Grid examples; it is now a `flex/examples/` folder (analogous to `grid/examples/`) with interactive examples:

- Auto Scroll
- Drop Indicator (default, custom style, custom component)
- Item snap
- Different Item Sizes
- Touchable
- Custom Handle
- Fixed Items
- Active Item Portal
- Custom Shadow

Each example is implemented with `Sortable.Flex` (the children-based API) using wrapping pill items. The drop-indicator examples use theme-aware colours (visible in light and dark mode) and the custom-handle example disables pointer events on the handle icon — consistent with the equivalent Grid examples.

There are no result videos yet (the Grid examples have them); the interactive demos serve as the result.

## Testing

- `yarn build` (Docusaurus production build) passes.
- `prettier --check`, `eslint`, and `tsc` pass on all new files.
- Verified every example renders in the local docs in light and dark mode: pills wrap correctly; handles, delete buttons, fixed (grayed) items, the snap switch and the scroll container all render; and the custom-shadow items receive the animated box-shadow.
