### PR TITLE
docs: Add interactive custom shadow example to grid

### DIFF
--- a/packages/docs/docs/grid/examples/custom-shadow.mdx
+++ b/packages/docs/docs/grid/examples/custom-shadow.mdx
@@ -11,80 +11,16 @@ This example demonstrates how to create a **custom shadow** for the active item 
 
 This is particularly useful when you want to add shadows on **Android**, where shadows are not supported by default and must be implemented by the user.
 
-## Source Code
+## Example
 
-```tsx
-import { memo, useCallback } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-import Animated, {
-  interpolateColor,
-  useAnimatedStyle
-} from 'react-native-reanimated';
-import type { SortableGridRenderItem } from 'react-native-sortables';
-import Sortable, { useItemContext } from 'react-native-sortables';
+import InteractiveExample from '@site/src/components/InteractiveExample';
+import GridCustomShadowExample from '@site/src/examples/GridCustomShadow';
+import GridCustomShadowCode from '!!raw-loader!@site/src/examples/GridCustomShadow';
 
-const DATA = Array.from({ length: 12 }, (_, index) => `Item ${index + 1}`);
-
-export default function Example() {
-  const renderItem = useCallback<SortableGridRenderItem<string>>(
-    ({ item }) => <GridItem item={item} />,
-    []
-  );
-
-  return (
-    <View style={styles.container}>
-      <Sortable.Grid
-        // Disable default shadow as we will apply our
-        // box-shadow in the item component
-        activeItemShadowOpacity={0}
-        columnGap={10}
-        columns={3}
-        data={DATA}
-        renderItem={renderItem}
-        rowGap={10}
-      />
-    </View>
-  );
-}
-
-const GridItem = memo(function GridItem({ item }: { item: string }) {
-  const { activationAnimationProgress } = useItemContext();
-
-  const animatedStyle = useAnimatedStyle(() => {
-    const color = interpolateColor(
-      activationAnimationProgress.value,
-      [0, 1],
-      ['transparent', '#1a433f']
-    );
-    return {
-      boxShadow: `0 5px 10px ${color}`
-    };
-  });
-
-  return (
-    <Animated.View style={[styles.card, animatedStyle]}>
-      <Text style={styles.text}>{item}</Text>
-    </Animated.View>
-  );
-});
-
-const styles = StyleSheet.create({
-  card: {
-    alignItems: 'center',
-    backgroundColor: '#36877F',
-    borderRadius: 10,
-    height: 100,
-    justifyContent: 'center'
-  },
-  container: {
-    padding: 16
-  },
-  text: {
-    color: 'white',
-    fontWeight: 'bold'
-  }
-});
-```
+<InteractiveExample
+  component={GridCustomShadowExample}
+  code={GridCustomShadowCode}
+/>
 
 ## Result
 

--- a/packages/docs/src/examples/GridCustomShadow.tsx
+++ b/packages/docs/src/examples/GridCustomShadow.tsx
@@ -1,0 +1,70 @@
+import { memo, useCallback } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  interpolateColor,
+  useAnimatedStyle
+} from 'react-native-reanimated';
+import type { SortableGridRenderItem } from 'react-native-sortables';
+import Sortable, { useItemContext } from 'react-native-sortables';
+
+const DATA = Array.from({ length: 12 }, (_, index) => `Item ${index + 1}`);
+
+export default function GridCustomShadowExample() {
+  const renderItem = useCallback<SortableGridRenderItem<string>>(
+    ({ item }) => <GridItem item={item} />,
+    []
+  );
+
+  return (
+    <View style={styles.container}>
+      <Sortable.Grid
+        // Disable the default shadow as we apply our own box-shadow
+        // in the item component
+        activeItemShadowOpacity={0}
+        columnGap={10}
+        columns={3}
+        data={DATA}
+        renderItem={renderItem}
+        rowGap={10}
+      />
+    </View>
+  );
+}
+
+const GridItem = memo(function GridItem({ item }: { item: string }) {
+  const { activationAnimationProgress } = useItemContext();
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const color = interpolateColor(
+      activationAnimationProgress.value,
+      [0, 1],
+      ['transparent', '#1a433f']
+    );
+    return {
+      boxShadow: `0 5px 10px ${color}`
+    };
+  });
+
+  return (
+    <Animated.View style={[styles.card, animatedStyle]}>
+      <Text style={styles.text}>{item}</Text>
+    </Animated.View>
+  );
+});
+
+const styles = StyleSheet.create({
+  card: {
+    alignItems: 'center',
+    backgroundColor: 'var(--ifm-color-primary)',
+    borderRadius: 10,
+    height: 100,
+    justifyContent: 'center'
+  },
+  container: {
+    padding: 16
+  },
+  text: {
+    color: 'white',
+    fontWeight: 'bold'
+  }
+});


### PR DESCRIPTION
## Summary

The [grid Custom Shadow example](https://react-native-sortables-docs.vercel.app/grid/examples/custom-shadow) only had a static code block, while the other grid examples (and the new Flex examples) have an interactive demo. This adds a live `InteractiveExample` for it so the custom shadow can be tried directly in the browser. The existing Android/iOS result videos are kept.

The example component (`GridCustomShadow.tsx`) is the same code that was previously inlined, with the card colour switched to `var(--ifm-color-primary)` for theme consistency with the other examples.

## Testing

Ran the docs locally — the page now renders the interactive demo (12 cards, each with the animated `box-shadow`) plus the source-code panel. `prettier --check`, `eslint` and `tsc` pass.
