### PR TITLE
fix: Item position drift on slow web container resize

### DIFF
--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayout.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayout.ts
@@ -170,23 +170,19 @@ export default function useItemLayout(
   useAnimatedReaction(
     () => ({
       active: isActive.value,
-      itemPosition: layoutPosition.value,
+      layoutPos: layoutPosition.value,
       progress: activationAnimationProgress.value
     }),
-    ({ active, itemPosition, progress }, prev) => {
-      if (!itemPosition || active) {
+    ({ active, layoutPos, progress }, prev) => {
+      if (!layoutPos || active) {
         interpolationStartValues.value = null;
         return;
       }
 
       if (!position.value) {
-        position.value = itemPosition;
+        position.value = layoutPos;
         return;
       }
-
-      const positionChanged =
-        prev?.itemPosition &&
-        areVectorsDifferent(prev.itemPosition, itemPosition, 1);
 
       if (progress === 0) {
         // interpolationStartValues value is not set when the reduced motion
@@ -194,14 +190,16 @@ export default function useItemLayout(
         // and the second if branch below is never entered
         if (interpolationStartValues.value || prev?.active) {
           interpolationStartValues.value = null;
-          position.value = itemPosition;
+          position.value = layoutPos;
           return;
         }
       }
       // Set dropStartValues only if the item was previously active or if is
       // already during the drop animation and the target position changed
       else if (
-        interpolationStartValues.value ? positionChanged : prev?.active
+        interpolationStartValues.value
+          ? prev?.layoutPos && areVectorsDifferent(prev.layoutPos, layoutPos, 1)
+          : prev?.active
       ) {
         interpolationStartValues.value = {
           position: position.value,
@@ -220,12 +218,8 @@ export default function useItemLayout(
         position.value = interpolateVector(
           currentProgress,
           startPosition,
-          itemPosition
+          layoutPos
         );
-        return;
-      }
-
-      if (!positionChanged) {
         return;
       }
 
@@ -233,9 +227,14 @@ export default function useItemLayout(
         shouldAnimateLayout.value &&
         (!animateLayoutOnReorderOnly.value || activeItemKey.value !== null)
       ) {
-        position.value = withTiming(itemPosition);
+        // Compare against the current position so sub-pixel changes accumulate
+        // (the previous reaction input advances even when the update is skipped)
+        if (!areVectorsDifferent(position.value, layoutPos, 1)) {
+          return;
+        }
+        position.value = withTiming(layoutPos);
       } else {
-        position.value = itemPosition;
+        position.value = layoutPos;
       }
     }
   );


### PR DESCRIPTION
## Description

On web, slowly resizing a Sortable container (e.g. dragging the docs split-pane divider) left grid items with wrong sizes/positions.

Cause: `useItemLayout` only applied a new position when it differed by 1px+ from the previous reaction input, but that baseline advances on every run even when the update is skipped - so a slow resize's sub-pixel steps were skipped forever and positions drifted out of sync with the CSS-driven sizes.

Fix: compare against the current position instead, and snap to the exact target on the non-animated path.

## Changes showcase

Repro: Grid > Examples > Touchable, widen so the split shows, drag the divider slowly. Items now stay aligned (before: stale positions while shrinking).
