### PR TITLE
chore: Clean up haptics adapters and add adapter tests

### DIFF
--- a/packages/react-native-sortables/src/integrations/haptics/adapters/expo-haptics.test.ts
+++ b/packages/react-native-sortables/src/integrations/haptics/adapters/expo-haptics.test.ts
@@ -1,0 +1,56 @@
+import ExpoHaptics from './expo-haptics';
+
+type ExpoGlobal = {
+  expo?: { modules?: { ExpoHaptics?: { impactAsync?: jest.Mock } } };
+};
+
+const expoGlobal = globalThis as ExpoGlobal;
+
+describe('expo-haptics adapter', () => {
+  beforeEach(() => {
+    // expo-haptics is fired through runOnJS, which schedules a microtask; use
+    // real timers so awaiting a microtask actually flushes it.
+    jest.useRealTimers();
+  });
+
+  afterEach(() => {
+    delete expoGlobal.expo;
+  });
+
+  it('bails when expo-haptics is not registered', () => {
+    expect(ExpoHaptics.load()).toBeNull();
+  });
+
+  it('bails when the module does not expose impactAsync', () => {
+    expoGlobal.expo = { modules: { ExpoHaptics: {} } };
+
+    expect(ExpoHaptics.load()).toBeNull();
+  });
+
+  it('maps impact types to expo-haptics impact styles', async () => {
+    const impactAsync = jest.fn(() => Promise.resolve());
+    expoGlobal.expo = { modules: { ExpoHaptics: { impactAsync } } };
+
+    const trigger = ExpoHaptics.load();
+    expect(trigger).not.toBeNull();
+
+    trigger?.('impactMedium');
+    trigger?.('impactLight');
+    trigger?.();
+    // expo-haptics is fired on the JS thread via runOnJS (queued as a microtask)
+    await Promise.resolve();
+
+    expect(impactAsync.mock.calls).toEqual([['medium'], ['light'], ['light']]);
+  });
+
+  it('swallows rejections from impactAsync', async () => {
+    const impactAsync = jest.fn(() => Promise.reject(new Error('unsupported')));
+    expoGlobal.expo = { modules: { ExpoHaptics: { impactAsync } } };
+
+    const trigger = ExpoHaptics.load();
+    expect(() => trigger?.('impactLight')).not.toThrow();
+    await Promise.resolve();
+
+    expect(impactAsync).toHaveBeenCalledWith('light');
+  });
+});

--- a/packages/react-native-sortables/src/integrations/haptics/adapters/expo-haptics.ts
+++ b/packages/react-native-sortables/src/integrations/haptics/adapters/expo-haptics.ts
@@ -1,11 +1,8 @@
 /**
- * Optional expo-haptics adapter.
- *
- * We never import `expo-haptics` directly, because a static import would break
- * Metro bundling for bare React Native apps that don't have it installed.
- * Instead we read its native module from the Expo runtime registry, so it's
- * picked up automatically in any Expo app (including Expo Go) and ignored
- * everywhere else.
+ * Optional expo-haptics adapter. We never import the package (a static import
+ * would break Metro for bare apps without it); instead we read its native
+ * module from the Expo runtime registry, so it is picked up in any Expo app and
+ * ignored elsewhere.
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/react-native-sortables/src/integrations/haptics/adapters/pulsar.ts
+++ b/packages/react-native-sortables/src/integrations/haptics/adapters/pulsar.ts
@@ -1,15 +1,10 @@
 /**
- * Optional react-native-pulsar adapter.
- *
- * Pulsar exposes its haptics through a Turbo Module ('RNPulsar'), so it only
- * works on the New Architecture and never in Expo Go. Like the expo-haptics
- * adapter, we never import the package: we look its native module up in the
- * Turbo Module registry, so Pulsar is used automatically when a consumer has
- * installed it and ignored everywhere else. That keeps it out of the
- * dependency tree and leaves bare old-architecture builds untouched.
- *
- * `Pulsar_play` is synchronous and Pulsar's own presets call it from worklets,
- * so we fire it directly on the UI thread without hopping to JS.
+ * Optional react-native-pulsar adapter. Pulsar's haptics live behind a Turbo
+ * Module ('RNPulsar'), available only on the New Architecture. Like the
+ * expo-haptics adapter we never import the package - we look the native module
+ * up in the Turbo Module registry, so it is used automatically when installed
+ * and adds nothing to the dependency tree. Its presets call the synchronous
+ * native method from worklets, so we fire directly on the UI thread.
  */
 
 import { type TurboModule, TurboModuleRegistry } from 'react-native';

--- a/packages/react-native-sortables/src/integrations/haptics/adapters/react-native-haptic-feedback.test.ts
+++ b/packages/react-native-sortables/src/integrations/haptics/adapters/react-native-haptic-feedback.test.ts
@@ -1,0 +1,51 @@
+/* eslint-disable no-underscore-dangle -- __turboModuleProxy is a React Native global */
+
+import { TurboModuleRegistry } from 'react-native';
+
+import { logger } from '../../../utils';
+import ReactNativeHapticFeedback from './react-native-haptic-feedback';
+
+jest.mock('react-native-haptic-feedback', () => ({
+  HapticFeedbackTypes: { selection: 'selection' }
+}));
+
+type TurboGlobal = { __turboModuleProxy?: unknown };
+const turboGlobal = global as TurboGlobal;
+
+describe('react-native-haptic-feedback adapter', () => {
+  afterEach(() => {
+    delete turboGlobal.__turboModuleProxy;
+    jest.restoreAllMocks();
+  });
+
+  it('forwards the haptic type to the native trigger on the New Architecture', () => {
+    turboGlobal.__turboModuleProxy = () => null;
+    const nativeTrigger = jest.fn();
+    jest
+      .spyOn(TurboModuleRegistry, 'get')
+      .mockReturnValue({ trigger: nativeTrigger } as never);
+
+    const trigger = ReactNativeHapticFeedback.load();
+    trigger?.('impactLight');
+
+    expect(nativeTrigger).toHaveBeenCalledTimes(1);
+    expect(nativeTrigger).toHaveBeenCalledWith(
+      'impactLight',
+      expect.any(Object)
+    );
+  });
+
+  it('falls back to a warning no-op when the native module is unavailable', () => {
+    turboGlobal.__turboModuleProxy = () => null;
+    jest.spyOn(TurboModuleRegistry, 'get').mockReturnValue(null);
+    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+    const trigger = ReactNativeHapticFeedback.load();
+    expect(typeof trigger).toBe('function');
+
+    trigger?.();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('react-native-haptic-feedback')
+    );
+  });
+});


### PR DESCRIPTION
Follow-up cleanup on top of the Pulsar haptics PR (do not merge before it).

- Trims the verbose header comments on the `react-native-pulsar` and `expo-haptics` adapters.
- Adds unit tests for the `expo-haptics` and `react-native-haptic-feedback` adapters (detection plus type-to-trigger mapping), mirroring the existing Pulsar adapter test.

No behavior changes.
