### PR TITLE
docs: List all built-in haptics libraries consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ React Native Sortables is a powerful and easy-to-use library that brings smooth,
 
   - **Auto-scrolling** beyond screen bounds
   - Customizable **layout animations** for items addition and removal
-  - Built-in **haptic feedback** integration via [react-native-pulsar](https://github.com/software-mansion/pulsar), [expo-haptics](https://docs.expo.dev/versions/latest/sdk/haptics/) or [react-native-haptic-feedback](https://github.com/mkuczera/react-native-haptic-feedback)
+  - Built-in **haptic feedback** integration (optional) via [react-native-pulsar](https://github.com/software-mansion/pulsar), [expo-haptics](https://github.com/expo/expo/tree/main/packages/expo-haptics) or [react-native-haptic-feedback](https://github.com/mkuczera/react-native-haptic-feedback)
   - Different **reordering strategies** (insertion, swapping)
 
 - 💡 **Developer Experience**

--- a/packages/docs/docs/intro.mdx
+++ b/packages/docs/docs/intro.mdx
@@ -56,5 +56,7 @@ Check out the **[Getting Started](./getting-started) guide** to begin using Reac
 
 - [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated)
 - [react-native-gesture-handler](https://github.com/software-mansion/react-native-gesture-handler)
-- [react-native-haptic-feedback](https://github.com/mkuczera/react-native-haptic-feedback)
+- [react-native-pulsar](https://github.com/software-mansion/pulsar) (optional, haptics)
+- [expo-haptics](https://github.com/expo/expo/tree/main/packages/expo-haptics) (optional, haptics)
+- [react-native-haptic-feedback](https://github.com/mkuczera/react-native-haptic-feedback) (optional, haptics)
 - [react-native-builder-bob](https://github.com/callstack/react-native-builder-bob)


### PR DESCRIPTION
Makes the haptics library references consistent across the docs now that three backends are supported.

- Adds `react-native-pulsar` and `expo-haptics` next to `react-native-haptic-feedback` in the "Built with" list in the intro (previously it listed only `react-native-haptic-feedback`).
- Points the `expo-haptics` link in the README at its GitHub page, matching the other entries.

The Getting Started and props pages already list all three.
