### PR TITLE
feat: add idleItemsLayout option for relative positioning while idle

### DIFF
--- a/example/app/src/examples/SortableFlex/tests/ResizableContainerExample.tsx
+++ b/example/app/src/examples/SortableFlex/tests/ResizableContainerExample.tsx
@@ -1,0 +1,102 @@
+import { useCallback, useState } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming
+} from 'react-native-reanimated';
+import Sortable from 'react-native-sortables';
+
+import { Button, FlexCell, ScrollScreen, Section } from '@/components';
+import { colors, radius, spacing } from '@/theme';
+
+const NARROW_WIDTH = 170;
+const WIDE_WIDTH = 320;
+const RESIZE_DURATION = 600;
+
+const ITEMS = [
+  'Lorem',
+  'ipsum',
+  'dolor',
+  'sit',
+  'amet',
+  'consectetur',
+  'adipiscing',
+  'elit'
+];
+
+export default function ResizableContainerExample() {
+  const [isWide, setIsWide] = useState(true);
+  // Keep separate order per container so dragging one does not affect the other.
+  // Order must be synced in onDragEnd - in relative idle layout items follow
+  // their order in the children, so this is required to persist a reorder.
+  const [relativeItems, setRelativeItems] = useState(ITEMS);
+  const [absoluteItems, setAbsoluteItems] = useState(ITEMS);
+  const width = useSharedValue(WIDE_WIDTH);
+
+  const toggleWidth = useCallback(() => {
+    setIsWide(prev => {
+      const next = !prev;
+      width.value = withTiming(next ? WIDE_WIDTH : NARROW_WIDTH, {
+        duration: RESIZE_DURATION
+      });
+      return next;
+    });
+  }, [width]);
+
+  const containerStyle = useAnimatedStyle(() => ({ width: width.value }));
+
+  return (
+    <ScrollScreen includeNavBarHeight>
+      <Section
+        description='Animate the container width and compare how items behave while the sortable is idle.'
+        title='Resize the container'>
+        <Button
+          title={isWide ? 'Make narrow' : 'Make wide'}
+          onPress={toggleWidth}
+        />
+      </Section>
+
+      <Section
+        description="idleItemsLayout='relative' keeps idle items in flex layout, so they reflow together with the container."
+        title='Relative (reflows immediately)'>
+        <Animated.View style={[styles.column, containerStyle]}>
+          <Sortable.Flex
+            gap={spacing.xs}
+            idleItemsLayout='relative'
+            onDragEnd={({ order }) => setRelativeItems(order)}>
+            {relativeItems.map(item => (
+              <FlexCell key={item} size='large'>
+                {item}
+              </FlexCell>
+            ))}
+          </Sortable.Flex>
+        </Animated.View>
+      </Section>
+
+      <Section
+        description="idleItemsLayout='absolute' (the default) keeps the library-computed positions, so items lag behind the container while it resizes."
+        title='Absolute (lags behind)'>
+        <Animated.View style={[styles.column, containerStyle]}>
+          <Sortable.Flex
+            gap={spacing.xs}
+            onDragEnd={({ order }) => setAbsoluteItems(order)}>
+            {absoluteItems.map(item => (
+              <FlexCell key={item} size='large'>
+                {item}
+              </FlexCell>
+            ))}
+          </Sortable.Flex>
+        </Animated.View>
+      </Section>
+    </ScrollScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  column: {
+    backgroundColor: colors.background3,
+    borderRadius: radius.md,
+    padding: spacing.xs
+  }
+});

--- a/example/app/src/examples/SortableFlex/tests/index.ts
+++ b/example/app/src/examples/SortableFlex/tests/index.ts
@@ -1,4 +1,9 @@
 import BottomTabsNavigatorExample from './BottomTabsNavigatorExample';
 import ComplexLayoutExample from './ComplexLayoutExample';
+import ResizableContainerExample from './ResizableContainerExample';
 
-export { BottomTabsNavigatorExample, ComplexLayoutExample };
+export {
+  BottomTabsNavigatorExample,
+  ComplexLayoutExample,
+  ResizableContainerExample
+};

--- a/example/app/src/examples/navigation/routes.ts
+++ b/example/app/src/examples/navigation/routes.ts
@@ -171,6 +171,10 @@ const routes: Routes = {
             Component: SortableFlex.tests.ComplexLayoutExample,
             name: 'Complex Layout'
           },
+          ResizableContainer: {
+            Component: SortableFlex.tests.ResizableContainerExample,
+            name: 'Resizable Container'
+          },
           BottomTabsNavigator: {
             Component: SortableFlex.tests.BottomTabsNavigatorExample,
             name: 'Bottom Tabs Navigator'

--- a/packages/docs/docs/flex/props.mdx
+++ b/packages/docs/docs/flex/props.mdx
@@ -275,6 +275,27 @@ Whether the height of the flex component should be animated when the items are r
 
 ---
 
+### idleItemsLayout
+
+Controls how items are positioned while the container is **idle** (no item is being dragged).
+
+| type                       | default      | required |
+| -------------------------- | ------------ | -------- |
+| `'absolute' \| 'relative'` | `'absolute'` | NO       |
+
+- `'absolute'` - idle items keep the **library-computed absolute positions**. This is the default and works best when the container has a **fixed size**.
+- `'relative'` - idle items use the container's **native flex layout**, so they **reflow immediately** when the container is **resized** (e.g. a resizable table cell). The library automatically switches back to absolute positioning while an item is being dragged.
+
+:::info
+
+Use `'relative'` when the `Sortable.Flex` is rendered inside a **container whose size can change** and you want the items to follow the new size without a delay.
+
+When `'relative'` is used, you should **persist the items order** in the `onDragEnd` callback (e.g. `onDragEnd={({ order }) => setItems(order)}`), because idle items follow the **order of the children** rather than the library-computed positions.
+
+:::
+
+---
+
 ## Item Drag
 
 ### overDrag

--- a/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableContainer.tsx
@@ -82,16 +82,26 @@ export default function SortableContainer({
     };
   });
 
-  const innerContainerStyle = useAnimatedStyle(() => ({
-    ...(controlledContainerDimensions.height &&
-      containerHeight.value !== null && {
-        height: containerHeight.value
-      }),
-    ...(controlledContainerDimensions.width &&
-      containerWidth.value !== null && {
-        width: containerWidth.value
-      })
-  }));
+  const innerContainerStyle = useAnimatedStyle(() => {
+    // While items are in relative (flex) layout, let the container size to its
+    // content so it reflows immediately on resize. Pinning the controlled
+    // dimensions here would leave a stale size on the controlled axis (e.g. a
+    // stale height that clips wrapped rows) until the next layout pass.
+    if (!usesAbsoluteLayout.value) {
+      return EMPTY_OBJECT;
+    }
+
+    return {
+      ...(controlledContainerDimensions.height &&
+        containerHeight.value !== null && {
+          height: containerHeight.value
+        }),
+      ...(controlledContainerDimensions.width &&
+        containerWidth.value !== null && {
+          width: containerWidth.value
+        })
+    };
+  });
 
   return (
     <Animated.View

--- a/packages/react-native-sortables/src/constants/props.ts
+++ b/packages/react-native-sortables/src/constants/props.ts
@@ -85,6 +85,7 @@ export const DEFAULT_SORTABLE_FLEX_PROPS = {
   flexDirection: 'row',
   flexWrap: 'wrap',
   gap: 0,
+  idleItemsLayout: 'absolute',
   justifyContent: 'flex-start',
   padding: 0,
   strategy: 'insert'

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
@@ -14,6 +14,7 @@ import type {
   CommonValuesContextType,
   ControlledDimensions,
   Dimensions,
+  IdleItemsLayout,
   ItemDragSettings,
   ItemSizes,
   ItemsLayoutTransitionMode,
@@ -35,6 +36,7 @@ type CommonValuesProviderProps = PropsWithChildren<
       customHandle: boolean;
       controlledContainerDimensions: ControlledDimensions;
       controlledItemDimensions: ControlledDimensions;
+      idleItemsLayout?: IdleItemsLayout;
       itemsLayoutTransitionMode: ItemsLayoutTransitionMode;
       stackingOrder: ItemsStackingOrder;
     }
@@ -56,6 +58,7 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
     dragActivationFailOffset: _dragActivationFailOffset,
     dropAnimationDuration: _dropAnimationDuration,
     enableActiveItemSnap: _enableActiveItemSnap,
+    idleItemsLayout = 'absolute',
     inactiveItemOpacity: _inactiveItemOpacity,
     inactiveItemScale: _inactiveItemScale,
     itemsLayoutTransitionMode,
@@ -126,6 +129,7 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
     const containerRef = useAnimatedRef<View>();
     const sortEnabled = useAnimatableValue(_sortEnabled);
     const usesAbsoluteLayout = useMutableValue(false);
+    const isMeasured = useMutableValue(false);
     const shouldAnimateLayout = useMutableValue(true);
     const animateLayoutOnReorderOnly = useDerivedValue(
       () => itemsLayoutTransitionMode === 'reorder',
@@ -164,10 +168,12 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
         dragActivationFailOffset,
         dropAnimationDuration,
         enableActiveItemSnap,
+        idleItemsLayout,
         inactiveAnimationProgress,
         inactiveItemOpacity,
         inactiveItemScale,
         indexToKey,
+        isMeasured,
         isStackingOrderDesc: stackingOrder === 'desc',
         itemHeights,
         itemPositions,

--- a/packages/react-native-sortables/src/providers/shared/DragProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/DragProvider.ts
@@ -92,10 +92,12 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
     dragActivationFailOffset,
     dropAnimationDuration,
     enableActiveItemSnap,
+    idleItemsLayout,
     inactiveAnimationProgress,
     inactiveItemOpacity,
     inactiveItemScale,
     indexToKey,
+    isMeasured,
     itemHeights,
     itemPositions,
     itemWidths,
@@ -282,6 +284,13 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
     ) => {
       'worklet';
       const ctx = context.value;
+      // In idle-relative mode items are laid out by flex while idle. Commit the
+      // switch to absolute positioning synchronously here, before any active
+      // item position starts updating, so the item is absolute on the first
+      // animated frame (itemPositions are kept current in both modes).
+      if (idleItemsLayout === 'relative') {
+        usesAbsoluteLayout.value = true;
+      }
       activeAnimationProgress.value = 0;
       activeItemDropped.value = false;
       prevActiveItemKey.value = null;
@@ -357,6 +366,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       context,
       containerId,
       haptics,
+      idleItemsLayout,
       inactiveAnimationProgress,
       inactiveItemOpacity,
       inactiveItemScale,
@@ -367,7 +377,8 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       onDragStart,
       touchPosition,
       updateLayer,
-      updateActiveHandleMeasurements
+      updateActiveHandleMeasurements,
+      usesAbsoluteLayout
     ]
   );
 
@@ -385,8 +396,8 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
         !touch ||
         // Sorting is disabled
         !sortEnabled.value ||
-        // Absolute layout is not applied yet
-        !usesAbsoluteLayout.value ||
+        // Items are not measured yet (positions are not ready)
+        !isMeasured.value ||
         // Another item is already being touched/activated
         activationAnimationProgress.value > 0 ||
         activeItemKey.value !== null
@@ -405,7 +416,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       // Start handling touch after a delay to prevent accidental activation
       // e.g. while scrolling the ScrollView
       ctx.activationTimeoutId = setAnimatedTimeout(() => {
-        if (!usesAbsoluteLayout.value) {
+        if (!isMeasured.value) {
           return;
         }
 
@@ -437,11 +448,11 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       currentTouch,
       dragActivationDelay,
       handleDragStart,
+      isMeasured,
       itemHeights,
       itemWidths,
       itemPositions,
-      sortEnabled,
-      usesAbsoluteLayout
+      sortEnabled
     ]
   );
 
@@ -562,6 +573,12 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
 
       setAnimatedTimeout(() => {
         activeItemDropped.value = true;
+        // Now that the drop animation finished and the sortable is fully idle,
+        // return items to relative (flex) layout so they reflow with the
+        // container until the next drag starts.
+        if (idleItemsLayout === 'relative') {
+          usesAbsoluteLayout.value = false;
+        }
         updateLayer?.(LayerState.IDLE);
         onActiveItemDropped({
           fromIndex,
@@ -585,6 +602,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       currentTouch,
       dropAnimationDuration,
       haptics,
+      idleItemsLayout,
       inactiveAnimationProgress,
       indexToKey,
       keyToIndex,
@@ -593,6 +611,7 @@ const { DragProvider, useDragContext } = createProvider('Drag')<
       stableOnDragEnd,
       touchPosition,
       updateLayer,
+      usesAbsoluteLayout,
       activeHandleMeasurements
     ]
   );

--- a/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
@@ -41,6 +41,8 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
     containerWidth,
     controlledContainerDimensions,
     controlledItemDimensions,
+    idleItemsLayout,
+    isMeasured,
     itemHeights,
     itemWidths,
     usesAbsoluteLayout
@@ -206,11 +208,17 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
         containerHeight.value = dimensions.height;
       }
 
-      if (!usesAbsoluteLayout.value) {
+      if (!isMeasured.value) {
         // Add timeout for safety, to prevent too many layout recalculations
         // in a short period of time (this may cause issues on low-end devices)
         setAnimatedTimeout(() => {
-          usesAbsoluteLayout.value = true;
+          isMeasured.value = true;
+          // When items should reflow with the container while idle, keep them
+          // in relative (flex) layout until a drag starts. Otherwise switch to
+          // absolute positioning right away and keep it for the whole lifetime.
+          if (idleItemsLayout !== 'relative') {
+            usesAbsoluteLayout.value = true;
+          }
         }, 100);
       }
     },
@@ -218,6 +226,8 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
       containerHeight,
       containerWidth,
       controlledContainerDimensions,
+      idleItemsLayout,
+      isMeasured,
       usesAbsoluteLayout
     ]
   );

--- a/packages/react-native-sortables/src/providers/shared/SharedProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/SharedProvider.tsx
@@ -12,6 +12,7 @@ import type {
   ActiveItemSnapSettings,
   AutoScrollSettings,
   ControlledDimensions,
+  IdleItemsLayout,
   ItemDragSettings,
   SharedProps,
   SortableCallbacks
@@ -46,6 +47,8 @@ export type SharedProviderProps = PropsWithChildren<
     Required<SortableCallbacks> & {
       controlledContainerDimensions: ControlledDimensions;
       controlledItemDimensions: ControlledDimensions;
+      // Flex-only: forwarded to CommonValuesProvider via `...rest`
+      idleItemsLayout?: IdleItemsLayout;
       dropIndicatorStyle?: ViewStyle;
     }
 >;

--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayout.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayout.ts
@@ -20,8 +20,17 @@ import { areVectorsDifferent } from '../../../utils';
 import { useCommonValuesContext } from '../CommonValuesProvider';
 import useItemZIndex from './useItemZIndex';
 
+// When switching back from absolute to relative layout (e.g. after a drop when
+// `idleItemsLayout` is 'relative'), the previously applied absolute positioning
+// props must be explicitly reset. Reanimated does not restore props that are
+// simply omitted from a new style object, so leaving them out would keep the
+// stale absolute `left`/`top`/`transform` and scatter the items.
 const RELATIVE_STYLE: ViewStyle = {
-  position: 'relative'
+  left: 0,
+  position: 'relative',
+  top: 0,
+  transform: [],
+  zIndex: 0
 };
 
 const HIDDEN_STYLE: ViewStyle = {

--- a/packages/react-native-sortables/src/types/props/flex.ts
+++ b/packages/react-native-sortables/src/types/props/flex.ts
@@ -9,7 +9,12 @@ import type {
   JustifyContent
 } from '../layout/flex';
 import type { SortStrategyFactory } from '../providers';
-import type { DefaultSharedProps, DragEndParams, SharedProps } from './shared';
+import type {
+  DefaultSharedProps,
+  DragEndParams,
+  IdleItemsLayout,
+  SharedProps
+} from './shared';
 
 /** Parameters passed to the onDragEnd callback of a sortable flex container */
 export type SortableFlexDragEndParams = DragEndParams & {
@@ -93,6 +98,16 @@ export type SortableFlexProps = Simplify<
          * @default 'insert'
          */
         strategy?: SortableFlexStrategy;
+        /** Controls how items are positioned while the container is idle (no
+         * item is being dragged).
+         *
+         * Set to `'relative'` to let items use the container's native flex
+         * layout while idle, so they reflow immediately when the container is
+         * resized (e.g. a resizable table column). The library automatically
+         * switches to absolute positioning while an item is being dragged.
+         * @default 'absolute'
+         */
+        idleItemsLayout?: IdleItemsLayout;
         /** Callback fired when drag gesture ends.
          * @note This callback is always called when drag ends, even if the order hasn't changed.
          * The order function provided in the callback parameters will maintain referential

--- a/packages/react-native-sortables/src/types/props/shared.ts
+++ b/packages/react-native-sortables/src/types/props/shared.ts
@@ -167,6 +167,16 @@ export type DropIndicatorSettings = {
  */
 export type ItemsLayoutTransitionMode = 'all' | 'reorder';
 
+/**
+ * Controls how items are positioned while the container is idle (no item is
+ * being dragged)
+ * - 'absolute' - items keep the library-computed absolute positions
+ * - 'relative' - items use the container's native flex layout while idle, so
+ *   they reflow immediately when the container is resized. The library switches
+ *   to absolute positioning automatically while an item is being dragged.
+ */
+export type IdleItemsLayout = 'absolute' | 'relative';
+
 type ItemLayoutAnimationSettings = {
   /** Animation to play when an item enters the list */
   itemEntering: LayoutAnimation | null;

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -22,6 +22,7 @@ import type { Dimensions, ItemSizes, Vector } from '../layout/shared';
 import type {
   ActiveItemDecorationSettings,
   ActiveItemSnapSettings,
+  IdleItemsLayout,
   ItemDragSettings,
   ReorderTriggerOrigin
 } from '../props/shared';
@@ -92,10 +93,16 @@ export type CommonValuesContextType =
       // OTHER
       containerRef: AnimatedRef<View>;
       sortEnabled: SharedValue<boolean>;
+      // Whether items are currently rendered with absolute positions. Toggled
+      // back to false when idle if `idleItemsLayout` is 'relative'.
       usesAbsoluteLayout: SharedValue<boolean>;
+      // Set to true once after the first layout and never reset. Gates the drag
+      // gesture independently of `usesAbsoluteLayout` (which may toggle).
+      isMeasured: SharedValue<boolean>;
       shouldAnimateLayout: SharedValue<boolean>; // is set to false on web when the browser window is resized
       animateLayoutOnReorderOnly: SharedValue<boolean>;
       customHandle: boolean;
+      idleItemsLayout: IdleItemsLayout;
       isStackingOrderDesc: boolean;
     };
 


### PR DESCRIPTION
## The bug

`Sortable.Flex` switches items to absolute positioning once they are measured and keeps them there. When the `Sortable.Flex` lives inside a container whose size can change (e.g. a resizable table column), the items keep their old computed positions and visibly lag behind the new container size - they only catch up after an `onLayout` round-trip and a timing animation. Reported in discussion #567.

## The fix

A new opt-in `idleItemsLayout` prop on `Sortable.Flex`:

- `'absolute'` (default) - current behavior, items keep the library-computed positions.
- `'relative'` - idle items stay in the native flex layout and reflow together with the container. The library switches to absolute positioning automatically only while an item is being dragged, and back to relative once it is dropped.

```tsx
<Sortable.Flex
  idleItemsLayout="relative"
  onDragEnd={({ order }) => setItems(order)}>
  {items.map(item => (
    <Item item={item} key={item.id} />
  ))}
</Sortable.Flex>
```

> [!NOTE]
> In `relative` mode idle items follow the order of the children, so the order has to be persisted in `onDragEnd` for a reorder to stick.

Implementation notes:

- A separate one-shot `isMeasured` signal now gates the drag gesture, since `usesAbsoluteLayout` is allowed to toggle in `relative` mode.
- `RELATIVE_STYLE` explicitly resets `left`/`top`/`transform`/`zIndex`. Reanimated does not restore props omitted from a new style object, so the absolute -> relative transition would otherwise keep stale offsets and **scatter the items after a drop** (this is exactly the difference between the two recordings below).
- The inner container is sized to its content while in relative layout so it reflows on resize instead of keeping a stale controlled size.
- Scoped to `Sortable.Flex` for now. Grid items derive their cross-axis size from the container, so enabling it there needs separate validation (the machinery is shared, so it is a small follow-up).

## Before / after

Same actions in both clips: drag an item in the `relative` container, then resize the column narrow.

| Before (without the `RELATIVE_STYLE` reset) | After |
| --- | --- |
| <!-- drag rns_before_fix.mp4 here --> | <!-- drag rns_after_fix.mp4 here --> |

Before, the dragged-then-dropped items stay stuck in scattered absolute positions and no longer reflow on resize. After, they drop back into a clean flex layout and reflow with the container.

## Debug example

Added under `Sortable Flex -> Test examples -> Resizable Container`. Minimal repro:

```tsx
import { useState } from 'react';
import Animated, {
  useAnimatedStyle,
  useSharedValue,
  withTiming
} from 'react-native-reanimated';
import Sortable from 'react-native-sortables';

const ITEMS = ['Lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consectetur'];

export default function Demo() {
  const [items, setItems] = useState(ITEMS);
  const width = useSharedValue(320);
  const style = useAnimatedStyle(() => ({ width: width.value }));

  return (
    <>
      <Button
        title="Toggle width"
        onPress={() => (width.value = withTiming(width.value > 240 ? 170 : 320))}
      />
      <Animated.View style={style}>
        <Sortable.Flex
          gap={8}
          idleItemsLayout="relative"
          onDragEnd={({ order }) => setItems(order)}>
          {items.map(item => (
            <Cell key={item}>{item}</Cell>
          ))}
        </Sortable.Flex>
      </Animated.View>
    </>
  );
}
```

Addresses discussion #567.
