### PR TITLE
fix: Keep Sortable.Grid measurements when revealed after react-freeze

### DIFF
--- a/packages/react-native-sortables/src/components/SortableGrid.tsx
+++ b/packages/react-native-sortables/src/components/SortableGrid.tsx
@@ -197,15 +197,18 @@ function SortableGridComponent<I>({
     useMeasurementsContext();
   const { mainGroupSize } = useGridLayoutContext();
 
-  const isFirstRenderRef = useRef(true);
+  const previousGroupsRef = useRef(groups);
 
   useOrderUpdater(strategy, GRID_STRATEGIES);
 
   useLayoutEffect(() => {
-    if (isFirstRenderRef.current) {
-      isFirstRenderRef.current = false;
+    // Reset only on a real column/row count change, not on a bare effect re-run
+    // (e.g. a react-freeze/Offscreen reveal) which would wipe valid measurements.
+    // https://github.com/MatiPl01/react-native-sortables/issues/519
+    if (previousGroupsRef.current === groups) {
       return;
     }
+    previousGroupsRef.current = groups;
     resetMeasurements();
   }, [groups, resetMeasurements]);
 


### PR DESCRIPTION
## Summary

Fixes #519. After a `Sortable.Grid` is frozen and then unfrozen by [`react-freeze`](https://github.com/software-mansion/react-freeze) (e.g. React Navigation's `freezeOnBlur`), dragging and item add/remove animations stop working.

## Cause

On reveal, react-freeze replays the grid's `useLayoutEffect` while preserving refs and shared values, and the items aren't re-rendered (so `onLayout` doesn't re-fire). That effect reset measurements on every run, so on unfreeze it wiped `itemWidths`/`itemHeights` with nothing left to repopulate them - drag activation then reads the now-null dimensions and bails.

## Fix

Reset measurements only when the column/row count actually changes (compare the previous value) instead of on every effect re-run, so a freeze/Offscreen reveal is a no-op. `Sortable.Flex` has no such effect and isn't affected.

<details><summary>Reproduction</summary>

```tsx
import { useState } from 'react';
import { Button, View } from 'react-native';
import { Freeze } from 'react-freeze';
import { GestureHandlerRootView } from 'react-native-gesture-handler';
import Sortable from 'react-native-sortables';

const DATA = Array.from({ length: 6 }, (_, i) => `Item ${i + 1}`);

export default function App() {
  const [frozen, setFrozen] = useState(false);

  return (
    <GestureHandlerRootView style={{ flex: 1, padding: 16 }}>
      <Button
        title={frozen ? 'Unfreeze' : 'Freeze'}
        onPress={() => setFrozen(f => !f)}
      />
      <Freeze freeze={frozen}>
        <Sortable.Grid
          columns={1}
          data={DATA}
          rowGap={10}
          keyExtractor={item => item}
          renderItem={() => (
            <View
              style={{ height: 60, borderRadius: 8, backgroundColor: '#36877F' }}
            />
          )}
        />
      </Freeze>
    </GestureHandlerRootView>
  );
}
```

Tap Freeze, tap Unfreeze, then try to drag an item - on `1.9.x` the drag is dead after unfreeze.

</details>

Verified on the iOS Fabric example; typecheck, lint and unit tests pass.
