### PR TITLE
chore: Add Sortable.Flex column grouping regression tests (#298)

### DIFF
--- a/packages/react-native-sortables/src/providers/flex/FlexLayoutProvider/utils/layout.test.ts
+++ b/packages/react-native-sortables/src/providers/flex/FlexLayoutProvider/utils/layout.test.ts
@@ -1,0 +1,97 @@
+import type {
+  FlexAlignments,
+  FlexLayout,
+  FlexLayoutProps
+} from '../../../../types';
+import { calculateLayout } from './layout';
+
+const FLEX_START_ALIGNMENTS: FlexAlignments = {
+  alignContent: 'flex-start',
+  alignItems: 'flex-start',
+  justifyContent: 'flex-start'
+};
+
+// Builds the calculateLayout input for a vertical (column) Sortable.Flex from a
+// list of item heights, mirroring what FlexLayoutProvider feeds it for a list.
+const columnProps = (
+  heights: Array<number>,
+  maxHeight: number,
+  {
+    flexWrap = 'wrap',
+    width = 200
+  }: { flexWrap?: FlexLayoutProps['flexWrap']; width?: number } = {}
+): FlexLayoutProps => {
+  const indexToKey = heights.map((_, i) => `key-${i}`);
+  const itemHeights = Object.fromEntries(
+    indexToKey.map((key, i) => [key, heights[i]!])
+  );
+  const itemWidths = Object.fromEntries(indexToKey.map(key => [key, width]));
+
+  return {
+    flexAlignments: FLEX_START_ALIGNMENTS,
+    flexDirection: 'column',
+    flexWrap,
+    gaps: { column: 0, row: 0 },
+    indexToKey,
+    itemHeights,
+    itemWidths,
+    limits: { maxHeight, maxWidth: Infinity, minHeight: 0, minWidth: 0 },
+    paddings: { bottom: 0, left: 0, right: 0, top: 0 }
+  };
+};
+
+const layoutOf = (props: FlexLayoutProps): FlexLayout => {
+  const layout = calculateLayout(props);
+  if (!layout) {
+    throw new Error('expected calculateLayout to return a layout');
+  }
+  return layout;
+};
+
+// Regression coverage for issue #298 "Last item from a long vertical list flies
+// off the screen". The fly-off was the last item being placed into a spurious
+// extra column (group) instead of staying in the single vertical column.
+describe('calculateLayout (Sortable.Flex column grouping)', () => {
+  describe('a measured column never wraps (#298 structural guarantee)', () => {
+    it('keeps every item in one group when maxHeight is unbounded', () => {
+      // A column Sortable.Flex with no explicit height/maxHeight is measured,
+      // so FlexLayoutProvider passes maxHeight: Infinity. However tall the list
+      // gets, it must stay a single column - wrapping (and the fly-off) is then
+      // structurally impossible.
+      const layout = layoutOf(columnProps([100, 100, 100, 100, 100], Infinity));
+
+      expect(layout.groupSizeLimit).toBe(Infinity);
+      expect(layout.itemGroups).toEqual([
+        ['key-0', 'key-1', 'key-2', 'key-3', 'key-4']
+      ]);
+    });
+  });
+
+  describe('sub-pixel overflow does not spill the last item (#347 tolerance)', () => {
+    it('keeps items in one group when their total exceeds the limit by < 0.1px', () => {
+      // Two items whose measured heights sum to 0.05px more than the column
+      // height. Without the floating-point tolerance this overflow pushed the
+      // last item into a new group (off-screen) - the reported "fly off".
+      const layout = layoutOf(columnProps([50, 50.05], 100));
+
+      expect(layout.itemGroups).toEqual([['key-0', 'key-1']]);
+    });
+
+    it('tolerates the classic 0.1 + 0.2 floating-point overshoot', () => {
+      // 0.1 + 0.2 === 0.30000000000000004 > 0.3 in IEEE-754.
+      const layout = layoutOf(columnProps([0.1, 0.2], 0.3));
+
+      expect(layout.itemGroups).toEqual([['key-0', 'key-1']]);
+    });
+  });
+
+  describe('genuine overflow still wraps (no over-correction)', () => {
+    it('starts a new group once an item truly exceeds the column height', () => {
+      // Three 50px items in a 100px column: two fit, the third wraps. The
+      // tolerance must not be so large that legitimate wrapping is suppressed.
+      const layout = layoutOf(columnProps([50, 50, 50], 100));
+
+      expect(layout.itemGroups).toEqual([['key-0', 'key-1'], ['key-2']]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Issue #298 reported that the **last item of a vertical `Sortable.Flex` list "flies off the screen"** when reordering. The root cause was a floating-point precision bug in the flex grouping: when the cumulative height of the items overshoots the column's wrap limit by a sub-pixel amount, the last item was pushed into a brand-new column (off to the side) instead of staying in the single vertical column.

This is already fixed on `main` (the `+ 0.1` tolerance in `createGroups`, originally from #347, together with the measured-column `groupSizeLimit = Infinity` behaviour). What was missing is a **regression test** for that grouping logic, which currently has no coverage. This PR adds it so the fix can't silently regress.

Closes #298.

## Before / after

The recordings toggle the `+ 0.1` tolerance to show the exact behaviour the test guards: 10 items of 50px in a column whose `maxHeight` sits 0.05px below their total height (`10 * 50 = 500`, `maxHeight = 499.95`).

| Before (tolerance removed) | After (current `main`) |
| --- | --- |
| _drag `before.gif` here_ | _drag `after.gif` here_ |

In **Before**, the last item (red) is flung into a second column off the right edge. In **After**, every item stays in one column and reorders normally.

## What the test covers

`calculateLayout` (the flex grouping) now has unit coverage for:

- a measured column (`maxHeight: Infinity`) never wrapping - the whole list stays a single group;
- sub-pixel overflow (`< 0.1px`) not spilling the last item into a new group;
- genuine overflow still wrapping - the tolerance does not suppress real wrapping.

Removing the `+ 0.1` tolerance makes the two sub-pixel tests fail (2 groups instead of 1), reproducing the fly-off - so the test actually guards the fix.

<details>
<summary>Debug example used for the recordings</summary>

```tsx
import { StyleSheet, Text, View } from 'react-native';
import Sortable from 'react-native-sortables';

// 10 items of exactly 50px in a column whose wrap limit sits 0.05px below
// their total height (10 * 50 = 500, maxHeight = 499.95). The 10th item's
// cumulative height overshoots the limit by a sub-pixel 0.05px.
const DATA = Array.from({ length: 10 }, (_, i) => `Item ${i + 1}`);

export default function FlexFlyOffExample() {
  return (
    <Sortable.Flex flexDirection="column" maxHeight={499.95}>
      {DATA.map((item, index) => (
        <View
          key={item}
          style={[styles.item, index === DATA.length - 1 && styles.lastItem]}>
          <Text style={styles.text}>{item}</Text>
        </View>
      ))}
    </Sortable.Flex>
  );
}

const styles = StyleSheet.create({
  item: {
    alignItems: 'center',
    backgroundColor: '#36877F',
    height: 50,
    justifyContent: 'center',
    width: 320
  },
  lastItem: { backgroundColor: '#d9534f' },
  text: { color: '#fff', fontSize: 18, fontWeight: '700' }
});
```

</details>

Tested on the Fabric example app on an iOS simulator.
