### PR TITLE
fix: Re-run grid layout after item dimensions settle

### DIFF
--- a/packages/react-native-sortables/src/providers/grid/GridLayoutProvider/GridLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/grid/GridLayoutProvider/GridLayoutProvider.tsx
@@ -57,6 +57,7 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
     itemHeights,
     itemPositions,
     itemWidths,
+    layoutRequestId,
     overriddenCellDimensions,
     shouldAnimateLayout
   } = useCommonValuesContext();
@@ -80,7 +81,6 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
   const crossGap = isVertical ? rowGap : columnGap;
 
   const mainGroupSize = useMutableValue<null | number>(null);
-  const layoutRequestId = useMutableValue(0);
 
   let updateShouldAnimateWeb: null | UpdateShouldAnimateWeb = null;
 

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
@@ -76,6 +76,9 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
     const touchPosition = useMutableValue<null | Vector>(null);
     const activeItemPosition = useMutableValue<null | Vector>(null);
     const itemPositions = useMutableValue<Record<string, Vector>>({});
+    // Bumped to force the layout reaction to re-run (e.g. after item dimensions
+    // settle), so positions can't get stuck stale if a reactive update is missed.
+    const layoutRequestId = useMutableValue(0);
 
     // DIMENSIONS
     const containerWidth = useMutableValue<null | number>(null);
@@ -174,6 +177,7 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
         itemsLayoutTransitionMode,
         itemWidths,
         keyToIndex,
+        layoutRequestId,
         overriddenCellDimensions,
         prevActiveItemKey,
         shouldAnimateLayout,

--- a/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
@@ -43,6 +43,7 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
     controlledItemDimensions,
     itemHeights,
     itemWidths,
+    layoutRequestId,
     usesAbsoluteLayout
   } = useCommonValuesContext();
   const { activeItemDimensions: multiZoneActiveItemDimensions } =
@@ -135,6 +136,15 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
           if (!isHeightControlled) {
             updateDimension('height', itemHeights);
           }
+
+          // Force the layout reaction to re-run a frame later. The reaction that
+          // reads these dimensions isn't guaranteed to re-fire when they settle,
+          // which can leave item positions stuck stale until a drag relayout
+          // (#565). The deferral keeps this on a separate frame from the
+          // dimensions write so it isn't coalesced into the same reaction run.
+          setAnimatedTimeout(() => {
+            layoutRequestId.value += 1;
+          });
 
           ctx.queuedMeasurements.clear();
           debounce.cancel();

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -70,6 +70,7 @@ export type CommonValuesContextType =
       touchPosition: SharedValue<null | Vector>;
       activeItemPosition: SharedValue<null | Vector>;
       itemPositions: SharedValue<Record<string, Vector>>;
+      layoutRequestId: SharedValue<number>;
 
       // DIMENSIONS
       controlledContainerDimensions: ControlledDimensions;


### PR DESCRIPTION
## Description

`Sortable.Grid` could leave a freshly **added** or **replaced** row mispositioned after a non-reorder `data` change — an empty gap, or the new row invisible — until a drag forced a relayout (the reporter's "fixed the instant a drag starts").

Root cause: the layout reaction that turns measured item heights into positions is correctly marked dirty when an item's height settles, but on native its execution depends on Reanimated's per-frame mapper loop being pumped. There are scheduling windows where the dirty layout mapper isn't run until something pumps the loop — and a gesture explicitly does (which is why a drag fixes it). This change forces a relayout once item dimensions settle (reusing the existing `layoutRequestId` mechanism) so positions don't wait for the loop to be pumped.

Closes #565 (related: #286).

> [!NOTE]
> Draft. This is a pragmatic compensation — the underlying trigger is Reanimated's native mapper scheduling, and the bug is intermittent and device/version dependent (it does not reproduce on a fast simulator). Please confirm it resolves the issue on a setup that reproduces before merging. A push-based layout (computing positions in the measurement flush instead of via the reactive mapper) would remove the dependency entirely but is a larger change.
