### PR TITLE
fix: Re-run grid layout after item dimensions settle

### DIFF
--- a/packages/react-native-sortables/src/providers/grid/GridLayoutProvider/GridLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/grid/GridLayoutProvider/GridLayoutProvider.tsx
@@ -57,6 +57,7 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
     itemHeights,
     itemPositions,
     itemWidths,
+    layoutRequestId,
     overriddenCellDimensions,
     shouldAnimateLayout
   } = useCommonValuesContext();
@@ -80,7 +81,6 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
   const crossGap = isVertical ? rowGap : columnGap;
 
   const mainGroupSize = useMutableValue<null | number>(null);
-  const layoutRequestId = useMutableValue(0);
 
   let updateShouldAnimateWeb: null | UpdateShouldAnimateWeb = null;
 

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
@@ -79,6 +79,8 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
     const touchPosition = useMutableValue<null | Vector>(null);
     const activeItemPosition = useMutableValue<null | Vector>(null);
     const itemPositions = useMutableValue<Record<string, Vector>>({});
+    // Bumped to force the grid layout reaction to re-run on demand.
+    const layoutRequestId = useMutableValue(0);
 
     // DIMENSIONS
     const containerWidth = useMutableValue<null | number>(null);
@@ -178,6 +180,7 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
         itemsLayoutTransitionMode,
         itemWidths,
         keyToIndex,
+        layoutRequestId,
         overriddenCellDimensions,
         prevActiveItemKey,
         shouldAnimateLayout,

--- a/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
@@ -43,6 +43,7 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
     controlledItemDimensions,
     itemHeights,
     itemWidths,
+    layoutRequestId,
     usesAbsoluteLayout
   } = useCommonValuesContext();
   const { activeItemDimensions: multiZoneActiveItemDimensions } =
@@ -135,6 +136,13 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
           if (!isHeightControlled) {
             updateDimension('height', itemHeights);
           }
+
+          // Re-run the layout reaction on the next frame - the dimensions write
+          // alone isn't guaranteed to re-trigger it on native, leaving positions
+          // stale until a drag (#565).
+          setAnimatedTimeout(() => {
+            layoutRequestId.value += 1;
+          });
 
           ctx.queuedMeasurements.clear();
           debounce.cancel();

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -71,6 +71,7 @@ export type CommonValuesContextType =
       touchPosition: SharedValue<null | Vector>;
       activeItemPosition: SharedValue<null | Vector>;
       itemPositions: SharedValue<Record<string, Vector>>;
+      layoutRequestId: SharedValue<number>;
 
       // DIMENSIONS
       controlledContainerDimensions: ControlledDimensions;


### PR DESCRIPTION
Fixes https://github.com/MatiPl01/react-native-sortables/issues/565

The grid layout reaction that turns measured item sizes into positions isn't guaranteed to re-run when the sizes settle on native, so adding or replacing a `Sortable.Grid` row could leave a stale gap or blank slot until a drag forced a relayout. This bumps `layoutRequestId` a frame after the dimensions flush to force the recompute.

Supersedes #578.
