### PR TITLE
fix: Re-run grid and flex layout after item sizes settle

### DIFF
--- a/packages/react-native-sortables/src/providers/flex/FlexLayoutProvider/FlexLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/flex/FlexLayoutProvider/FlexLayoutProvider.tsx
@@ -64,6 +64,7 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
     itemHeights,
     itemPositions,
     itemWidths,
+    layoutRequestId,
     shouldAnimateLayout
   } = useCommonValuesContext();
   const { applyControlledContainerDimensions } = useMeasurementsContext();
@@ -157,7 +158,8 @@ const { FlexLayoutProvider, useFlexLayoutContext } = createProvider(
       itemHeights: itemHeights.value,
       itemWidths: itemWidths.value,
       limits: dimensionsLimits.value,
-      paddings
+      paddings,
+      requestId: layoutRequestId.value // Helper to force layout re-calculation
     }),
     (props, previousProps) => {
       const layout = calculateLayout(props);

--- a/packages/react-native-sortables/src/providers/grid/GridLayoutProvider/GridLayoutProvider.tsx
+++ b/packages/react-native-sortables/src/providers/grid/GridLayoutProvider/GridLayoutProvider.tsx
@@ -57,6 +57,7 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
     itemHeights,
     itemPositions,
     itemWidths,
+    layoutRequestId,
     overriddenCellDimensions,
     shouldAnimateLayout
   } = useCommonValuesContext();
@@ -80,7 +81,6 @@ const { GridLayoutProvider, useGridLayoutContext } = createProvider(
   const crossGap = isVertical ? rowGap : columnGap;
 
   const mainGroupSize = useMutableValue<null | number>(null);
-  const layoutRequestId = useMutableValue(0);
 
   let updateShouldAnimateWeb: null | UpdateShouldAnimateWeb = null;
 

--- a/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/CommonValuesProvider.ts
@@ -79,6 +79,8 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
     const touchPosition = useMutableValue<null | Vector>(null);
     const activeItemPosition = useMutableValue<null | Vector>(null);
     const itemPositions = useMutableValue<Record<string, Vector>>({});
+    // Bumped to force the layout reaction to re-run after item sizes settle.
+    const layoutRequestId = useMutableValue(0);
 
     // DIMENSIONS
     const containerWidth = useMutableValue<null | number>(null);
@@ -178,6 +180,7 @@ const { CommonValuesContext, CommonValuesProvider, useCommonValuesContext } =
         itemsLayoutTransitionMode,
         itemWidths,
         keyToIndex,
+        layoutRequestId,
         overriddenCellDimensions,
         prevActiveItemKey,
         shouldAnimateLayout,

--- a/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
@@ -43,6 +43,7 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
     controlledItemDimensions,
     itemHeights,
     itemWidths,
+    layoutRequestId,
     usesAbsoluteLayout
   } = useCommonValuesContext();
   const { activeItemDimensions: multiZoneActiveItemDimensions } =
@@ -135,6 +136,13 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
           if (!isHeightControlled) {
             updateDimension('height', itemHeights);
           }
+
+          // Re-run the layout reaction on the next frame - the dimensions write
+          // alone isn't guaranteed to re-trigger it on native, leaving positions
+          // stale until a drag (#565).
+          setAnimatedTimeout(() => {
+            layoutRequestId.value += 1;
+          });
 
           ctx.queuedMeasurements.clear();
           debounce.cancel();

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -71,6 +71,7 @@ export type CommonValuesContextType =
       touchPosition: SharedValue<null | Vector>;
       activeItemPosition: SharedValue<null | Vector>;
       itemPositions: SharedValue<Record<string, Vector>>;
+      layoutRequestId: SharedValue<number>;
 
       // DIMENSIONS
       controlledContainerDimensions: ControlledDimensions;


### PR DESCRIPTION
Fixes https://github.com/MatiPl01/react-native-sortables/issues/565

The grid and flex layout reactions that map measured item sizes to positions aren't guaranteed to re-run when the sizes settle on native, so adding or replacing an item could leave a stale gap or blank slot until a drag forced a relayout. This bumps a shared `layoutRequestId` a frame after the dimensions flush, forcing whichever layout reaction is mounted (grid or flex) to re-run.

Covers both `Sortable.Grid` and `Sortable.Flex`. Supersedes #580 (grid-only).
