### PR TITLE
docs: Document gesture-handler v2 and v3 compatibility

### DIFF
--- a/packages/docs/docs/getting-started.mdx
+++ b/packages/docs/docs/getting-started.mdx
@@ -10,12 +10,20 @@ Before getting started, you need to install and configure the following dependen
 
 ### Required Dependencies
 
-- **react-native-reanimated**: Required for animations
+- **react-native-reanimated** (`3.x` or `4.x`): Required for animations
 
   - Follow the installation guide in [react-native-reanimated](https://docs.swmansion.com/react-native-reanimated/) docs
 
-- **react-native-gesture-handler**: Required for gesture handling
+- **react-native-gesture-handler** (`2.x` or `3.x`): Required for gesture handling
   - Follow the installation guide in [react-native-gesture-handler](https://docs.swmansion.com/react-native-gesture-handler/) docs
+
+:::info Gesture Handler compatibility
+
+On iOS with the New Architecture, gesture-handler `2.x` has a known limitation: a sortable can stop recognizing drags after its screen is detached and re-attached (for example bottom tabs with `detachInactiveScreens={false}`), which can leave a dragged item stuck (see [#349](https://github.com/MatiPl01/react-native-sortables/issues/349)).
+
+This is not fixable on the `2.x` API and is resolved by gesture-handler `3.x`, which the library uses automatically when it is installed. Gesture Handler `3.x` requires the New Architecture, so on the Old Architecture (Paper) keep using `2.x`, where the issue does not occur.
+
+:::
 
 ### Optional Dependencies
 


### PR DESCRIPTION
Stacked on #573.

Documents that the library supports gesture-handler 2.x and 3.x (and reanimated 3.x/4.x), and adds a Getting Started note mirroring the README: gesture-handler 2.x has an iOS + New Architecture limitation (a sortable can stop recognizing drags after a screen is detached and re-attached, issue #349) that is fixed by gesture-handler 3.x, which the library uses automatically when installed. v3 requires the New Architecture; the Old Architecture (Paper) keeps 2.x, where the issue does not occur.