### PR TITLE
fix: Sortable.Touchable crash on gesture-handler v3 (onActivate not a worklet)

### DIFF
--- a/packages/react-native-sortables/src/components/shared/SortableTouchable.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableTouchable.tsx
@@ -19,6 +19,7 @@ type SortableTouchableProps = PropsWithChildren<
 >;
 
 export default function SortableTouchable({
+  children,
   failDistance = 10,
   gestureMode = 'exclusive',
   onDoubleTap,
@@ -26,8 +27,18 @@ export default function SortableTouchable({
   onTap,
   onTouchesDown,
   onTouchesUp,
-  ...rest
+  ...viewProps
 }: SortableTouchableProps) {
+  // No callbacks means no gestures at all - render just the view and skip the
+  // gesture detector entirely.
+  if (!(onTap ?? onDoubleTap ?? onLongPress ?? onTouchesDown ?? onTouchesUp)) {
+    return (
+      <View {...viewProps} collapsable={false}>
+        {children}
+      </View>
+    );
+  }
+
   // The inner component creates a gesture only for the handlers that exist, so
   // its hook order depends on which handlers are set. Remount when that set (or
   // the mode) changes so the hook order stays stable within a mount.
@@ -43,8 +54,9 @@ export default function SortableTouchable({
       onTap={onTap}
       onTouchesDown={onTouchesDown}
       onTouchesUp={onTouchesUp}
-      {...rest}
-    />
+      {...viewProps}>
+      {children}
+    </TouchableGesture>
   );
 }
 

--- a/packages/react-native-sortables/src/components/shared/SortableTouchable.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableTouchable.tsx
@@ -2,6 +2,7 @@ import { type PropsWithChildren } from 'react';
 import type { ViewProps } from 'react-native';
 import { View } from 'react-native';
 
+import type { RequiredBy } from '../../helperTypes';
 import { useTouchableGesture } from '../../integrations/gesture-handler';
 import { useItemContext } from '../../providers';
 import SortableGestureDetector from './SortableGestureDetector';
@@ -62,10 +63,10 @@ export default function SortableTouchable({
 
 // Same props as the public component, but the inner component receives
 // `failDistance`/`gestureMode` already resolved to defaults.
-type TouchableGestureProps = Required<
-  Pick<SortableTouchableProps, 'failDistance' | 'gestureMode'>
-> &
-  SortableTouchableProps;
+type TouchableGestureProps = RequiredBy<
+  SortableTouchableProps,
+  'failDistance' | 'gestureMode'
+>;
 
 function TouchableGesture({
   children,

--- a/packages/react-native-sortables/src/components/shared/SortableTouchable.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableTouchable.tsx
@@ -19,7 +19,6 @@ type SortableTouchableProps = PropsWithChildren<
 >;
 
 export default function SortableTouchable({
-  children,
   failDistance = 10,
   gestureMode = 'exclusive',
   onDoubleTap,
@@ -27,8 +26,51 @@ export default function SortableTouchable({
   onTap,
   onTouchesDown,
   onTouchesUp,
-  ...viewProps
+  ...rest
 }: SortableTouchableProps) {
+  // The inner component creates a gesture only for the handlers that exist, so
+  // its hook order depends on which handlers are set. Remount when that set (or
+  // the mode) changes so the hook order stays stable within a mount.
+  const gesturesKey = `${gestureMode}:${+!!onTap}${+!!onDoubleTap}${+!!onLongPress}${+!!onTouchesDown}${+!!onTouchesUp}`;
+
+  return (
+    <TouchableGesture
+      failDistance={failDistance}
+      gestureMode={gestureMode}
+      key={gesturesKey}
+      onDoubleTap={onDoubleTap}
+      onLongPress={onLongPress}
+      onTap={onTap}
+      onTouchesDown={onTouchesDown}
+      onTouchesUp={onTouchesUp}
+      {...rest}
+    />
+  );
+}
+
+type TouchableGestureProps = PropsWithChildren<
+  ViewProps & {
+    failDistance: number;
+    gestureMode: 'exclusive' | 'simultaneous';
+    onTap?: () => void;
+    onDoubleTap?: () => void;
+    onLongPress?: () => void;
+    onTouchesDown?: () => void;
+    onTouchesUp?: () => void;
+  }
+>;
+
+function TouchableGesture({
+  children,
+  failDistance,
+  gestureMode,
+  onDoubleTap,
+  onLongPress,
+  onTap,
+  onTouchesDown,
+  onTouchesUp,
+  ...viewProps
+}: TouchableGestureProps) {
   const { gesture: externalGesture } = useItemContext();
 
   const gesture = useTouchableGesture({

--- a/packages/react-native-sortables/src/components/shared/SortableTouchable.tsx
+++ b/packages/react-native-sortables/src/components/shared/SortableTouchable.tsx
@@ -60,17 +60,12 @@ export default function SortableTouchable({
   );
 }
 
-type TouchableGestureProps = PropsWithChildren<
-  ViewProps & {
-    failDistance: number;
-    gestureMode: 'exclusive' | 'simultaneous';
-    onTap?: () => void;
-    onDoubleTap?: () => void;
-    onLongPress?: () => void;
-    onTouchesDown?: () => void;
-    onTouchesUp?: () => void;
-  }
->;
+// Same props as the public component, but the inner component receives
+// `failDistance`/`gestureMode` already resolved to defaults.
+type TouchableGestureProps = Required<
+  Pick<SortableTouchableProps, 'failDistance' | 'gestureMode'>
+> &
+  SortableTouchableProps;
 
 function TouchableGesture({
   children,

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.test.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import * as GestureHandler from 'react-native-gesture-handler';
+import { isWorkletFunction } from 'react-native-reanimated';
 
 import { useDragGesture, useTouchableGesture } from '../index';
 import type { ManualGestureCallbacks } from '../types';
@@ -43,17 +44,15 @@ it('selects the v3 adapter and wires the drag callbacks into the manual hook', (
   expect(typeof config.onTouchesUp).toBe('function');
 });
 
-it('keeps worklet touchable handlers on the reanimated detector and JS ones off it', () => {
-  const jsTap = jest.fn();
-  const workletLongPress = Object.assign(jest.fn(), { __workletHash: 1 });
+it('wraps touchable handlers into worklets so JS callbacks do not reach the detector raw', () => {
+  const onTap = jest.fn();
 
   renderHook(() =>
     useTouchableGesture({
       externalGesture: {},
       failDistance: 10,
       gestureMode: 'exclusive',
-      onLongPress: workletLongPress,
-      onTap: jsTap,
+      onTap,
       onTouchesDown: jest.fn()
     })
   );
@@ -61,16 +60,14 @@ it('keeps worklet touchable handlers on the reanimated detector and JS ones off 
   const configOf = (mock: jest.Mock) =>
     mock.mock.calls.map(([config]) => config as Record<string, unknown>);
 
-  // Plain JS handlers opt out of the reanimated detector (its `useHandler`
-  // rejects non-worklets); worklet handlers keep it and run on the UI thread.
+  // The raw JS handler is wrapped into a worklet, so the reanimated detector's
+  // `useHandler` never sees a non-worklet (which would throw at render).
   const tapConfig = configOf(mocked.useTapGesture).find(
-    config => config.onActivate === jsTap
+    config => config.onActivate !== undefined
   );
-  expect(tapConfig?.disableReanimated).toBe(true);
+  expect(tapConfig?.onActivate).not.toBe(onTap);
+  expect(isWorkletFunction(tapConfig?.onActivate)).toBe(true);
 
-  const [longPressConfig] = configOf(mocked.useLongPressGesture);
-  expect(longPressConfig?.onActivate).toBe(workletLongPress);
-  expect(longPressConfig?.disableReanimated).toBe(false);
-
-  expect(configOf(mocked.useManualGesture)[0]?.disableReanimated).toBe(true);
+  const [manualConfig] = configOf(mocked.useManualGesture);
+  expect(isWorkletFunction(manualConfig?.onTouchesDown)).toBe(true);
 });

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.test.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.test.ts
@@ -44,7 +44,7 @@ it('selects the v3 adapter and wires the drag callbacks into the manual hook', (
   expect(typeof config.onTouchesUp).toBe('function');
 });
 
-it('wraps touchable handlers into worklets so JS callbacks do not reach the detector raw', () => {
+it('creates a gesture only for the handlers that are provided and wraps them as worklets', () => {
   const onTap = jest.fn();
 
   renderHook(() =>
@@ -52,22 +52,40 @@ it('wraps touchable handlers into worklets so JS callbacks do not reach the dete
       externalGesture: {},
       failDistance: 10,
       gestureMode: 'exclusive',
-      onTap,
-      onTouchesDown: jest.fn()
+      onTap
     })
   );
 
-  const configOf = (mock: jest.Mock) =>
-    mock.mock.calls.map(([config]) => config as Record<string, unknown>);
+  // Only onTap -> a single tap gesture; no long-press or manual gesture (so no
+  // native handlers for callbacks the user never set).
+  expect(mocked.useTapGesture).toHaveBeenCalledTimes(1);
+  expect(mocked.useLongPressGesture).not.toHaveBeenCalled();
+  expect(mocked.useManualGesture).not.toHaveBeenCalled();
 
   // The raw JS handler is wrapped into a worklet, so the reanimated detector's
   // `useHandler` never sees a non-worklet (which would throw at render).
-  const tapConfig = configOf(mocked.useTapGesture).find(
-    config => config.onActivate !== undefined
-  );
-  expect(tapConfig?.onActivate).not.toBe(onTap);
-  expect(isWorkletFunction(tapConfig?.onActivate)).toBe(true);
+  const [tapConfig] = mocked.useTapGesture.mock.calls[0] as [
+    Record<string, unknown>
+  ];
+  expect(tapConfig.onActivate).not.toBe(onTap);
+  expect(isWorkletFunction(tapConfig.onActivate)).toBe(true);
+});
 
-  const [manualConfig] = configOf(mocked.useManualGesture);
-  expect(isWorkletFunction(manualConfig?.onTouchesDown)).toBe(true);
+it('creates tap, double-tap, long-press and manual gestures when every handler is set', () => {
+  renderHook(() =>
+    useTouchableGesture({
+      externalGesture: {},
+      failDistance: 10,
+      gestureMode: 'exclusive',
+      onDoubleTap: jest.fn(),
+      onLongPress: jest.fn(),
+      onTap: jest.fn(),
+      onTouchesDown: jest.fn(),
+      onTouchesUp: jest.fn()
+    })
+  );
+
+  expect(mocked.useTapGesture).toHaveBeenCalledTimes(2);
+  expect(mocked.useLongPressGesture).toHaveBeenCalledTimes(1);
+  expect(mocked.useManualGesture).toHaveBeenCalledTimes(1);
 });

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.test.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.test.ts
@@ -43,38 +43,34 @@ it('selects the v3 adapter and wires the drag callbacks into the manual hook', (
   expect(typeof config.onTouchesUp).toBe('function');
 });
 
-it('disables the reanimated detector for touchable JS callbacks', () => {
-  const onTap = jest.fn();
+it('keeps worklet touchable handlers on the reanimated detector and JS ones off it', () => {
+  const jsTap = jest.fn();
+  const workletLongPress = Object.assign(jest.fn(), { __workletHash: 1 });
 
   renderHook(() =>
     useTouchableGesture({
       externalGesture: {},
       failDistance: 10,
       gestureMode: 'exclusive',
-      onLongPress: jest.fn(),
-      onTap,
+      onLongPress: workletLongPress,
+      onTap: jsTap,
       onTouchesDown: jest.fn()
     })
   );
 
-  // Touchable handlers are plain JS callbacks, not worklets. Every gesture must
-  // set `disableReanimated` so reanimated's `useHandler` (which rejects
-  // non-worklet handlers) never runs - `runOnJS` alone does not skip that check.
   const configOf = (mock: jest.Mock) =>
     mock.mock.calls.map(([config]) => config as Record<string, unknown>);
 
-  for (const config of configOf(mocked.useTapGesture)) {
-    expect(config.disableReanimated).toBe(true);
-  }
-  for (const config of configOf(mocked.useLongPressGesture)) {
-    expect(config.disableReanimated).toBe(true);
-  }
-  for (const config of configOf(mocked.useManualGesture)) {
-    expect(config.disableReanimated).toBe(true);
-  }
+  // Plain JS handlers opt out of the reanimated detector (its `useHandler`
+  // rejects non-worklets); worklet handlers keep it and run on the UI thread.
+  const tapConfig = configOf(mocked.useTapGesture).find(
+    config => config.onActivate === jsTap
+  );
+  expect(tapConfig?.disableReanimated).toBe(true);
 
-  // The JS callback is forwarded untouched as the tap handler.
-  expect(
-    configOf(mocked.useTapGesture).some(config => config.onActivate === onTap)
-  ).toBe(true);
+  const [longPressConfig] = configOf(mocked.useLongPressGesture);
+  expect(longPressConfig?.onActivate).toBe(workletLongPress);
+  expect(longPressConfig?.disableReanimated).toBe(false);
+
+  expect(configOf(mocked.useManualGesture)[0]?.disableReanimated).toBe(true);
 });

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.test.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import * as GestureHandler from 'react-native-gesture-handler';
 
-import { useDragGesture } from '../index';
+import { useDragGesture, useTouchableGesture } from '../index';
 import type { ManualGestureCallbacks } from '../types';
 
 // gesture-handler with the hook API present -> the integration must select the
@@ -13,12 +13,19 @@ jest.mock('react-native-gesture-handler', () => ({
     deactivate: jest.fn(),
     fail: jest.fn()
   },
-  useManualGesture: jest.fn(() => ({ config: {}, handlerTag: 1 }))
+  useExclusiveGestures: jest.fn(() => ({})),
+  useLongPressGesture: jest.fn(() => ({ handlerTag: 3 })),
+  useManualGesture: jest.fn(() => ({ config: {}, handlerTag: 1 })),
+  useSimultaneousGestures: jest.fn(() => ({})),
+  useTapGesture: jest.fn(() => ({ handlerTag: 2 }))
 }));
 
-const useManualGesture = (
-  GestureHandler as unknown as { useManualGesture: jest.Mock }
-).useManualGesture;
+const mocked = GestureHandler as unknown as {
+  useLongPressGesture: jest.Mock;
+  useManualGesture: jest.Mock;
+  useTapGesture: jest.Mock;
+};
+const useManualGesture = mocked.useManualGesture;
 
 const callbacks: ManualGestureCallbacks = {
   onTouchesCancelled: jest.fn(),
@@ -34,4 +41,40 @@ it('selects the v3 adapter and wires the drag callbacks into the manual hook', (
   const [config] = useManualGesture.mock.calls[0] as [Record<string, unknown>];
   expect(typeof config.onTouchesDown).toBe('function');
   expect(typeof config.onTouchesUp).toBe('function');
+});
+
+it('disables the reanimated detector for touchable JS callbacks', () => {
+  const onTap = jest.fn();
+
+  renderHook(() =>
+    useTouchableGesture({
+      externalGesture: {},
+      failDistance: 10,
+      gestureMode: 'exclusive',
+      onLongPress: jest.fn(),
+      onTap,
+      onTouchesDown: jest.fn()
+    })
+  );
+
+  // Touchable handlers are plain JS callbacks, not worklets. Every gesture must
+  // set `disableReanimated` so reanimated's `useHandler` (which rejects
+  // non-worklet handlers) never runs - `runOnJS` alone does not skip that check.
+  const configOf = (mock: jest.Mock) =>
+    mock.mock.calls.map(([config]) => config as Record<string, unknown>);
+
+  for (const config of configOf(mocked.useTapGesture)) {
+    expect(config.disableReanimated).toBe(true);
+  }
+  for (const config of configOf(mocked.useLongPressGesture)) {
+    expect(config.disableReanimated).toBe(true);
+  }
+  for (const config of configOf(mocked.useManualGesture)) {
+    expect(config.disableReanimated).toBe(true);
+  }
+
+  // The JS callback is forwarded untouched as the tap handler.
+  expect(
+    configOf(mocked.useTapGesture).some(config => config.onActivate === onTap)
+  ).toBe(true);
 });

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
@@ -109,55 +109,69 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
   onTouchesDown,
   onTouchesUp
 }) => {
-  // Related to every touchable gesture; `simultaneousWith` accepts v3's
-  // `AnyGesture` union, which is not exported by name.
+  // `simultaneousWith` accepts v3's `AnyGesture` union, which is not exported
+  // by name.
   const simultaneousWith =
     externalGesture as unknown as ManualGestureConfig['simultaneousWith'];
 
-  // Wrap into worklets so a worklet handler runs on the UI thread and a JS
-  // handler is marshalled to the JS thread - the reanimated detector requires
-  // worklets and rejects raw JS callbacks.
-  const tapHandler = useStableCallbackValue(onTap);
-  const doubleTapHandler = useStableCallbackValue(onDoubleTap);
-  const longPressHandler = useStableCallbackValue(onLongPress);
-  const touchesDownHandler = useStableCallbackValue(onTouchesDown);
-  const touchesUpHandler = useStableCallbackValue(onTouchesUp);
+  // Only the handlers the caller passed create a gesture (and a native
+  // handler), so a touchable with a single callback stays a single gesture.
+  // `useStableCallbackValue` makes each one a worklet - a worklet handler runs
+  // on the UI thread, a JS handler is marshalled to the JS thread - which the
+  // reanimated detector requires. SortableTouchable remounts when the set of
+  // handlers or the mode changes, keeping these gated hooks in a stable order.
+  /* eslint-disable react-hooks/rules-of-hooks */
+  const gestures: Parameters<typeof useExclusiveGestures> = [];
 
-  const tap = useTapGesture({
-    enabled: !!onTap,
-    maxDistance: failDistance,
-    onActivate: onTap ? tapHandler : undefined,
-    simultaneousWith
-  });
-  const doubleTap = useTapGesture({
-    enabled: !!onDoubleTap,
-    maxDistance: failDistance,
-    numberOfTaps: 2,
-    onActivate: onDoubleTap ? doubleTapHandler : undefined,
-    simultaneousWith
-  });
-  const longPress = useLongPressGesture({
-    enabled: !!onLongPress,
-    maxDistance: failDistance,
-    onActivate: onLongPress ? longPressHandler : undefined,
-    simultaneousWith
-  });
-  const manual = useManualGesture({
-    enabled: !!(onTouchesDown ?? onTouchesUp),
-    onTouchesDown: onTouchesDown ? touchesDownHandler : undefined,
-    onTouchesUp: onTouchesUp ? touchesUpHandler : undefined,
-    simultaneousWith
-  });
+  if (onTap) {
+    gestures.push(
+      useTapGesture({
+        maxDistance: failDistance,
+        onActivate: useStableCallbackValue(onTap),
+        simultaneousWith
+      })
+    );
+  }
+  if (onDoubleTap) {
+    gestures.push(
+      useTapGesture({
+        maxDistance: failDistance,
+        numberOfTaps: 2,
+        onActivate: useStableCallbackValue(onDoubleTap),
+        simultaneousWith
+      })
+    );
+  }
+  if (onLongPress) {
+    gestures.push(
+      useLongPressGesture({
+        maxDistance: failDistance,
+        onActivate: useStableCallbackValue(onLongPress),
+        simultaneousWith
+      })
+    );
+  }
+  if (onTouchesDown ?? onTouchesUp) {
+    gestures.push(
+      useManualGesture({
+        onTouchesDown: onTouchesDown
+          ? useStableCallbackValue(onTouchesDown)
+          : undefined,
+        onTouchesUp: onTouchesUp
+          ? useStableCallbackValue(onTouchesUp)
+          : undefined,
+        simultaneousWith
+      })
+    );
+  }
 
-  const exclusive = useExclusiveGestures(tap, doubleTap, longPress, manual);
-  const simultaneous = useSimultaneousGestures(
-    tap,
-    doubleTap,
-    longPress,
-    manual
-  );
+  const gesture =
+    gestureMode === 'exclusive'
+      ? useExclusiveGestures(...gestures)
+      : useSimultaneousGestures(...gestures);
+  /* eslint-enable react-hooks/rules-of-hooks */
 
-  return gestureMode === 'exclusive' ? exclusive : simultaneous;
+  return gesture;
 };
 
 export const adapter: GestureHandlerAdapter = {

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
@@ -3,16 +3,11 @@ import type {
   ManualGestureConfig
 } from 'react-native-gesture-handler';
 import * as GestureHandler from 'react-native-gesture-handler';
-import { isWorkletFunction, type SharedValue } from 'react-native-reanimated';
+import type { SharedValue } from 'react-native-reanimated';
 
-import { useMutableValue } from '../../reanimated';
+import { useMutableValue, useStableCallbackValue } from '../../reanimated';
 import type { ManualGestureControl } from '../types';
 import type { GestureHandlerAdapter } from './types';
-
-// A plain-JS handler must opt out of the reanimated detector (its `useHandler`
-// rejects non-worklets); a worklet handler keeps it and runs on the UI thread.
-const runsOnJS = (handler?: () => void) =>
-  handler !== undefined && !isWorkletFunction(handler);
 
 // gesture-handler v3 hook API, which fixes issue #349: hook gestures keep
 // receiving touches after a screen re-attaches. Hooks are read off a namespace
@@ -119,33 +114,38 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
   const simultaneousWith =
     externalGesture as unknown as ManualGestureConfig['simultaneousWith'];
 
+  // Wrap into worklets so a worklet handler runs on the UI thread and a JS
+  // handler is marshalled to the JS thread - the reanimated detector requires
+  // worklets and rejects raw JS callbacks.
+  const tapHandler = useStableCallbackValue(onTap);
+  const doubleTapHandler = useStableCallbackValue(onDoubleTap);
+  const longPressHandler = useStableCallbackValue(onLongPress);
+  const touchesDownHandler = useStableCallbackValue(onTouchesDown);
+  const touchesUpHandler = useStableCallbackValue(onTouchesUp);
+
   const tap = useTapGesture({
-    disableReanimated: runsOnJS(onTap),
     enabled: !!onTap,
     maxDistance: failDistance,
-    onActivate: onTap,
+    onActivate: onTap ? tapHandler : undefined,
     simultaneousWith
   });
   const doubleTap = useTapGesture({
-    disableReanimated: runsOnJS(onDoubleTap),
     enabled: !!onDoubleTap,
     maxDistance: failDistance,
     numberOfTaps: 2,
-    onActivate: onDoubleTap,
+    onActivate: onDoubleTap ? doubleTapHandler : undefined,
     simultaneousWith
   });
   const longPress = useLongPressGesture({
-    disableReanimated: runsOnJS(onLongPress),
     enabled: !!onLongPress,
     maxDistance: failDistance,
-    onActivate: onLongPress,
+    onActivate: onLongPress ? longPressHandler : undefined,
     simultaneousWith
   });
   const manual = useManualGesture({
-    disableReanimated: runsOnJS(onTouchesDown) || runsOnJS(onTouchesUp),
     enabled: !!(onTouchesDown ?? onTouchesUp),
-    onTouchesDown,
-    onTouchesUp,
+    onTouchesDown: onTouchesDown ? touchesDownHandler : undefined,
+    onTouchesUp: onTouchesUp ? touchesUpHandler : undefined,
     simultaneousWith
   });
 

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
@@ -114,34 +114,39 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
   const simultaneousWith =
     externalGesture as unknown as ManualGestureConfig['simultaneousWith'];
 
+  // Touchable callbacks are plain JS functions, not worklets. In v3 that
+  // requires `disableReanimated` (not `runOnJS`): the reanimated detector runs
+  // `useHandler`, which rejects non-worklet handlers, so the reanimated path
+  // has to be turned off entirely - the same config gesture-handler's own
+  // Touchable/Pressable use for their JS handlers.
   // Hooks run unconditionally; gestures without a handler stay disabled.
   const tap = useTapGesture({
+    disableReanimated: true,
     enabled: !!onTap,
     maxDistance: failDistance,
     onActivate: onTap,
-    runOnJS: true,
     simultaneousWith
   });
   const doubleTap = useTapGesture({
+    disableReanimated: true,
     enabled: !!onDoubleTap,
     maxDistance: failDistance,
     numberOfTaps: 2,
     onActivate: onDoubleTap,
-    runOnJS: true,
     simultaneousWith
   });
   const longPress = useLongPressGesture({
+    disableReanimated: true,
     enabled: !!onLongPress,
     maxDistance: failDistance,
     onActivate: onLongPress,
-    runOnJS: true,
     simultaneousWith
   });
   const manual = useManualGesture({
+    disableReanimated: true,
     enabled: !!(onTouchesDown ?? onTouchesUp),
     onTouchesDown,
     onTouchesUp,
-    runOnJS: true,
     simultaneousWith
   });
 

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
@@ -3,11 +3,16 @@ import type {
   ManualGestureConfig
 } from 'react-native-gesture-handler';
 import * as GestureHandler from 'react-native-gesture-handler';
-import type { SharedValue } from 'react-native-reanimated';
+import { isWorkletFunction, type SharedValue } from 'react-native-reanimated';
 
 import { useMutableValue } from '../../reanimated';
 import type { ManualGestureControl } from '../types';
 import type { GestureHandlerAdapter } from './types';
+
+// A plain-JS handler must opt out of the reanimated detector (its `useHandler`
+// rejects non-worklets); a worklet handler keeps it and runs on the UI thread.
+const runsOnJS = (handler?: () => void) =>
+  handler !== undefined && !isWorkletFunction(handler);
 
 // gesture-handler v3 hook API, which fixes issue #349: hook gestures keep
 // receiving touches after a screen re-attaches. Hooks are read off a namespace
@@ -114,21 +119,15 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
   const simultaneousWith =
     externalGesture as unknown as ManualGestureConfig['simultaneousWith'];
 
-  // Touchable callbacks are plain JS functions, not worklets. In v3 that
-  // requires `disableReanimated` (not `runOnJS`): the reanimated detector runs
-  // `useHandler`, which rejects non-worklet handlers, so the reanimated path
-  // has to be turned off entirely - the same config gesture-handler's own
-  // Touchable/Pressable use for their JS handlers.
-  // Hooks run unconditionally; gestures without a handler stay disabled.
   const tap = useTapGesture({
-    disableReanimated: true,
+    disableReanimated: runsOnJS(onTap),
     enabled: !!onTap,
     maxDistance: failDistance,
     onActivate: onTap,
     simultaneousWith
   });
   const doubleTap = useTapGesture({
-    disableReanimated: true,
+    disableReanimated: runsOnJS(onDoubleTap),
     enabled: !!onDoubleTap,
     maxDistance: failDistance,
     numberOfTaps: 2,
@@ -136,14 +135,14 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
     simultaneousWith
   });
   const longPress = useLongPressGesture({
-    disableReanimated: true,
+    disableReanimated: runsOnJS(onLongPress),
     enabled: !!onLongPress,
     maxDistance: failDistance,
     onActivate: onLongPress,
     simultaneousWith
   });
   const manual = useManualGesture({
-    disableReanimated: true,
+    disableReanimated: runsOnJS(onTouchesDown) || runsOnJS(onTouchesUp),
     enabled: !!(onTouchesDown ?? onTouchesUp),
     onTouchesDown,
     onTouchesUp,

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
@@ -99,6 +99,11 @@ const useEnabledGesture: GestureHandlerAdapter['useEnabledGesture'] = (
   return next;
 };
 
+// Only the handlers that are passed create a gesture (and a native handler), so
+// a touchable with a single callback stays a single gesture. That makes the
+// hook order depend on which handlers exist, so a caller MUST keep that set
+// (and `gestureMode`) stable across renders, or remount when it changes -
+// SortableTouchable enforces this by keying its inner component on the set.
 const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
   externalGesture,
   failDistance,
@@ -114,12 +119,9 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
   const simultaneousWith =
     externalGesture as unknown as ManualGestureConfig['simultaneousWith'];
 
-  // Only the handlers the caller passed create a gesture (and a native
-  // handler), so a touchable with a single callback stays a single gesture.
-  // `useStableCallbackValue` makes each one a worklet - a worklet handler runs
+  // `useStableCallbackValue` wraps each handler into a worklet - a worklet runs
   // on the UI thread, a JS handler is marshalled to the JS thread - which the
-  // reanimated detector requires. SortableTouchable remounts when the set of
-  // handlers or the mode changes, keeping these gated hooks in a stable order.
+  // reanimated detector requires.
   /* eslint-disable react-hooks/rules-of-hooks */
   const gestures: Parameters<typeof useExclusiveGestures> = [];
 


### PR DESCRIPTION
`Sortable.Touchable` with an `onTap` / `onLongPress` / `onTouchesDown` / `onTouchesUp` handler crashes at render on gesture-handler v3:

> [Reanimated] Passed handlers that are not worklets. Only worklet functions are allowed. Handlers "onActivate" are not worklets.

The v3 touchable adapter set `runOnJS: true` on the tap/doubleTap/longPress/manual gestures, mirroring v2's `.runOnJS(true)`. In v3 that is not enough: `useGestureCallbacks` runs reanimated's `useHandler` (which rejects non-worklet handlers) unless `disableReanimated: true` is set, and the touchable callbacks are plain JS. gesture-handler's own `Touchable` / `Pressable` components set `disableReanimated: true` for the same reason. The bug surfaced once the fabric example moved to gesture-handler v3.

This sets `disableReanimated: true` on those four gestures (the drag gesture keeps its worklet handlers untouched) and adds a regression test that fails if it reverts to `runOnJS`.

Verified on the fabric (gesture-handler v3) example on iOS: `SortableGrid > Touchable` and `SortableGrid > Data Change` render and respond to taps without the redbox.