### PR TITLE
fix: Deduplicate expo example native modules for expo-doctor

### DIFF
--- a/example/expo/package.json
+++ b/example/expo/package.json
@@ -21,7 +21,6 @@
     "react-native-reanimated": "4.5.1",
     "react-native-safe-area-context": "5.7.0",
     "react-native-screens": "4.25.2",
-    "react-native-sortables": "workspace:*",
     "react-native-svg": "15.15.4",
     "react-native-worklets": "0.10.1"
   },
@@ -31,7 +30,6 @@
     "typescript": "~5.9.2"
   },
   "installConfig": {
-    "hoistingLimits": "workspaces",
     "selfReferences": false
   },
   "main": "index.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8497,7 +8497,6 @@ __metadata:
     react-native-reanimated: "npm:4.5.1"
     react-native-safe-area-context: "npm:5.7.0"
     react-native-screens: "npm:4.25.2"
-    react-native-sortables: "workspace:*"
     react-native-svg: "npm:15.15.4"
     react-native-worklets: "npm:0.10.1"
     typescript: "npm:~5.9.2"


### PR DESCRIPTION
After #589, the `Build Expo App` CI job fails `npx expo-doctor` on the duplicate-dependencies check.

The expo example set `installConfig.hoistingLimits: "workspaces"`, which nested its declared dependencies under `example/expo/node_modules` instead of hoisting them to the monorepo root, so react, react-native, reanimated and worklets each existed twice. It also declared `react-native-sortables`, which made expo-doctor walk into the library and flag its gesture-handler v3 test devDep against the app's v2.

Dropping both lets every dependency hoist and dedupe against the shared example-app copies. Expo keeps declaring its other native deps because, unlike fabric/paper, it has no `react-native.config.js` + `getDependencies` helper and autolinks from its own `package.json`. The library stays resolvable because it is JS-only and metro still resolves it as a workspace package.

Verified: expo-doctor's duplicate check passes, `expo prebuild` + pod install resolve every native module from the monorepo root, and a full `expo run:ios` builds, launches and renders the example.
