### PR TITLE
fix: Item can settle on another item's slot after a rapid re-order

### DIFF
--- a/packages/react-native-sortables/src/providers/shared/hooks/useItemLayout.ts
+++ b/packages/react-native-sortables/src/providers/shared/hooks/useItemLayout.ts
@@ -241,9 +241,15 @@ export default function useItemLayout(
         shouldAnimateLayout.value &&
         (!animateLayoutOnReorderOnly.value || activeItemKey.value !== null)
       ) {
-        // Compare against the current position so sub-pixel changes accumulate
-        // (the previous reaction input advances even when the update is skipped)
-        if (!areVectorsDifferent(position.value, layoutPos, 1)) {
+        // Skip when already at the target and it did not just change. A
+        // re-order that flips the target back must re-animate even while the
+        // item is transiently near it, else it rides a stale animation to the
+        // wrong slot. The position check still lets sub-pixel resize accumulate.
+        if (
+          !areVectorsDifferent(position.value, layoutPos, 1) &&
+          (!prev?.layoutPos ||
+            !areVectorsDifferent(prev.layoutPos, layoutPos, 1))
+        ) {
           return;
         }
         position.value = withTiming(layoutPos);


### PR DESCRIPTION
Occasionally a dragged item would overlap a neighbour and, on drop, two items settled on the same slot with another slot left empty.

The inactive-item layout reaction skipped re-issuing its `withTiming` when the new target was within a pixel of the item's *current, mid-animation* position. A rapid re-order that flipped a displaced neighbour's target back mid-flight was therefore swallowed while the item was transiently near that target, and it kept animating to the wrong slot. #586's `reconcilePositions` stopped handing out fresh position refs for unchanged items, which removed an accidental self-correction that had been hiding this, so it surfaced then.

The skip now also requires the layout target itself to be unchanged since the previous update, read from the reaction's own `prev` value (the same signal the drop-interpolation branch already uses). It adds no state and keeps the original sub-pixel `position` check, so it is strictly a superset of the previous animation triggers and smooth-resize following is unchanged, while any real re-target now issues a fresh animation.

Note: the original overlap is timing-dependent and I could not reproduce it with scripted gestures, so this rests on the code trace rather than a captured before/after. Verified with typecheck, eslint, all 21 library tests, and rapid cross-row plus over-and-back re-target drags on device (every item settles to a distinct slot, no regression).
