### PR TITLE
fix: Grid items overlap after returning from an extended background

### DIFF
--- a/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
@@ -1,4 +1,5 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import { AppState } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
 import { runOnUI } from 'react-native-reanimated';
 
@@ -41,7 +42,9 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
     containerWidth,
     controlledContainerDimensions,
     controlledItemDimensions,
+    itemCurrentPositions,
     itemHeights,
+    itemLayoutPositions,
     itemWidths,
     usesAbsoluteLayout
   } = useCommonValuesContext();
@@ -234,6 +237,40 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
       }
     })();
   }, [itemHeights, itemWidths, context]);
+
+  // Re-establish the layout when the app returns to the foreground.
+  // After an extended background, the platform may recreate the sortable's
+  // native views (and Reanimated may not re-run the mappers that position them),
+  // which leaves the absolutely positioned items overlapping until the next
+  // drag re-runs the layout. Item positions live entirely in Reanimated shared
+  // values, so on resume we drop the JS-side dimension cache (so the onLayout
+  // events fired by recreated views are treated as fresh measurements instead
+  // of being diffed away) and re-emit each inactive item's position from the
+  // authoritative layout so the freshly committed views pick it up.
+  // https://github.com/MatiPl01/react-native-sortables/issues/592
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', state => {
+      if (state !== 'active') {
+        return;
+      }
+      previousItemDimensionsRef.current = {};
+      runOnUI(() => {
+        const activeKey = activeItemKey.value;
+        const layoutPositions = itemLayoutPositions.value;
+        for (const key in itemCurrentPositions.value) {
+          if (key === activeKey) {
+            continue;
+          }
+          const target = layoutPositions[key];
+          const position = itemCurrentPositions.value[key];
+          if (target && position) {
+            position.value = { x: target.x, y: target.y };
+          }
+        }
+      })();
+    });
+    return () => subscription.remove();
+  }, [activeItemKey, itemCurrentPositions, itemLayoutPositions]);
 
   return {
     value: {

--- a/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
+++ b/packages/react-native-sortables/src/providers/shared/MeasurementsProvider.ts
@@ -239,14 +239,25 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
   }, [itemHeights, itemWidths, context]);
 
   // Re-establish the layout when the app returns to the foreground.
-  // After an extended background, the platform may recreate the sortable's
-  // native views (and Reanimated may not re-run the mappers that position them),
-  // which leaves the absolutely positioned items overlapping until the next
-  // drag re-runs the layout. Item positions live entirely in Reanimated shared
-  // values, so on resume we drop the JS-side dimension cache (so the onLayout
-  // events fired by recreated views are treated as fresh measurements instead
-  // of being diffed away) and re-emit each inactive item's position from the
-  // authoritative layout so the freshly committed views pick it up.
+  //
+  // Each item's absolute position lives only in a Reanimated shared value whose
+  // derived style is pushed to the native view exactly once, when the value
+  // changes. After a long background some platforms recreate the sortable's
+  // native views; the shared values survive but the freshly committed views
+  // never receive the last emitted style (the value did not change, so nothing
+  // re-pushes it), so absolutely positioned items collapse onto each other. The
+  // first drag is the only thing that mutates a position and thus re-pushes the
+  // style, which is why "a drag fixes it".
+  //
+  // On resume we reproduce that nudge without a drag: re-assign every inactive
+  // item's position to its authoritative layout target. The value is unchanged
+  // but the write is a fresh object, so Reanimated re-emits the style to the
+  // (possibly recreated) view. We also drop the JS dimension cache so a
+  // recreated view's onLayout is treated as a fresh measurement rather than
+  // diffed away, covering items whose size changed while backgrounded. The
+  // active item is skipped so a drag interrupted by backgrounding is not fought.
+  // Skipped entirely while still in relative layout, where there are no absolute
+  // positions to restore.
   // https://github.com/MatiPl01/react-native-sortables/issues/592
   useEffect(() => {
     const subscription = AppState.addEventListener('change', state => {
@@ -255,6 +266,9 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
       }
       previousItemDimensionsRef.current = {};
       runOnUI(() => {
+        if (!usesAbsoluteLayout.value) {
+          return;
+        }
         const activeKey = activeItemKey.value;
         const layoutPositions = itemLayoutPositions.value;
         for (const key in itemCurrentPositions.value) {
@@ -270,7 +284,12 @@ const { MeasurementsProvider, useMeasurementsContext } = createProvider(
       })();
     });
     return () => subscription.remove();
-  }, [activeItemKey, itemCurrentPositions, itemLayoutPositions]);
+  }, [
+    activeItemKey,
+    itemCurrentPositions,
+    itemLayoutPositions,
+    usesAbsoluteLayout
+  ]);
 
   return {
     value: {


### PR DESCRIPTION
Closes #592.

`Sortable.Grid` / `Sortable.Flex` item positions are driven entirely by Reanimated shared values and are never re-established when the app returns to the foreground. After an extended background, the platform can recreate the sortable's native views (and Reanimated may not re-run the mappers that position them), so the absolutely positioned items commit stale, overlapping positions and stay overlapped until a drag re-runs the layout.

On `AppState` becoming `active` this now:

- drops the JS-side dimension cache so the `onLayout` events fired by recreated views are treated as fresh measurements instead of being diffed away, and
- re-emits each inactive item's position from the authoritative layout (`itemLayoutPositions`) so the freshly committed views pick it up.

Shared between grid and flex; the currently dragged item is skipped, and the re-seed is a no-op while the grid is still in relative layout (nothing absolute to restore).

## Before / after

| Before (overlaps, only a drag fixes it) | After (re-establishes on foreground) |
| --- | --- |
| <!-- drag 592_issue.mp4 here --> | <!-- drag 592_fixed.mp4 here --> |

> The natural trigger is real-device memory reclaim over several minutes and cannot be scripted on an emulator (RN retains the surface across an Activity finish), so the recordings inject the exact resume-stale position state via a temporary debug hook to show the failure mode and the recovery, then background/foreground the app. In the "before" clip the overlap persists on return; in the "after" clip it snaps back to the correct layout with no drag.

## Verification

Tested on an Android emulator (RN 0.86, Reanimated 4.5.1, Fabric). The failure mode was reproduced by injecting the resume-stale state that the "fixed by a drag" clue implies: the applied `position.value`s go stale while `itemHeights` and `itemLayoutPositions` stay correct. Temporary logging on resume shows the fix restoring each item's position from the authoritative layout:

```
# after injecting the stale (overlapping) state, then background -> foreground:
posY before     = { "1": 0, "2": 6,  "3": 30 }    # applied positions stale (items overlapping)
after(=layoutY) = { "1": 0, "2": 70, "3": 335 }   # re-seeded from the (correct) computed layout

# on a normal resume (nothing stale) the same handler is a no-op:
posY before     = { "1": 0, "2": 70, "3": 335 }
after(=layoutY) = { "1": 0, "2": 70, "3": 335 }    # writes back the values already there
```

So the overlap recovers on the next foreground with no drag, and the handler does nothing (writes back identical values) when the layout is already correct. Expand/collapse, dynamic-height `+ Add` reflow, and drag-reorder all keep working.

Also re-verified on the iOS fabric example (New Arch) as a direct A/B with the same injected resume-stale state:

- Fix ON: injected overlap, then background + foreground, snaps back to the correct layout with no drag.
- Fix OFF: injected overlap, then background + foreground, the overlap persists.

Note: this validates the fix against the failure mechanism (injected), not the un-forceable natural OS-reclaim trigger, which could not be reproduced on the available hardware (an emulator and a 12 GB device both keep the surface alive across an Activity finish). Reporter confirmation on the original device would close that last gap.

## Follow-up commit

Refines the original change: gates the resume re-seed on `usesAbsoluteLayout` so it is skipped entirely while the grid is still in relative flow, and rewrites the explanatory comment to describe the real mechanism (a recreated native view never receives the last emitted style because the shared value did not change; re-assigning each inactive item's position as a fresh object forces Reanimated to re-push it, which is exactly what the first drag would otherwise do).
