### PR TITLE
fix: Balance onTouchesUp on Sortable.Touchable long press

### DIFF
--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.test.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.test.ts
@@ -7,6 +7,9 @@ import type { ManualGestureCallbacks } from '../types';
 
 // gesture-handler with the hook API present -> the integration must select the
 // v3 hook adapter (the one that fixes issue #349).
+// Tag each composed/leaf gesture so a test can tell which composition wrapped
+// which - `useSimultaneousGestures` is reused for the 'simultaneous' recognizer
+// group and for the outer wrap that keeps the touch tracker observing.
 jest.mock('react-native-gesture-handler', () => ({
   GestureDetector: () => null,
   GestureStateManager: {
@@ -14,16 +17,28 @@ jest.mock('react-native-gesture-handler', () => ({
     deactivate: jest.fn(),
     fail: jest.fn()
   },
-  useExclusiveGestures: jest.fn(() => ({})),
-  useLongPressGesture: jest.fn(() => ({ handlerTag: 3 })),
-  useManualGesture: jest.fn(() => ({ config: {}, handlerTag: 1 })),
-  useSimultaneousGestures: jest.fn(() => ({})),
-  useTapGesture: jest.fn(() => ({ handlerTag: 2 }))
+  useExclusiveGestures: jest.fn((...gestures) => ({
+    gestures,
+    kind: 'exclusive'
+  })),
+  useLongPressGesture: jest.fn(() => ({ handlerTag: 3, kind: 'longPress' })),
+  useManualGesture: jest.fn(() => ({
+    config: {},
+    handlerTag: 1,
+    kind: 'manual'
+  })),
+  useSimultaneousGestures: jest.fn((...gestures) => ({
+    gestures,
+    kind: 'simultaneous'
+  })),
+  useTapGesture: jest.fn(() => ({ handlerTag: 2, kind: 'tap' }))
 }));
 
 const mocked = GestureHandler as unknown as {
+  useExclusiveGestures: jest.Mock;
   useLongPressGesture: jest.Mock;
   useManualGesture: jest.Mock;
+  useSimultaneousGestures: jest.Mock;
   useTapGesture: jest.Mock;
 };
 const useManualGesture = mocked.useManualGesture;
@@ -88,4 +103,49 @@ it('creates tap, double-tap, long-press and manual gestures when every handler i
   expect(mocked.useTapGesture).toHaveBeenCalledTimes(2);
   expect(mocked.useLongPressGesture).toHaveBeenCalledTimes(1);
   expect(mocked.useManualGesture).toHaveBeenCalledTimes(1);
+});
+
+it('composes the touch tracker simultaneously with the recognizers so onTouchesUp survives a winning long press', () => {
+  // Regression: with the tracker composed exclusively, a winning long press
+  // cancelled it and dropped onTouchesUp. It must instead be composed as
+  // simultaneous(exclusive(...recognizers), manualTracker) so it is never a
+  // losing sibling.
+  renderHook(() =>
+    useTouchableGesture({
+      externalGesture: {},
+      failDistance: 10,
+      gestureMode: 'exclusive',
+      onLongPress: jest.fn(),
+      onTap: jest.fn(),
+      onTouchesDown: jest.fn(),
+      onTouchesUp: jest.fn()
+    })
+  );
+  expect(mocked.useExclusiveGestures).toHaveBeenCalledTimes(1);
+  expect(mocked.useSimultaneousGestures).toHaveBeenCalledTimes(1);
+  const outer = mocked.useSimultaneousGestures.mock.calls[0] as Array<{
+    kind: string;
+  }>;
+  expect(outer).toHaveLength(2);
+  expect(outer[0]!.kind).toBe('exclusive');
+  expect(outer[1]!.kind).toBe('manual');
+});
+
+it('returns the bare touch tracker when only touch callbacks are set (no recognizer wrap)', () => {
+  renderHook(() =>
+    useTouchableGesture({
+      externalGesture: {},
+      failDistance: 10,
+      gestureMode: 'exclusive',
+      onTouchesDown: jest.fn(),
+      onTouchesUp: jest.fn()
+    })
+  );
+
+  // No tap/long-press recognizers -> the tracker is used directly, so there is
+  // no outer simultaneous wrap around it.
+  expect(mocked.useTapGesture).not.toHaveBeenCalled();
+  expect(mocked.useLongPressGesture).not.toHaveBeenCalled();
+  expect(useManualGesture).toHaveBeenCalledTimes(1);
+  expect(mocked.useSimultaneousGestures).not.toHaveBeenCalled();
 });

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
@@ -123,10 +123,10 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
   // on the UI thread, a JS handler is marshalled to the JS thread - which the
   // reanimated detector requires.
   /* eslint-disable react-hooks/rules-of-hooks */
-  const gestures: Parameters<typeof useExclusiveGestures> = [];
+  const recognizers: Parameters<typeof useExclusiveGestures> = [];
 
   if (onTap) {
-    gestures.push(
+    recognizers.push(
       useTapGesture({
         maxDistance: failDistance,
         onActivate: useStableCallbackValue(onTap),
@@ -135,7 +135,7 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
     );
   }
   if (onDoubleTap) {
-    gestures.push(
+    recognizers.push(
       useTapGesture({
         maxDistance: failDistance,
         numberOfTaps: 2,
@@ -145,7 +145,7 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
     );
   }
   if (onLongPress) {
-    gestures.push(
+    recognizers.push(
       useLongPressGesture({
         maxDistance: failDistance,
         onActivate: useStableCallbackValue(onLongPress),
@@ -153,24 +153,34 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
       })
     );
   }
-  if (onTouchesDown ?? onTouchesUp) {
-    gestures.push(
-      useManualGesture({
-        onTouchesDown: onTouchesDown
-          ? useStableCallbackValue(onTouchesDown)
-          : undefined,
-        onTouchesUp: onTouchesUp
-          ? useStableCallbackValue(onTouchesUp)
-          : undefined,
-        simultaneousWith
-      })
-    );
-  }
 
-  const gesture =
+  // Touch callbacks live on their own Manual gesture composed simultaneously
+  // (below) with the recognizers, so they keep firing after a recognizer wins.
+  // An Exclusive relation cancels the losing siblings, which is what dropped
+  // `onTouchesUp` after a long press activated.
+  const touchTracker =
+    (onTouchesDown ?? onTouchesUp)
+      ? useManualGesture({
+          onTouchesDown: onTouchesDown
+            ? useStableCallbackValue(onTouchesDown)
+            : undefined,
+          onTouchesUp: onTouchesUp
+            ? useStableCallbackValue(onTouchesUp)
+            : undefined,
+          simultaneousWith
+        })
+      : null;
+
+  const composedRecognizers =
     gestureMode === 'exclusive'
-      ? useExclusiveGestures(...gestures)
-      : useSimultaneousGestures(...gestures);
+      ? useExclusiveGestures(...recognizers)
+      : useSimultaneousGestures(...recognizers);
+
+  const gesture = !touchTracker
+    ? composedRecognizers
+    : recognizers.length
+      ? useSimultaneousGestures(composedRecognizers, touchTracker)
+      : touchTracker;
   /* eslint-enable react-hooks/rules-of-hooks */
 
   return gesture;


### PR DESCRIPTION
## Description

On the New Architecture (gesture-handler v3), `Sortable.Touchable` fired `onTouchesDown` and `onLongPress` on a long press but never `onTouchesUp`, leaving the `onTouchesDown` unbalanced (e.g. a press highlight stayed stuck after a long press). A plain tap was unaffected, and the Old Architecture (v2) was unaffected.

The v3 adapter attached `onTouchesDown` / `onTouchesUp` to a Manual gesture composed **exclusively** with the tap/long-press recognizers. When the long press won the exclusive relation, gesture-handler cancelled that Manual gesture and fired `onTouchesCancel` instead of `onTouchesUp`. This composes the touch tracker **simultaneously** with the recognizers instead, so it keeps receiving touches regardless of which recognizer wins.

Only the v3 adapter changes — the v2 adapter already attaches the touch callbacks to the winning recognizer, so its `onTouchesUp` fires on lift.

## Testing

Verified on the iOS fabric example (New Arch), Touchable screen:

- Long-pressing an item now shows `touches down -> long press -> touches up` (previously the `touches up` was missing), including a held press released after the long press had fired.
- A plain tap still shows `touches down -> touches up -> tap`.

`typecheck`, `lint`, and `test` pass; the v3 adapter test asserts the tracker is composed as `simultaneous(exclusive(...recognizers), tracker)`.
