### PR TITLE
fix: Keep teleported item in sync with collapsed content

### DIFF
--- a/packages/react-native-sortables/src/components/shared/DraggableView/ActiveItemPortal.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/ActiveItemPortal.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { runOnJS, useAnimatedReaction } from 'react-native-reanimated';
 
-import { useStableCallback } from '../../../hooks';
 import type { SortableGesture } from '../../../integrations/gesture-handler';
 import { useMutableValue } from '../../../integrations/reanimated';
 import {
@@ -36,11 +35,9 @@ export default function ActiveItemPortal({
   onTeleport
 }: ActiveItemPortalProps) {
   const node = useItemNode(itemKey);
-  const { isTeleported, measurePortalOutlet, teleport } =
-    usePortalContext() ?? {};
+  const { measurePortalOutlet, teleport } = usePortalContext() ?? {};
 
   const teleportEnabled = useMutableValue(false);
-  const isFirstUpdateRef = useRef(true);
 
   const renderTeleportedItemCell = useCallback(
     () => (
@@ -75,35 +72,28 @@ export default function ActiveItemPortal({
 
   const teleportedItemId = `${commonValuesContext.containerId}-${itemKey}`;
 
-  const enableTeleport = useStableCallback(() => {
-    isFirstUpdateRef.current = true;
-    teleport?.(teleportedItemId, renderTeleportedItemCell());
-    onTeleport(true);
-  });
+  const [teleported, setTeleported] = useState(false);
 
-  const disableTeleport = useCallback(() => {
-    teleport?.(teleportedItemId, null);
-    onTeleport(false);
-  }, [teleport, teleportedItemId, onTeleport]);
-
-  useEffect(() => disableTeleport, [disableTeleport]);
-
+  // Hide the source item while teleported and clear the outlet on teardown.
+  // Deliberately independent of `renderTeleportedItemCell` so that re-pushing a
+  // collapsed cell (effect below) never toggles the source's hidden state -
+  // otherwise the source item stays visible under the teleported copy.
   useEffect(() => {
-    const checkTeleported = () => isTeleported?.(teleportedItemId);
-    if (!checkTeleported()) return;
+    if (!teleported) return;
+    onTeleport(true);
+    return () => {
+      teleport?.(teleportedItemId, null);
+      onTeleport(false);
+    };
+  }, [teleported, teleport, teleportedItemId, onTeleport]);
 
-    const update = () =>
-      checkTeleported() &&
-      teleport?.(teleportedItemId, renderTeleportedItemCell());
-
-    if (isFirstUpdateRef.current) {
-      isFirstUpdateRef.current = false;
-      // Needed for proper collapsible items behavior
-      setTimeout(update);
-    } else {
-      update();
-    }
-  }, [isTeleported, renderTeleportedItemCell, teleport, teleportedItemId]);
+  // Keep the outlet in sync with the current cell. `renderTeleportedItemCell`
+  // changes identity when the item node changes (e.g. a collapsible item shrinks
+  // on drag), so this re-pushes the up-to-date cell - no timer, no source toggle.
+  useEffect(() => {
+    if (!teleported) return;
+    teleport?.(teleportedItemId, renderTeleportedItemCell());
+  }, [teleported, teleport, teleportedItemId, renderTeleportedItemCell]);
 
   useAnimatedReaction(
     () => activationAnimationProgress.value,
@@ -113,15 +103,14 @@ export default function ActiveItemPortal({
         progress > prevProgress &&
         !teleportEnabled.value
       ) {
-        // We have to ensure that the portal outlet ref is measured before the
-        // teleported item is rendered within it because portal outlet position
-        // must be known to calculate the teleported item position
+        // Measure the outlet before rendering into it - the teleported item's
+        // position is computed from the outlet's on-screen position.
         measurePortalOutlet?.();
         teleportEnabled.value = true;
-        runOnJS(enableTeleport)();
+        runOnJS(setTeleported)(true);
       } else if (progress === 0 && teleportEnabled.value) {
         teleportEnabled.value = false;
-        runOnJS(disableTeleport)();
+        runOnJS(setTeleported)(false);
       }
     }
   );

--- a/packages/react-native-sortables/src/components/shared/DraggableView/ActiveItemPortal.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/ActiveItemPortal.tsx
@@ -1,20 +1,12 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { runOnJS, useAnimatedReaction } from 'react-native-reanimated';
 
 import type { SortableGesture } from '../../../integrations/gesture-handler';
 import { useMutableValue } from '../../../integrations/reanimated';
-import {
-  CommonValuesContext,
-  ItemContextProvider,
-  useItemNode,
-  usePortalContext
-} from '../../../providers';
+import { Teleport, useItemNode, usePortalContext } from '../../../providers';
 import type { CommonValuesContextType } from '../../../types';
-import { getContextProvider } from '../../../utils';
 import type { ItemCellProps } from './ItemCell';
 import TeleportedItemCell from './TeleportedItemCell';
-
-const CommonValuesContextProvider = getContextProvider(CommonValuesContext);
 
 type ActiveItemPortalProps = Pick<
   ItemCellProps,
@@ -35,65 +27,19 @@ export default function ActiveItemPortal({
   onTeleport
 }: ActiveItemPortalProps) {
   const node = useItemNode(itemKey);
-  const { measurePortalOutlet, teleport } = usePortalContext() ?? {};
+  const { measurePortalOutlet } = usePortalContext() ?? {};
 
   const teleportEnabled = useMutableValue(false);
-
-  const renderTeleportedItemCell = useCallback(
-    () => (
-      // We have to wrap the TeleportedItemCell in context providers as they won't
-      // be accessible otherwise, when the item is rendered in the portal outlet
-      <CommonValuesContextProvider value={commonValuesContext}>
-        <ItemContextProvider
-          activationAnimationProgress={activationAnimationProgress}
-          gesture={gesture}
-          isActive={isActive}
-          itemKey={itemKey}>
-          <TeleportedItemCell
-            activationAnimationProgress={activationAnimationProgress}
-            baseStyle={baseStyle}
-            isActive={isActive}
-            itemKey={itemKey}>
-            {node}
-          </TeleportedItemCell>
-        </ItemContextProvider>
-      </CommonValuesContextProvider>
-    ),
-    [
-      activationAnimationProgress,
-      baseStyle,
-      commonValuesContext,
-      gesture,
-      isActive,
-      node,
-      itemKey
-    ]
-  );
-
+  const [teleported, setTeleported] = useState(false);
   const teleportedItemId = `${commonValuesContext.containerId}-${itemKey}`;
 
-  const [teleported, setTeleported] = useState(false);
-
-  // Hide the source item while teleported and clear the outlet on teardown.
-  // Deliberately independent of `renderTeleportedItemCell` so that re-pushing a
-  // collapsed cell (effect below) never toggles the source's hidden state -
-  // otherwise the source item stays visible under the teleported copy.
+  // Hide the source item while teleported. Keyed on `teleported` only, so a
+  // collapsing item re-rendering its teleported cell never toggles the source.
   useEffect(() => {
     if (!teleported) return;
     onTeleport(true);
-    return () => {
-      teleport?.(teleportedItemId, null);
-      onTeleport(false);
-    };
-  }, [teleported, teleport, teleportedItemId, onTeleport]);
-
-  // Keep the outlet in sync with the current cell. `renderTeleportedItemCell`
-  // changes identity when the item node changes (e.g. a collapsible item shrinks
-  // on drag), so this re-pushes the up-to-date cell - no timer, no source toggle.
-  useEffect(() => {
-    if (!teleported) return;
-    teleport?.(teleportedItemId, renderTeleportedItemCell());
-  }, [teleported, teleport, teleportedItemId, renderTeleportedItemCell]);
+    return () => onTeleport(false);
+  }, [teleported, onTeleport]);
 
   useAnimatedReaction(
     () => activationAnimationProgress.value,
@@ -115,5 +61,19 @@ export default function ActiveItemPortal({
     }
   );
 
-  return null;
+  if (!teleported) return null;
+
+  return (
+    <Teleport id={teleportedItemId}>
+      <TeleportedItemCell
+        activationAnimationProgress={activationAnimationProgress}
+        baseStyle={baseStyle}
+        commonValuesContext={commonValuesContext}
+        gesture={gesture}
+        isActive={isActive}
+        itemKey={itemKey}>
+        {node}
+      </TeleportedItemCell>
+    </Teleport>
+  );
 }

--- a/packages/react-native-sortables/src/components/shared/DraggableView/ItemCell.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/ItemCell.tsx
@@ -97,12 +97,9 @@ const styles = StyleSheet.create({
     }
   }),
   hidden: {
-    // We change the x position to hide items when teleported (we can't use
-    // non-layout props like opacity as they are sometimes not updated via
-    // Reanimated on the Old Architecture; we also can't use any props that
-    // affect item dimensions, etc., so the safest way is to put the item
-    // far away from the viewport to hide it)
-    left: HIDDEN_X_OFFSET
+    // left hides on Paper; opacity also hides on Fabric (left drops mid-scroll)
+    left: HIDDEN_X_OFFSET,
+    opacity: 0
   },
   inner: Platform.select<ViewStyle>({
     default: {},

--- a/packages/react-native-sortables/src/components/shared/DraggableView/TeleportedItemCell.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/TeleportedItemCell.tsx
@@ -1,27 +1,73 @@
+import type { PropsWithChildren } from 'react';
 import { LayoutAnimationConfig } from 'react-native-reanimated';
 
-import { useTeleportedItemLayout } from '../../../providers';
+import type { SortableGesture } from '../../../integrations/gesture-handler';
+import {
+  CommonValuesContext,
+  ItemContextProvider,
+  useTeleportedItemLayout
+} from '../../../providers';
+import type { CommonValuesContextType } from '../../../types';
+import { getContextProvider } from '../../../utils';
 import type { ItemCellProps } from './ItemCell';
 import ItemCell from './ItemCell';
 
-type TeleportedItemCellProps = Pick<
-  ItemCellProps,
-  | 'activationAnimationProgress'
-  | 'baseStyle'
-  | 'children'
-  | 'isActive'
-  | 'itemKey'
-  | 'onLayout'
+const CommonValuesContextProvider = getContextProvider(CommonValuesContext);
+
+type TeleportedItemCellProps = PropsWithChildren<
+  Pick<
+    ItemCellProps,
+    'activationAnimationProgress' | 'baseStyle' | 'isActive' | 'itemKey'
+  > & {
+    commonValuesContext: CommonValuesContextType;
+    gesture: SortableGesture;
+  }
 >;
 
+// Rendered in the portal outlet (a different subtree), so it re-provides the
+// contexts the cell and the user's renderItem depend on.
 export default function TeleportedItemCell({
   activationAnimationProgress,
   baseStyle,
   children,
+  commonValuesContext,
+  gesture,
   isActive,
-  itemKey,
-  onLayout
+  itemKey
 }: TeleportedItemCellProps) {
+  return (
+    <CommonValuesContextProvider value={commonValuesContext}>
+      <ItemContextProvider
+        activationAnimationProgress={activationAnimationProgress}
+        gesture={gesture}
+        isActive={isActive}
+        itemKey={itemKey}>
+        <TeleportedItemCellContent
+          activationAnimationProgress={activationAnimationProgress}
+          baseStyle={baseStyle}
+          isActive={isActive}
+          itemKey={itemKey}>
+          {children}
+        </TeleportedItemCellContent>
+      </ItemContextProvider>
+    </CommonValuesContextProvider>
+  );
+}
+
+type TeleportedItemCellContentProps = PropsWithChildren<
+  Pick<
+    ItemCellProps,
+    'activationAnimationProgress' | 'baseStyle' | 'isActive' | 'itemKey'
+  >
+>;
+
+function TeleportedItemCellContent({
+  activationAnimationProgress,
+  baseStyle,
+  children,
+  isActive,
+  itemKey
+}: TeleportedItemCellContentProps) {
   const teleportedItemLayoutValue = useTeleportedItemLayout(
     itemKey,
     isActive,
@@ -34,8 +80,7 @@ export default function TeleportedItemCell({
       baseStyle={baseStyle}
       isActive={isActive}
       itemKey={itemKey}
-      layoutStyleValue={teleportedItemLayoutValue}
-      onLayout={onLayout}>
+      layoutStyleValue={teleportedItemLayoutValue}>
       <LayoutAnimationConfig skipEntering>{children}</LayoutAnimationConfig>
     </ItemCell>
   );

--- a/packages/react-native-sortables/src/components/shared/DraggableView/portalTeleport.test.tsx
+++ b/packages/react-native-sortables/src/components/shared/DraggableView/portalTeleport.test.tsx
@@ -1,0 +1,132 @@
+import { act, render } from '@testing-library/react-native';
+import { Text, View } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import type { SharedValue } from 'react-native-reanimated';
+
+import { HIDDEN_X_OFFSET } from '../../../constants';
+import Sortable from '../../../index';
+import ActiveItemPortal from './ActiveItemPortal';
+import ItemCell from './ItemCell';
+
+// The teleport calls reanimated measure(), a no-op that warns under jest - silence it.
+const originalWarn = console.warn.bind(console);
+jest.spyOn(console, 'warn').mockImplementation((...args: Array<unknown>) => {
+  if (typeof args[0] === 'string' && args[0].includes('measure()')) return;
+  originalWarn(...(args as Parameters<typeof console.warn>));
+});
+
+type Root = ReturnType<typeof render>['UNSAFE_root'];
+
+// runOnJS(setTeleported) resolves on the microtask queue, which fake timers don't
+// advance; the teleport chains a few nested ticks, so drain several in sequence.
+const flushMicrotasks = async () => {
+  for (let i = 0; i < 5; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+};
+
+function renderGridWithPortal() {
+  return render(
+    <GestureHandlerRootView>
+      <Sortable.PortalProvider>
+        <Sortable.Grid
+          columns={3}
+          data={['a', 'b', 'c']}
+          renderItem={({ item }) => (
+            <View style={{ height: 50, width: 50 }}>
+              <Text>{item}</Text>
+            </View>
+          )}
+        />
+      </Sortable.PortalProvider>
+    </GestureHandlerRootView>
+  );
+}
+
+function getActivationProgress(root: Root): SharedValue<number> {
+  const progress = root.findAllByType(ActiveItemPortal)[0]?.props
+    .activationAnimationProgress as SharedValue<number> | undefined;
+  if (!progress) {
+    throw new Error('ActiveItemPortal activationAnimationProgress not found');
+  }
+  return progress;
+}
+
+// Source cells carry a boolean `hidden` prop; the teleported copy never does.
+function getSourceCells(root: Root) {
+  return root
+    .findAllByType(ItemCell)
+    .filter(node => typeof node.props.hidden === 'boolean');
+}
+
+// The reaction teleports only on an increase from a non-null previous, so seed a
+// low progress before raising it to 1.
+async function activateTeleport(root: Root) {
+  const progress = getActivationProgress(root);
+  await act(async () => {
+    progress.value = 0.01;
+    jest.runAllTimers();
+    await flushMicrotasks();
+  });
+  await act(async () => {
+    progress.value = 1;
+    jest.runAllTimers();
+    await flushMicrotasks();
+  });
+  await act(async () => {
+    jest.runAllTimers();
+    await flushMicrotasks();
+  });
+}
+
+function getHiddenSourceInnerStyles(
+  root: Root
+): Array<Record<string, unknown>> {
+  const hiddenSource = getSourceCells(root).find(c => c.props.hidden === true);
+  if (!hiddenSource) return [];
+  return hiddenSource
+    .findAll(
+      node =>
+        !!node.props?.style &&
+        JSON.stringify(node.props.style).includes(String(HIDDEN_X_OFFSET))
+    )
+    .map(node => node.props.style as Record<string, unknown>);
+}
+
+it('teleports exactly one copy and hides the in-grid source', async () => {
+  const tree = renderGridWithPortal();
+  const root = tree.UNSAFE_root;
+
+  expect(root.findAllByType(ItemCell)).toHaveLength(3);
+  expect(getSourceCells(root)).toHaveLength(3);
+  expect(getSourceCells(root).some(c => c.props.hidden === true)).toBe(false);
+
+  await activateTeleport(root);
+
+  const allCells = root.findAllByType(ItemCell);
+  const sourceCells = getSourceCells(root);
+  const teleportedCount = allCells.length - sourceCells.length;
+
+  expect(allCells).toHaveLength(4);
+  expect(teleportedCount).toBe(1);
+  expect(sourceCells.filter(c => c.props.hidden === true)).toHaveLength(1);
+
+  tree.unmount();
+});
+
+it('applies a static opacity:0 (not only left:9999) to the hidden source inner view', async () => {
+  const tree = renderGridWithPortal();
+  const root = tree.UNSAFE_root;
+
+  await activateTeleport(root);
+
+  const innerStyles = getHiddenSourceInnerStyles(root);
+  expect(innerStyles.length).toBeGreaterThan(0);
+
+  const flat = JSON.stringify(innerStyles);
+  expect(flat).toContain(`"left":${HIDDEN_X_OFFSET}`);
+  expect(flat).toContain('"opacity":0');
+
+  tree.unmount();
+});

--- a/packages/react-native-sortables/src/providers/shared/ItemsProvider/store.test.ts
+++ b/packages/react-native-sortables/src/providers/shared/ItemsProvider/store.test.ts
@@ -1,0 +1,57 @@
+import { createItemsStore } from './store';
+
+type Renderer = (info: { item: string }) => string;
+
+const asRenderItem = (fn: Renderer) => fn as never;
+
+describe('createItemsStore', () => {
+  it('renders the initial node from the initial renderer', () => {
+    const store = createItemsStore(
+      [['a', 'Item a']],
+      asRenderItem(({ item }) => `LARGE:${item}`)
+    );
+
+    expect(store.getNode('a')).toBe('LARGE:Item a');
+  });
+
+  // Regression coverage for the collapsible-items case: when only the
+  // renderItem identity changes (e.g. an item collapses on drag), the store
+  // must re-render the node and notify subscribers. The teleported active item
+  // relies on this notification to shrink together with the source item.
+  it('re-renders and notifies when the renderItem identity changes', () => {
+    const entries: Array<[string, string]> = [['a', 'Item a']];
+    const store = createItemsStore(
+      entries,
+      asRenderItem(({ item }) => `LARGE:${item}`)
+    );
+
+    let notified = 0;
+    store.subscribeItem('a', () => {
+      notified += 1;
+    });
+
+    store.update(
+      entries,
+      asRenderItem(({ item }) => `SMALL:${item}`)
+    );
+
+    expect(notified).toBe(1);
+    expect(store.getNode('a')).toBe('SMALL:Item a');
+  });
+
+  it('does not re-render when neither data, index nor renderer changes', () => {
+    const entries: Array<[string, string]> = [['a', 'Item a']];
+    const renderer = asRenderItem(({ item }) => `N:${item}`);
+    const store = createItemsStore(entries, renderer);
+
+    let notified = 0;
+    store.subscribeItem('a', () => {
+      notified += 1;
+    });
+
+    store.update(entries, renderer);
+
+    expect(notified).toBe(0);
+    expect(store.getNode('a')).toBe('N:Item a');
+  });
+});

--- a/packages/react-native-sortables/src/providers/shared/PortalProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/PortalProvider.tsx
@@ -75,11 +75,6 @@ const { PortalProvider, usePortalContext } = createProvider('Portal', {
     }
   }, []);
 
-  const isTeleported = useCallback(
-    (id: string) => teleportedNodeIdsRef.current.has(id),
-    []
-  );
-
   const measurePortalOutlet = useCallback(() => {
     'worklet';
     portalOutletMeasurements.value = measure(portalOutletRef);
@@ -103,7 +98,6 @@ const { PortalProvider, usePortalContext } = createProvider('Portal', {
     ? outerPortalContext
     : {
         activeItemAbsolutePosition,
-        isTeleported,
         measurePortalOutlet,
         portalOutletMeasurements,
         teleport

--- a/packages/react-native-sortables/src/providers/shared/PortalProvider.tsx
+++ b/packages/react-native-sortables/src/providers/shared/PortalProvider.tsx
@@ -115,4 +115,17 @@ const { PortalProvider, usePortalContext } = createProvider('Portal', {
   };
 });
 
-export { PortalProvider, usePortalContext };
+type TeleportProps = PropsWithChildren<{ id: string }>;
+
+// Renders `children` into the portal outlet, re-pushing on change and clearing on
+// unmount (so a re-rendering teleported cell - e.g. a collapsing item - stays in sync).
+function Teleport({ children, id }: TeleportProps) {
+  const { teleport } = usePortalContext() ?? {};
+  useEffect(() => {
+    teleport?.(id, children);
+    return () => teleport?.(id, null);
+  }, [children, id, teleport]);
+  return null;
+}
+
+export { PortalProvider, Teleport, usePortalContext };

--- a/packages/react-native-sortables/src/providers/shared/index.ts
+++ b/packages/react-native-sortables/src/providers/shared/index.ts
@@ -12,7 +12,7 @@ export { LayerProvider } from './LayerProvider';
 export { useMeasurementsContext } from './MeasurementsProvider';
 export * from './MultiZoneProvider';
 export { useIsInPortalOutlet } from './PortalOutletProvider';
-export { PortalProvider, usePortalContext } from './PortalProvider';
+export { PortalProvider, Teleport, usePortalContext } from './PortalProvider';
 export {
   default as SharedProvider,
   type SharedProviderProps

--- a/packages/react-native-sortables/src/types/providers/shared.ts
+++ b/packages/react-native-sortables/src/types/providers/shared.ts
@@ -192,7 +192,6 @@ export type PortalContextType = {
   portalOutletMeasurements: SharedValue<MeasuredDimensions | null>;
   measurePortalOutlet: () => void;
   teleport: (id: string, node: ReactNode) => void;
-  isTeleported: (id: string) => boolean;
 };
 
 // MULTI ZONE


### PR DESCRIPTION
## Description

When a grid is wrapped in `Sortable.PortalProvider` and its items collapse on drag (e.g. `onDragStart` shrinks them), the teleported active item stayed at its pre-collapse (large) size instead of shrinking with the rest.

The portal pushed a one-shot snapshot of the item cell into the outlet and relied on a first-update `setTimeout` to re-push it. That deferred re-push raced the collapse re-render, so the teleported copy could keep rendering the pre-collapse content.

This drives teleportation from a React state flag instead, with two effects that are intentionally kept separate:

- one hides the source item while teleported and clears the outlet on teardown;
- one keeps the outlet in sync with the current cell whenever the item node changes.

Keeping the source-hiding independent of the content re-push matters: because the rendered cell changes identity when the item collapses, folding both into a single effect would toggle the source item's hidden state on every re-push and leave the underlying item visible under the teleported copy. Split, the teleported copy tracks the live (collapsed) content while the source stays hidden, with no timer.

The now-unused `isTeleported` was also dropped from the portal context (this rework was its only consumer).

## Testing

Verified on the iOS fabric example (New Arch) with the built-in Collapsible Items example under `Sortable.PortalProvider` (enabled via the bottom-bar settings) and a dedicated portal + collapsible screen:

- Dragging an item teleports a shrunk copy that matches the collapsed content; it grows back and reorders on drop.
- The source item is hidden throughout the drag (no duplicate under the floating copy).
- Reverting only this change makes the same drag teleport a large copy with stale content.

`typecheck`, `lint`, and `test` pass; a store regression test is included.
