### PR TITLE
fix: keep Sortable.Touchable onTouchesUp firing on web

### DIFF
--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v2.test.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v2.test.ts
@@ -1,41 +1,175 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { Gesture } from 'react-native-gesture-handler';
 
-import { useDragGesture } from '../index';
+import { useDragGesture, useTouchableGesture } from '../index';
 import type { ManualGestureCallbacks } from '../types';
 
 // gesture-handler without the hook API -> the integration must select the v2
-// imperative-builder adapter.
+// imperative-builder adapter. Each builder is a chainable stub that records the
+// touch handlers attached to it (and its kind), so a test can assert the shape
+// of the composed touchable gesture tree.
 jest.mock('react-native-gesture-handler', () => {
-  const manual: Record<string, jest.Mock> = {};
-  for (const method of [
-    'onTouchesDown',
-    'onTouchesMove',
-    'onTouchesCancelled',
-    'onTouchesUp'
-  ]) {
-    manual[method] = jest.fn(() => manual);
-  }
+  const makeGesture = (kind: string) => {
+    const gesture: Record<string, unknown> = { handlers: {}, kind };
+    for (const method of [
+      'maxDistance',
+      'numberOfTaps',
+      'onStart',
+      'runOnJS',
+      'simultaneousWithExternalGesture'
+    ]) {
+      gesture[method] = jest.fn(() => gesture);
+    }
+    for (const method of [
+      'onTouchesCancelled',
+      'onTouchesDown',
+      'onTouchesMove',
+      'onTouchesUp'
+    ]) {
+      gesture[method] = jest.fn((callback: unknown) => {
+        (gesture.handlers as Record<string, unknown>)[method] = callback;
+        return gesture;
+      });
+    }
+    return gesture;
+  };
+
   return {
-    Gesture: { Manual: jest.fn(() => manual) },
+    Gesture: {
+      Exclusive: jest.fn((...gestures: Array<unknown>) => ({
+        gestures,
+        kind: 'exclusive'
+      })),
+      LongPress: jest.fn(() => makeGesture('longPress')),
+      Manual: jest.fn(() => makeGesture('manual')),
+      Simultaneous: jest.fn((...gestures: Array<unknown>) => ({
+        gestures,
+        kind: 'simultaneous'
+      })),
+      Tap: jest.fn(() => makeGesture('tap'))
+    },
     GestureDetector: () => null
   };
 });
 
-const Manual = (Gesture as unknown as { Manual: jest.Mock }).Manual;
+type MockGesture = { kind: string; handlers: Record<string, unknown> };
+type MockComposed = {
+  kind: string;
+  gestures: Array<MockComposed | MockGesture>;
+};
 
-const callbacks: ManualGestureCallbacks = {
+const mocked = Gesture as unknown as {
+  Exclusive: jest.Mock;
+  LongPress: jest.Mock;
+  Manual: jest.Mock;
+  Simultaneous: jest.Mock;
+  Tap: jest.Mock;
+};
+
+const dragCallbacks: ManualGestureCallbacks = {
   onTouchesCancelled: jest.fn(),
   onTouchesDown: jest.fn(),
   onTouchesMove: jest.fn(),
   onTouchesUp: jest.fn()
 };
 
-it('selects the v2 adapter and wires the drag callbacks into the builder', () => {
-  renderHook(() => useDragGesture(callbacks, []));
+const baseConfig = {
+  externalGesture: {},
+  failDistance: 10,
+  gestureMode: 'exclusive' as const
+};
 
-  expect(Manual).toHaveBeenCalledTimes(1);
-  const manual = Manual.mock.results[0]!.value as Record<string, jest.Mock>;
-  expect(manual.onTouchesDown).toHaveBeenCalledWith(callbacks.onTouchesDown);
-  expect(manual.onTouchesUp).toHaveBeenCalledWith(callbacks.onTouchesUp);
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it('selects the v2 adapter and wires the drag callbacks into the builder', () => {
+  renderHook(() => useDragGesture(dragCallbacks, []));
+
+  expect(mocked.Manual).toHaveBeenCalledTimes(1);
+  const manual = mocked.Manual.mock.results[0]!.value as MockGesture;
+  expect(manual.handlers.onTouchesDown).toBe(dragCallbacks.onTouchesDown);
+  expect(manual.handlers.onTouchesUp).toBe(dragCallbacks.onTouchesUp);
+});
+
+it('keeps onTouchesUp on a separate manual tracker composed simultaneously, not on an exclusive recognizer', () => {
+  // Regression (web): with onTouchesUp bolted onto the last recognizer inside
+  // Gesture.Exclusive, a winning tap cancelled the losing long-press sibling and
+  // dropped onTouchesUp. It must live on its own Manual composed simultaneously.
+  const onTouchesUp = jest.fn();
+
+  renderHook(() =>
+    useTouchableGesture({
+      ...baseConfig,
+      onLongPress: jest.fn(),
+      onTap: jest.fn(),
+      onTouchesDown: jest.fn(),
+      onTouchesUp
+    })
+  );
+
+  // The two recognizers are grouped exclusively; the touch tracker is NOT one
+  // of them, so a winning recognizer can no longer cancel it.
+  expect(mocked.Exclusive).toHaveBeenCalledTimes(1);
+  const recognizers = mocked.Exclusive.mock.calls[0] as Array<MockGesture>;
+  expect(recognizers.map(recognizer => recognizer.kind)).toEqual([
+    'tap',
+    'longPress'
+  ]);
+  for (const recognizer of recognizers) {
+    expect(recognizer.handlers.onTouchesUp).toBeUndefined();
+  }
+
+  // The outer wrap composes the exclusive group with the manual tracker, which
+  // is the gesture that actually carries onTouchesUp.
+  expect(mocked.Simultaneous).toHaveBeenCalledTimes(1);
+  const outer = mocked.Simultaneous.mock.calls[0] as [
+    MockComposed,
+    MockGesture
+  ];
+  expect(outer[0].kind).toBe('exclusive');
+  expect(outer[1].kind).toBe('manual');
+  expect(outer[1].handlers.onTouchesUp).toBe(onTouchesUp);
+});
+
+it('returns the bare manual tracker when only touch callbacks are set', () => {
+  const onTouchesUp = jest.fn();
+
+  const { result } = renderHook(() =>
+    useTouchableGesture({
+      ...baseConfig,
+      onTouchesDown: jest.fn(),
+      onTouchesUp
+    })
+  );
+
+  // No recognizers -> no Exclusive/Simultaneous wrap; the lone Manual (which
+  // fires a clean onTouchesUp on web) is returned as is.
+  expect(mocked.Tap).not.toHaveBeenCalled();
+  expect(mocked.LongPress).not.toHaveBeenCalled();
+  expect(mocked.Exclusive).not.toHaveBeenCalled();
+  expect(mocked.Simultaneous).not.toHaveBeenCalled();
+  expect(mocked.Manual).toHaveBeenCalledTimes(1);
+
+  const gesture = result.current as MockGesture;
+  expect(gesture.kind).toBe('manual');
+  expect(gesture.handlers.onTouchesUp).toBe(onTouchesUp);
+});
+
+it('groups recognizers simultaneously when gestureMode is simultaneous', () => {
+  renderHook(() =>
+    useTouchableGesture({
+      externalGesture: {},
+      failDistance: 10,
+      gestureMode: 'simultaneous',
+      onDoubleTap: jest.fn(),
+      onTap: jest.fn(),
+      onTouchesUp: jest.fn()
+    })
+  );
+
+  // The recognizer group uses Simultaneous (not Exclusive), and the outer wrap
+  // that keeps the touch tracker observing also uses Simultaneous.
+  expect(mocked.Exclusive).not.toHaveBeenCalled();
+  expect(mocked.Simultaneous).toHaveBeenCalledTimes(2);
 });

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v2.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v2.ts
@@ -69,11 +69,6 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
       );
     }
 
-    // Touch callbacks live on their own Manual gesture composed simultaneously
-    // (below) with the recognizers, so they keep firing after a recognizer wins.
-    // Attached to a recognizer inside Gesture.Exclusive they were dropped on web:
-    // a winning recognizer cancels the losing siblings, and web turns a cancelled
-    // handler's final touch into `onTouchesCancelled` instead of `onTouchesUp`.
     let touchTracker: GestureType | null = null;
     if (onTouchesDown || onTouchesUp) {
       touchTracker = decorate(Gesture.Manual());

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v2.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v2.ts
@@ -47,44 +47,56 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
     };
 
     // maxDistance only exists on the Tap/LongPress builders, so set it there.
-    const gestures: Array<GestureType> = [];
+    const recognizers: Array<GestureType> = [];
 
     if (onTap) {
-      gestures.push(
+      recognizers.push(
         decorate(Gesture.Tap().maxDistance(failDistance)).onStart(onTap)
       );
     }
     if (onDoubleTap) {
-      gestures.push(
+      recognizers.push(
         decorate(
           Gesture.Tap().numberOfTaps(2).maxDistance(failDistance)
         ).onStart(onDoubleTap)
       );
     }
     if (onLongPress) {
-      gestures.push(
+      recognizers.push(
         decorate(Gesture.LongPress().maxDistance(failDistance)).onStart(
           onLongPress
         )
       );
     }
 
+    // Touch callbacks live on their own Manual gesture composed simultaneously
+    // (below) with the recognizers, so they keep firing after a recognizer wins.
+    // Attached to a recognizer inside Gesture.Exclusive they were dropped on web:
+    // a winning recognizer cancels the losing siblings, and web turns a cancelled
+    // handler's final touch into `onTouchesCancelled` instead of `onTouchesUp`.
+    let touchTracker: GestureType | null = null;
     if (onTouchesDown || onTouchesUp) {
-      const target = gestures.at(-1) ?? decorate(Gesture.Manual());
-      if (!gestures.length) {
-        gestures.push(target);
-      }
+      touchTracker = decorate(Gesture.Manual());
       if (onTouchesDown) {
-        target.onTouchesDown(onTouchesDown);
+        touchTracker.onTouchesDown(onTouchesDown);
       }
       if (onTouchesUp) {
-        target.onTouchesUp(onTouchesUp);
+        touchTracker.onTouchesUp(onTouchesUp);
       }
     }
 
-    return gestureMode === 'exclusive'
-      ? Gesture.Exclusive(...gestures)
-      : Gesture.Simultaneous(...gestures);
+    const recognizerGroup = recognizers.length
+      ? gestureMode === 'exclusive'
+        ? Gesture.Exclusive(...recognizers)
+        : Gesture.Simultaneous(...recognizers)
+      : null;
+
+    if (recognizerGroup && touchTracker) {
+      return Gesture.Simultaneous(recognizerGroup, touchTracker);
+    }
+    // SortableTouchable renders a plain View when no callback is set, so exactly
+    // one of these is non-null by the time we get here.
+    return recognizerGroup ?? touchTracker ?? Gesture.Manual();
   }, [
     failDistance,
     onTap,


### PR DESCRIPTION
On web, `Sortable.Touchable`'s `onTouchesUp` did not fire when the touchable also had a tap or long-press handler.

The web build uses gesture-handler's v2 adapter, which attached the touch callbacks to the last recognizer inside `Gesture.Exclusive`. When a recognizer won the exclusive race, web cancelled the losing siblings and delivered a synthetic `onTouchesCancelled` instead of `onTouchesUp`. This is the web counterpart of #594: the touch callbacks now live on their own `Manual` composed simultaneously with the recognizers, so a winning recognizer can no longer cancel them.

Native was unaffected (native gesture-handler delivers touches to losing siblings differently), but the v2 adapter runs on both web and the Old Architecture, so the fix covers both. Added v2 adapter test coverage, including a regression test that asserts `onTouchesUp` sits on a simultaneous `Manual` rather than an exclusive recognizer.
