### PR TITLE
chore: run gesture-handler v3 in the web example

### DIFF
--- a/example/web/metro.config.js
+++ b/example/web/metro.config.js
@@ -3,4 +3,9 @@ const { createMetroConfig } = require('../app/scripts/metro');
 
 const defaultConfig = getDefaultConfig(__dirname);
 
-module.exports = createMetroConfig(defaultConfig, __dirname);
+module.exports = createMetroConfig(defaultConfig, __dirname, {
+  // This example runs gesture-handler v3 on web (so it exercises the v3 hook
+  // adapter); resolve it from this app rather than the v2 copy pinned by the
+  // shared example app.
+  filterFromCommonApp: ['react-native-gesture-handler']
+});

--- a/example/web/package.json
+++ b/example/web/package.json
@@ -5,8 +5,9 @@
     "expo": "57.0.2",
     "react-dom": "19.2.3",
     "react-native": "0.86.0",
+    "react-native-gesture-handler": "3.0.2",
     "react-native-sortables": "workspace:*",
-    "react-native-web": "0.21.1"
+    "react-native-web": "0.21.2"
   },
   "devDependencies": {
     "@expo/metro-runtime": "~57.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8538,8 +8538,9 @@ __metadata:
     expo: "npm:57.0.2"
     react-dom: "npm:19.2.3"
     react-native: "npm:0.86.0"
+    react-native-gesture-handler: "npm:3.0.2"
     react-native-sortables: "workspace:*"
-    react-native-web: "npm:0.21.1"
+    react-native-web: "npm:0.21.2"
     serve: "npm:^14.2.4"
   languageName: unknown
   linkType: soft
@@ -15184,9 +15185,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-web@npm:0.21.1":
-  version: 0.21.1
-  resolution: "react-native-web@npm:0.21.1"
+"react-native-web@npm:0.21.2":
+  version: 0.21.2
+  resolution: "react-native-web@npm:0.21.2"
   dependencies:
     "@babel/runtime": "npm:^7.18.6"
     "@react-native/normalize-colors": "npm:^0.74.1"
@@ -15199,7 +15200,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/6a72f32c30909d2e76f721f8257f6bf32d83ec8dec480aebefc549a479b9c87e4ef019d5dadc9d0d21703a9b1801803d51a25227f54cd4ad330ca14676dd5956
+  checksum: 10c0/8c184fef0045c25deff765c8e80963454a5dffd8e389a9e11cf2fec9e769ff0f82c3d56d082b1897a7ded8374d9ae8a49dac7f09377a104f1995a5ddea645095
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Runs gesture-handler v3 in the web example so web exercises the v3 hook adapter (the same one the New Architecture uses) instead of the v2 builder adapter. This gives web the more robust gesture composition directly, rather than relying on the v2-specific patch in #596.

Mirrors the fabric example: adds `react-native-gesture-handler` 3.0.2 and blocks the shared app's v2 copy in Metro (`filterFromCommonApp`) so web resolves v3. Bumps `react-native-web` to 0.21.2 (React Native stays 0.86.0). The other examples keep their own v2 copies, so they are unaffected.

Verified the web bundle builds cleanly with gh v3 and the app plus the grid and flex sortables render on web with no runtime errors. No library or app-code changes are needed - the adapter auto-selects v3 once the hook API is present.
