### PR TITLE
fix: disable dragging for fixed-order and non-draggable handles

### DIFF
--- a/packages/react-native-sortables/src/components/shared/CustomHandle.tsx
+++ b/packages/react-native-sortables/src/components/shared/CustomHandle.tsx
@@ -3,7 +3,6 @@ import type { StyleProp, ViewStyle } from 'react-native';
 import { View } from 'react-native';
 import { runOnUI, useAnimatedRef } from 'react-native-reanimated';
 
-import { useEnabledGesture } from '../../integrations/gesture-handler';
 import {
   useCustomHandleContext,
   useIsInPortalOutlet,
@@ -61,8 +60,6 @@ function CustomHandleComponent({
 
   const { registerHandle, updateActiveHandleMeasurements } =
     customHandleContext;
-  const dragEnabled = mode === 'draggable';
-  const handleGesture = useEnabledGesture(gesture, dragEnabled);
 
   useEffect(() => {
     return registerHandle(itemKey, handleRef, mode === 'fixed-order');
@@ -75,17 +72,25 @@ function CustomHandleComponent({
     }
   }, [itemKey, isActive, updateActiveHandleMeasurements]);
 
-  return (
-    <SortableGestureDetector gesture={handleGesture}>
-      <View
-        collapsable={false}
-        ref={handleRef}
-        style={style}
-        onLayout={() => {
-          runOnUI(onLayout)();
-        }}>
-        {children}
-      </View>
+  const handle = (
+    <View
+      collapsable={false}
+      ref={handleRef}
+      style={style}
+      onLayout={() => {
+        runOnUI(onLayout)();
+      }}>
+      {children}
+    </View>
+  );
+
+  // Only a draggable handle attaches the drag gesture. A `non-draggable` or
+  // `fixed-order` handle leaves it off, so the item cannot be picked up.
+  return mode === 'draggable' ? (
+    <SortableGestureDetector gesture={gesture}>
+      {handle}
     </SortableGestureDetector>
+  ) : (
+    handle
   );
 }

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/types.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/types.ts
@@ -11,9 +11,5 @@ export type GestureHandlerAdapter = {
     callbacks: ManualGestureCallbacks,
     deps: ReadonlyArray<unknown>
   ) => SortableGesture;
-  useEnabledGesture: (
-    gesture: SortableGesture,
-    enabled: boolean
-  ) => SortableGesture;
   useTouchableGesture: (config: TouchableGestureConfig) => SortableGesture;
 };

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v2.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v2.ts
@@ -23,11 +23,6 @@ const useDragGesture: GestureHandlerAdapter['useDragGesture'] = (
     deps
   );
 
-const useEnabledGesture: GestureHandlerAdapter['useEnabledGesture'] = (
-  gesture,
-  enabled
-) => (gesture as GestureType).enabled(enabled);
-
 const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
   externalGesture,
   failDistance,
@@ -105,6 +100,5 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
 
 export const adapter: GestureHandlerAdapter = {
   useDragGesture,
-  useEnabledGesture,
   useTouchableGesture
 };

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
@@ -1,7 +1,4 @@
-import type {
-  ManualGesture,
-  ManualGestureConfig
-} from 'react-native-gesture-handler';
+import type { ManualGestureConfig } from 'react-native-gesture-handler';
 import * as GestureHandler from 'react-native-gesture-handler';
 import type { SharedValue } from 'react-native-reanimated';
 
@@ -86,17 +83,6 @@ const useDragGesture: GestureHandlerAdapter['useDragGesture'] = callbacks => {
       );
     }
   });
-};
-
-const useEnabledGesture: GestureHandlerAdapter['useEnabledGesture'] = (
-  gesture,
-  enabled
-) => {
-  // v3 gestures are immutable; return a copy with config.enabled toggled.
-  const current = gesture as ManualGesture;
-  const next = { ...current, config: { ...current.config } };
-  next.config.enabled = enabled;
-  return next;
 };
 
 // Only the handlers that are passed create a gesture (and a native handler), so
@@ -188,6 +174,5 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
 
 export const adapter: GestureHandlerAdapter = {
   useDragGesture,
-  useEnabledGesture,
   useTouchableGesture
 };

--- a/packages/react-native-sortables/src/integrations/gesture-handler/index.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/index.ts
@@ -12,7 +12,6 @@ const hasHookApi =
 const adapter = hasHookApi ? v3Adapter : v2Adapter;
 
 export const useDragGesture = adapter.useDragGesture;
-export const useEnabledGesture = adapter.useEnabledGesture;
 export const useTouchableGesture = adapter.useTouchableGesture;
 
 export { SortableGestureDetectorView } from './detector';


### PR DESCRIPTION
## Summary

`fixed-order` and `non-draggable` custom handles could still be picked up and dragged (visible in the Fixed Order Items example on gesture-handler v3). The old `useEnabledGesture` toggled `config.enabled` on a copy of the v3 gesture, which never reached the native handler.

Rather than toggling `enabled`, `Sortable.Handle` now attaches the drag gesture only when its `mode` is `draggable`. `non-draggable` and `fixed-order` handles render without the gesture detector, so the item cannot be picked up. This is adapter-agnostic (v2 and v3 behave the same), so the now-unused `useEnabledGesture` is dropped from both adapters.

## Testing

Verified on the iOS fabric example (gesture-handler v3):

- fixed-order items are not draggable and keep their ordinal position while other items reorder around them
- draggable items drag and reorder as before
- toggling an item between fixed and draggable at runtime works

## Known limitation

Toggling a handle's `mode` at runtime remounts the handle subtree (the gesture detector wrapper is added/removed). This is fine for statically fixed items; item content holding local state would reset if flipped live.
