### PR TITLE
fix: Keep Sortable.Touchable tap and long press working on teleported items

### DIFF
--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v2.test.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v2.test.ts
@@ -16,6 +16,7 @@ jest.mock('react-native-gesture-handler', () => {
       'numberOfTaps',
       'onStart',
       'runOnJS',
+      'shouldCancelWhenOutside',
       'simultaneousWithExternalGesture'
     ]) {
       gesture[method] = jest.fn(() => gesture);
@@ -130,6 +131,28 @@ it('keeps onTouchesUp on a separate manual tracker composed simultaneously, not 
   expect(outer[0].kind).toBe('exclusive');
   expect(outer[1].kind).toBe('manual');
   expect(outer[1].handlers.onTouchesUp).toBe(onTouchesUp);
+});
+
+it('disables shouldCancelWhenOutside on the recognizers so they survive a teleported item hide', () => {
+  // Regression: the teleported item's still-mounted source cell is hidden
+  // (off-screen / opacity 0), which reads as "outside" and, with the default
+  // true, cancels Tap/LongPress - dropping onTap/onLongPress under the portal.
+  renderHook(() =>
+    useTouchableGesture({
+      ...baseConfig,
+      onLongPress: jest.fn(),
+      onTap: jest.fn()
+    })
+  );
+
+  const tap = mocked.Tap.mock.results[0]!.value as {
+    shouldCancelWhenOutside: jest.Mock;
+  };
+  const longPress = mocked.LongPress.mock.results[0]!.value as {
+    shouldCancelWhenOutside: jest.Mock;
+  };
+  expect(tap.shouldCancelWhenOutside).toHaveBeenCalledWith(false);
+  expect(longPress.shouldCancelWhenOutside).toHaveBeenCalledWith(false);
 });
 
 it('returns the bare manual tracker when only touch callbacks are set', () => {

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v2.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v2.ts
@@ -46,21 +46,28 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
 
     if (onTap) {
       recognizers.push(
-        decorate(Gesture.Tap().maxDistance(failDistance)).onStart(onTap)
+        decorate(
+          Gesture.Tap().maxDistance(failDistance).shouldCancelWhenOutside(false)
+        ).onStart(onTap)
       );
     }
     if (onDoubleTap) {
       recognizers.push(
         decorate(
-          Gesture.Tap().numberOfTaps(2).maxDistance(failDistance)
+          Gesture.Tap()
+            .numberOfTaps(2)
+            .maxDistance(failDistance)
+            .shouldCancelWhenOutside(false)
         ).onStart(onDoubleTap)
       );
     }
     if (onLongPress) {
       recognizers.push(
-        decorate(Gesture.LongPress().maxDistance(failDistance)).onStart(
-          onLongPress
-        )
+        decorate(
+          Gesture.LongPress()
+            .maxDistance(failDistance)
+            .shouldCancelWhenOutside(false)
+        ).onStart(onLongPress)
       );
     }
 

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.test.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.test.ts
@@ -86,6 +86,30 @@ it('creates a gesture only for the handlers that are provided and wraps them as 
   expect(isWorkletFunction(tapConfig.onActivate)).toBe(true);
 });
 
+it('disables shouldCancelWhenOutside on the recognizers so they survive a teleported item hide', () => {
+  // Regression: the teleported item's still-mounted source cell is hidden
+  // (off-screen / opacity 0), which reads as "outside" and, with the default
+  // true, cancels Tap/LongPress - dropping onTap/onLongPress under the portal.
+  renderHook(() =>
+    useTouchableGesture({
+      externalGesture: {},
+      failDistance: 10,
+      gestureMode: 'exclusive',
+      onLongPress: jest.fn(),
+      onTap: jest.fn()
+    })
+  );
+
+  const [tapConfig] = mocked.useTapGesture.mock.calls[0] as [
+    Record<string, unknown>
+  ];
+  const [longPressConfig] = mocked.useLongPressGesture.mock.calls[0] as [
+    Record<string, unknown>
+  ];
+  expect(tapConfig.shouldCancelWhenOutside).toBe(false);
+  expect(longPressConfig.shouldCancelWhenOutside).toBe(false);
+});
+
 it('creates tap, double-tap, long-press and manual gestures when every handler is set', () => {
   renderHook(() =>
     useTouchableGesture({

--- a/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
+++ b/packages/react-native-sortables/src/integrations/gesture-handler/adapters/v3.ts
@@ -116,6 +116,7 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
       useTapGesture({
         maxDistance: failDistance,
         onActivate: useStableCallbackValue(onTap),
+        shouldCancelWhenOutside: false,
         simultaneousWith
       })
     );
@@ -126,6 +127,7 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
         maxDistance: failDistance,
         numberOfTaps: 2,
         onActivate: useStableCallbackValue(onDoubleTap),
+        shouldCancelWhenOutside: false,
         simultaneousWith
       })
     );
@@ -135,6 +137,7 @@ const useTouchableGesture: GestureHandlerAdapter['useTouchableGesture'] = ({
       useLongPressGesture({
         maxDistance: failDistance,
         onActivate: useStableCallbackValue(onLongPress),
+        shouldCancelWhenOutside: false,
         simultaneousWith
       })
     );


### PR DESCRIPTION
When the active-item portal teleports an item, its still-mounted source cell is hidden (moved off-screen via `left` or set to `opacity: 0`). gesture-handler reads that hidden view as the finger being outside its bounds, and because a Tap/LongPress recognizer defaults `shouldCancelWhenOutside` to `true`, it cancels them - so `onTap`/`onLongPress` stop firing on a portal-enabled `Sortable.Touchable`. The Manual drag gesture is unaffected because it defaults the flag to `false`, which is why dragging kept working while tap and long press did not. It only surfaces once the app is on gesture-handler v3 (its Android touch handling cancels these recognizers on the hidden source where v2 did not), so it is not caught on the iOS simulator with synthetic touches.

The fix sets `shouldCancelWhenOutside: false` on the tap, double-tap and long-press recognizers in both gesture-handler adapters (v2 and v3), so they survive the hide the same way the drag gesture does. `maxDistance` still bounds how far the finger may travel, so the recognizers still fail if it moves off the item.

This targets the root cause; the earlier switch of the hide from an off-screen offset to opacity did not help because opacity 0 is cancelled the same way on Android.

Verified on a physical Android device (New Architecture, gesture-handler v3) driven over adb: with the portal enabled, tap and long press now fire on teleported items across repeated controlled presses, and dragging is unchanged. Regression tests added to both adapter test suites.