### PR TITLE
fix: autoAdjustOffsetDuringDrag stale offset and missing reorder

### DIFF
--- a/packages/react-native-sortables/src/providers/grid/AutoOffsetAdjustmentProvider.tsx
+++ b/packages/react-native-sortables/src/providers/grid/AutoOffsetAdjustmentProvider.tsx
@@ -274,6 +274,15 @@ const { AutoOffsetAdjustmentProvider, useAutoOffsetAdjustmentContext } =
           };
         }
 
+        // At-rest cross-size change (e.g. a "collapse all"/"expand all" toggle)
+        // with no active drag: `itemKey` above fell back to a stale
+        // `prevActiveItemKey` from the previous drag. Applying an offset here
+        // would shift the whole layout and set `sortEnabled = false` with no
+        // drop event ever coming to restore it, permanently disabling sorting.
+        if (activeItemKey.value === null) {
+          return props;
+        }
+
         let snapBasedOffset = 0;
 
         if (

--- a/packages/react-native-sortables/src/providers/grid/GridLayoutProvider/updates/common.ts
+++ b/packages/react-native-sortables/src/providers/grid/GridLayoutProvider/updates/common.ts
@@ -1,8 +1,14 @@
-import { type SharedValue, useDerivedValue } from 'react-native-reanimated';
+import {
+  type SharedValue,
+  useAnimatedReaction,
+  useDerivedValue
+} from 'react-native-reanimated';
 
+import { useMutableValue } from '../../../../integrations/reanimated';
 import type {
   Coordinate,
   Dimension,
+  ItemSizes,
   ReorderFunction,
   SortStrategyFactory
 } from '../../../../types';
@@ -23,6 +29,7 @@ export const createGridStrategy =
   ): SortStrategyFactory =>
   () => {
     const {
+      activeItemKey,
       containerHeight,
       containerWidth,
       indexToKey,
@@ -37,21 +44,37 @@ export const createGridStrategy =
     const othersIndexToKey = useInactiveIndexToKey();
     const debugBox = useDebugBoundingBox();
 
+    // Cross sizes captured at each drag start. Used to detect a mid-drag size
+    // change (e.g. items collapsing on drag start) that is still in flight
+    // before the auto offset is applied - see the gate in the order updater.
+    // Re-captured on every drag start (activeItemKey null -> key), so it stays
+    // correct even when the same item is dragged twice in a row.
+    const dragStartCrossSizes = useMutableValue<ItemSizes>(null);
+
+    useAnimatedReaction(
+      () => activeItemKey.value,
+      key => {
+        if (key !== null) {
+          dragStartCrossSizes.value = isVertical
+            ? itemHeights.value
+            : itemWidths.value;
+        }
+      }
+    );
+
     const othersLayout = useDerivedValue(() =>
-      additionalCrossOffset?.value === null
-        ? null
-        : calculateLayout({
-            gaps: {
-              cross: crossGap.value,
-              main: mainGap.value
-            },
-            indexToKey: othersIndexToKey.value,
-            isVertical,
-            itemHeights: itemHeights.value,
-            itemWidths: itemWidths.value,
-            numGroups,
-            startCrossOffset: additionalCrossOffset?.value
-          })
+      calculateLayout({
+        gaps: {
+          cross: crossGap.value,
+          main: mainGap.value
+        },
+        indexToKey: othersIndexToKey.value,
+        isVertical,
+        itemHeights: itemHeights.value,
+        itemWidths: itemWidths.value,
+        numGroups,
+        startCrossOffset: additionalCrossOffset?.value ?? 0
+      })
     );
 
     let mainContainerSize: SharedValue<null | number>;
@@ -76,6 +99,26 @@ export const createGridStrategy =
 
     return ({ activeIndex, dimensions, position }) => {
       'worklet';
+      // While the auto offset is enabled (additionalCrossOffset defined) but not
+      // yet applied (value still null), hold ordering only during a mid-drag
+      // size transition - when the cross sizes changed since the drag started.
+      // In that window othersLayout (new sizes, offset 0) is inconsistent with
+      // the on-screen layout and the finger position, so the bounds walk would
+      // fire a far-jump reorder that the offset block then anchors on. Ordering
+      // resumes as soon as the offset is applied. Drags with no size change
+      // (uniform or already-collapsed items) are unaffected - the snapshot
+      // stays reference-equal, so ordering works from the first move.
+      const currentCrossSizes = isVertical
+        ? itemHeights.value
+        : itemWidths.value;
+      if (
+        additionalCrossOffset &&
+        additionalCrossOffset.value === null &&
+        dragStartCrossSizes.value !== currentCrossSizes
+      ) {
+        return;
+      }
+
       if (
         !othersLayout.value ||
         crossContainerSize.value === null ||


### PR DESCRIPTION
## Description

Fixes two bugs in `Sortable.Grid`'s `autoAdjustOffsetDuringDrag` when items change size (collapsible cards), reported in #605.

**Bug 1 - an at-rest size change after a drag permanently disables sorting.** `handleDragEnd` leaves `prevActiveItemKey` set to the just-dropped key (cleared only at the next drag start). In `adaptLayoutProps`, `itemKey = activeItemKey ?? prevActiveItemKey` then resolves to that stale key on an at-rest "collapse/expand all", so the offset-application block runs and sets `sortEnabled = false` with no drop event to restore it. Fix: pass the props through unchanged when no item is being dragged.

**Bug 2 - a drag with no mid-drag size change never reorders.** `othersLayout` was gated to `null` while `additionalCrossOffset` was `null`, and that only becomes non-null once a mid-drag size change routes through the offset block, so a drag over uniform (already-collapsed) items never produced an order change. Fix: compute `othersLayout` unconditionally (`calculateLayout` already treats `startCrossOffset` as `?? 0`) and hold ordering only during the mid-drag size transition, when comparing the finger's old-layout position against a new-sizes/offset-0 model would otherwise fire a far-jump reorder.

The drag-start cross sizes are snapshotted via a reaction on `activeItemKey`, re-captured on every drag start, so ordering keeps working even when the same item is dragged twice in a row (a plain per-drag flag would go stale after an at-rest re-measure between two same-key drags).

## Testing

Reproduced and verified on the iOS simulator with a minimal collapsible-cards grid (the reporter's repro). Before/after, from app-side callbacks:

| Scenario | Before | After |
| --- | --- | --- |
| All-collapsed drag (bug 2) | `DRAG ACTIVATED`, no `ORDER CHANGE`, drop reverts | reorders correctly |
| Drag then "Expand all" then drag (bug 1) | `touch` only, `DRAG ACTIVATED` never fires (sorting dead) | drag activates and reorders |
| Expanded drag (collapse on drag start) | (worked) | reorders, no far jump |
| Same item dragged twice with a toggle between | n/a | reorders |
| Grid without `autoAdjustOffsetDuringDrag` | (worked) | unchanged |

`yarn lib typecheck`, `eslint`, and `yarn lib test` (34/34) all pass.

Closes #605
