### PR TITLE
fix: Keep npm version from walking yarn workspaces during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           HUSKY: 0
+          # npm version runs an implicit workspaces update, which fails on the
+          # examples' workspace: deps (npm does not support that protocol)
+          npm_config_workspaces_update: false


### PR DESCRIPTION
The first OIDC release run failed in `@semantic-release/npm`'s prepare step: `npm version` triggers an implicit workspaces update, and npm can't parse the `workspace:` deps the example apps use (`EUNSUPPORTEDPROTOCOL`). The yarn publisher never hit this because yarn understands that protocol. The dry-run couldn't catch it either, since dry-run skips the prepare step.

Sets `workspaces-update=false` for the release step, so `npm version` just writes the package's version (there is no package-lock for it to update anyway). Reproduced the exact failing command locally on npm 11.16 and confirmed it passes with the flag; `npm pack` is unaffected.

The failed run published and tagged nothing, so rerunning the release workflow after this lands should cut 1.10.0.
